### PR TITLE
Generate fields from node params

### DIFF
--- a/pyutils/src/icon4py/pyutils/stencil24.dat
+++ b/pyutils/src/icon4py/pyutils/stencil24.dat
@@ -1,8 +1,0 @@
-vn_nnow          Field[[Edge, K], dtype=float64]  in
-ddt_vn_adv_ntl1  Field[[Edge, K], dtype=float64]  in
-ddt_vn_phy       Field[[Edge, K], dtype=float64]  in
-z_theta_v_e      Field[[Edge, K], dtype=float64]  in
-z_gradh_exner    Field[[Edge, K], dtype=float64]  in
-vn_nnew          Field[[Edge, K], dtype=float64]  inout
-dtime            Field[[], dtype=float64]         in
-cpd              Field[[], dtype=float64]         in


### PR DESCRIPTION
### Changed
- Generate metadata field dictionary from `node.params` to preserve function signature order, to match function signature generated by gridtools fn backend.