### PR TITLE
Changed order of sparse and shifted fields

### DIFF
--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_icon_interpolation_scalar_cells2verts_scalar_ri_dsl.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_icon_interpolation_scalar_cells2verts_scalar_ri_dsl.py
@@ -28,7 +28,7 @@ def _mo_icon_interpolation_scalar_cells2verts_scalar_ri_dsl(
     p_cell_in: Field[[CellDim, KDim], float],
     c_intp: Field[[VertexDim, V2CDim], float],
 ) -> Field[[VertexDim, KDim], float]:
-    p_vert_out = neighbor_sum(c_intp * p_cell_in(V2C), axis=V2CDim)
+    p_vert_out = neighbor_sum(p_cell_in(V2C) * c_intp, axis=V2CDim)
     return p_vert_out
 
 

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_math_divrot_rot_vertex_ri_dsl.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_math_divrot_rot_vertex_ri_dsl.py
@@ -28,7 +28,7 @@ def _mo_math_divrot_rot_vertex_ri_dsl(
     vec_e: Field[[EdgeDim, KDim], float],
     geofac_rot: Field[[VertexDim, V2EDim], float],
 ) -> Field[[VertexDim, KDim], float]:
-    rot_vec = neighbor_sum(geofac_rot * vec_e(V2E), axis=V2EDim)
+    rot_vec = neighbor_sum(vec_e(V2E) * geofac_rot, axis=V2EDim)
     return rot_vec
 
 

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_solve_nonhydro_stencil_25.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_solve_nonhydro_stencil_25.py
@@ -22,7 +22,7 @@ def _mo_solve_nonhydro_stencil_25(
     geofac_grdiv: Field[[EdgeDim, E2C2EODim], float],
     z_graddiv_vn: Field[[EdgeDim, KDim], float],
 ) -> Field[[EdgeDim, KDim], float]:
-    z_graddiv2_vn = neighbor_sum(geofac_grdiv * z_graddiv_vn(E2C2EO), axis=E2C2EODim)
+    z_graddiv2_vn = neighbor_sum(z_graddiv_vn(E2C2EO) * geofac_grdiv, axis=E2C2EODim)
     return z_graddiv2_vn
 
 

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_velocity_advection_stencil_08.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_velocity_advection_stencil_08.py
@@ -22,7 +22,7 @@ def _mo_velocity_advection_stencil_08(
     z_kin_hor_e: Field[[EdgeDim, KDim], float],
     e_bln_c_s: Field[[CellDim, C2EDim], float],
 ) -> Field[[CellDim, KDim], float]:
-    z_ekinh = neighbor_sum(e_bln_c_s * z_kin_hor_e(C2E), axis=C2EDim)
+    z_ekinh = neighbor_sum(z_kin_hor_e(C2E) * e_bln_c_s, axis=C2EDim)
     return z_ekinh
 
 

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_velocity_advection_stencil_09.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_velocity_advection_stencil_09.py
@@ -22,7 +22,7 @@ def _mo_velocity_advection_stencil_09(
     z_w_concorr_me: Field[[EdgeDim, KDim], float],
     e_bln_c_s: Field[[CellDim, C2EDim], float],
 ) -> Field[[CellDim, KDim], float]:
-    z_w_concorr_mc = neighbor_sum(e_bln_c_s * z_w_concorr_me(C2E), axis=C2EDim)
+    z_w_concorr_mc = neighbor_sum(z_w_concorr_me(C2E) * e_bln_c_s, axis=C2EDim)
     return z_w_concorr_mc
 
 

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_velocity_advection_stencil_17.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_velocity_advection_stencil_17.py
@@ -23,7 +23,7 @@ def _mo_velocity_advection_stencil_17(
     z_v_grad_w: Field[[EdgeDim, KDim], float],
     ddt_w_adv: Field[[CellDim, KDim], float],
 ) -> Field[[CellDim, KDim], float]:
-    ddt_w_adv = ddt_w_adv + neighbor_sum(e_bln_c_s * z_v_grad_w(C2E), axis=C2EDim)
+    ddt_w_adv = ddt_w_adv + neighbor_sum(z_v_grad_w(C2E) * e_bln_c_s, axis=C2EDim)
     return ddt_w_adv
 
 


### PR DESCRIPTION
This is a temporary fix to the general problem that in gt4py the UnrollReduce always assumes that the first argument to the lifted reduce is a shifted call