### PR TITLE
Fixed node version in pre-commit for tsa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 default_stages: [commit, push]
 default_language_version:
     python: python3.10
+    # The latest node version doesn't work on tsa
+    # Remove frozen version once we migrated away from tsa
     node: 17.9.1
 minimum_pre_commit_version: 2.20.0
 


### PR DESCRIPTION
This patch fixes the node version that pre-commit will use. Without it, pre-commit will use the latest which is 18.7.0 and doesn't work with tsa's libc:

```console
pre-commit run --all-files                                                  ok  icon4py py  mroeth@tsa-ln003  14:08:42 
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/users/mroeth/.cache/pre-commit/repot7jchaw0/node_env-default/bin/node', '/users/mroeth/.cache/pre-commit/repot7jchaw0/node_env-default/bin/npm', 'install', '--dev', '--prod', '--ignore-prepublish', '--no-progress', '--no-save')
return code: 1
expected return code: 0
stdout: (none)
stderr:
    /users/mroeth/.cache/pre-commit/repot7jchaw0/node_env-default/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /users/mroeth/.cache/pre-commit/repot7jchaw0/node_env-default/bin/node)
    /users/mroeth/.cache/pre-commit/repot7jchaw0/node_env-default/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /users/mroeth/.cache/pre-commit/repot7jchaw0/node_env-default/bin/node)
    /users/mroeth/.cache/pre-commit/repot7jchaw0/node_env-default/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /users/mroeth/.cache/pre-commit/repot7jchaw0/node_env-default/bin/node)
    
Check the log at /users/mroeth/.cache/pre-commit/pre-commit.log
```