### PR TITLE
update icongen: scalars, optional metadata, standalone

### DIFF
--- a/pyutils/setup.cfg
+++ b/pyutils/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
 
 [options.entry_points]
 console_scripts =
-  icon4pygen = icon4py.pyutils.icongen:icongen_main
+  icon4pygen = icon4py.pyutils.icon4pygen:main
 
 
 [options.packages.find]

--- a/pyutils/src/icon4py/pyutils/icon4pygen.py
+++ b/pyutils/src/icon4py/pyutils/icon4pygen.py
@@ -113,7 +113,7 @@ def generate_cli(fencil_function):
     help="file path for optional metadata output",
 )
 @click.argument("fencil", type=str)
-def icongen_main(output_metadata, fencil):
+def main(output_metadata, fencil):
     """
     Generate metadata and C++ code for an icon4py fencil.
 


### PR DESCRIPTION
Changed:
* output-metadata option is now optional
* scalars are represented in metadata as `Field[[], dtype]`

Added:
* standalone `icon4pygen` CLI, gets installed by pip and should be on PATH after installing the package.
* standalone can only be used on python modules which are installed or had their containing directory manually added to the PYTHONPATH env variable.
* standalone can work on functions with or without `program` or `field_operator` decorator applied to them.

Notes:
* both versions of icongen are missing a way to connect fencils with offset providers, therefore they currently don't work on fencils with partial shifts in them (neighborhood reductions etc).
* when running `icon4pygen` on a `FieldOperator`, the name of the generated function may follow a different convention compared to when running it on a `Program` (this is up to the `GTFN` backend in `gt4py`).