### PR TITLE
Fix Sequence of Parameters

### DIFF
--- a/pyutils/src/icon4py/bindings/entities.py
+++ b/pyutils/src/icon4py/bindings/entities.py
@@ -105,13 +105,13 @@ class Field(Node, FieldEntity):
         self.renderer = FieldRenderer(self)
 
     def is_sparse(self) -> bool:
-        return isinstance(self.location, ChainedLocation)
+        return self.location is not None and isinstance(self.location, ChainedLocation)
 
     def is_dense(self) -> bool:
-        return isinstance(self.location, BasicLocation)
+        return self.location is not None and isinstance(self.location, BasicLocation)
 
     def is_compound(self) -> bool:
-        return isinstance(self.location, CompoundLocation)
+        return self.location is not None and isinstance(self.location, CompoundLocation)
 
     def rank(self) -> int:
         rank = int(self.has_vertical_dimension) + int(self.location is not None)


### PR DESCRIPTION
`pybindgen` was putting the scalar parameters always at the end of the call, instead of respecting their relative order given by the python stencil. This was masked out so far because people were putting their parameters at the end of the calling sequence by chance. 

This is a quick PR to fix this issue. 