### PR TITLE
Gitpod: remove pylance

### DIFF
--- a/.gitpod/.vscode/settings.json
+++ b/.gitpod/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
     "python.formatting.provider": "black",
-    "python.languageServer": "Pylance",
     "python.testing.pytestEnabled": true
 }


### PR DESCRIPTION
Pylance is not licensed for Gitpod in the browser. Was this here for when you open in vscode desktop? (Pylance is anyway the default if available and fallback to Jedi if not available. Forcing it to Pylance will disable the fallback.)