### PR TITLE
Allow sliced out args

### DIFF
--- a/pyutils/src/icon4py/pyutils/icon4pygen.py
+++ b/pyutils/src/icon4py/pyutils/icon4pygen.py
@@ -19,6 +19,7 @@ import dataclasses
 import importlib
 import pathlib
 import types
+import warnings
 from collections.abc import Iterable
 from typing import Any, TypeGuard
 
@@ -58,7 +59,11 @@ def get_field_infos(fvprog: Program) -> dict[str, _FieldInfo]:
     input_arg_ids = set(arg.id for arg in fvprog.past_node.body[0].args)
 
     out_arg = fvprog.past_node.body[0].kwargs["out"]
-    out_arg = out_arg.value if isinstance(out_arg, past.Subscript) else out_arg
+    if isinstance(out_arg, past.Subscript):
+        warnings.warn(
+            f"Slicing in `out` argument is ignored in call to `{fvprog.past_node.id}`."
+        )
+        out_arg = out_arg.value
     assert isinstance(out_arg, (past.Name, past.TupleExpr))
     output_fields = out_arg.elts if isinstance(out_arg, past.TupleExpr) else [out_arg]
     output_arg_ids = set(arg.id for arg in output_fields)


### PR DESCRIPTION
@mroethlin proposed this change to allow, e.g.

```python
@program
def mo_solve_nonhydro_stencil_06(
    z_exner_ic: Field[[CellDim, KDim], float],
    inv_ddqz_z_full: Field[[CellDim, KDim], float],
    z_dexner_dz_c_1: Field[[CellDim, KDim], float],
):
    _mo_solve_nonhydro_stencil_06(
        z_exner_ic, inv_ddqz_z_full, out=z_dexner_dz_c_1[:, :-1]
    )
```

Let's discuss if we want this, as it might be confusing. For embedded execution the slicing is used, but for the generated code it is ignored.