### PR TITLE
Remove Skip Values from Offset Providers

### DIFF
--- a/pyutils/src/icon4py/pyutils/icon4pygen.py
+++ b/pyutils/src/icon4py/pyutils/icon4pygen.py
@@ -108,7 +108,7 @@ def provide_offset(chain: str) -> SimpleNamespace:
             raise InvalidConnectivityException(location_chain)
     return SimpleNamespace(
         max_neighbors=IcoChainSize.get(location_chain) + include_center,
-        has_skip_values=True,
+        has_skip_values=False,
     )
 
 


### PR DESCRIPTION
In icon, the horizontal (sub)domains are designed such that no stencil ever touches the boundary. Further, there are no pentagonal neighborhoods in the limited area mode. Hence, skip values are not required. This PR removes them and hence improves performance 