### PR TITLE
Adapt icon4py to new gt4py Type System 

### DIFF
--- a/pyutils/src/icon4py/bindings/codegen/type_conversion.py
+++ b/pyutils/src/icon4py/bindings/codegen/type_conversion.py
@@ -11,20 +11,20 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from functional.ffront.common_types import ScalarKind
+from functional.ffront import type_specifications as ts
 
 
-BUILTIN_TO_ISO_C_TYPE: dict[ScalarKind, str] = {
-    ScalarKind.FLOAT64: "real(c_double)",
-    ScalarKind.FLOAT32: "real(c_float)",
-    ScalarKind.BOOL: "logical(c_int)",
-    ScalarKind.INT32: "integer(c_int)",
-    ScalarKind.INT64: "integer(c_long)",
+BUILTIN_TO_ISO_C_TYPE: dict[ts.ScalarKind, str] = {
+    ts.ScalarKind.FLOAT64: "real(c_double)",
+    ts.ScalarKind.FLOAT32: "real(c_float)",
+    ts.ScalarKind.BOOL: "logical(c_int)",
+    ts.ScalarKind.INT32: "integer(c_int)",
+    ts.ScalarKind.INT64: "integer(c_long)",
 }
-BUILTIN_TO_CPP_TYPE: dict[ScalarKind, str] = {
-    ScalarKind.FLOAT64: "double",
-    ScalarKind.FLOAT32: "float",
-    ScalarKind.BOOL: "int",
-    ScalarKind.INT32: "int",
-    ScalarKind.INT64: "long",
+BUILTIN_TO_CPP_TYPE: dict[ts.ScalarKind, str] = {
+    ts.ScalarKind.FLOAT64: "double",
+    ts.ScalarKind.FLOAT32: "float",
+    ts.ScalarKind.BOOL: "int",
+    ts.ScalarKind.INT32: "int",
+    ts.ScalarKind.INT64: "long",
 }

--- a/pyutils/src/icon4py/bindings/codegen/types.py
+++ b/pyutils/src/icon4py/bindings/codegen/types.py
@@ -15,7 +15,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Union
 
-from functional.ffront.common_types import ScalarKind
+from functional.ffront import type_specifications as ts
 
 from icon4py.bindings.locations import (
     BasicLocation,
@@ -32,7 +32,7 @@ class FieldIntent:
 
 class FieldEntity(ABC):
     name: str
-    field_type: ScalarKind
+    field_type: ts.ScalarKind
     intent: FieldIntent
     has_vertical_dimension: bool
     includes_center: bool

--- a/pyutils/src/icon4py/bindings/entities.py
+++ b/pyutils/src/icon4py/bindings/entities.py
@@ -15,7 +15,7 @@ from typing import Union
 
 from eve import Node
 from functional.ffront import program_ast as past
-from functional.ffront.common_types import FieldType, ScalarKind
+from functional.ffront import type_specifications as ts
 
 from icon4py.bindings.codegen.render.field import FieldRenderer
 from icon4py.bindings.codegen.render.offset import OffsetRenderer
@@ -129,15 +129,15 @@ class Field(Node, FieldEntity):
         return calc_num_neighbors(self.location.to_dim_list(), self.includes_center)  # type: ignore
 
     @staticmethod
-    def _extract_field_type(field: past.DataSymbol) -> ScalarKind:
+    def _extract_field_type(field: past.DataSymbol) -> ts.ScalarKind:
         """Handle extraction of field types for different fields e.g. Scalar."""
-        if not isinstance(field.type, FieldType):
+        if not isinstance(field.type, ts.FieldType):
             return field.type.kind  # type: ignore
         return field.type.dtype.kind
 
     @staticmethod
     def _has_vertical_dimension(field: past.DataSymbol) -> bool:
-        if not isinstance(field.type, FieldType):
+        if not isinstance(field.type, ts.FieldType):
             return False
         return any(dim.value == "K" for dim in field.type.dims)
 
@@ -145,7 +145,7 @@ class Field(Node, FieldEntity):
         self.location = None
 
         # early abort if field is in fact scalar
-        if not isinstance(field.type, FieldType):
+        if not isinstance(field.type, ts.FieldType):
             return
 
         maybe_horizontal_dimension = list(

--- a/pyutils/src/icon4py/pyutils/metadata.py
+++ b/pyutils/src/icon4py/pyutils/metadata.py
@@ -19,8 +19,8 @@ from typing import Any, TypeGuard
 
 import eve
 from functional.common import Dimension, DimensionKind
-from functional.ffront import common_types as ct
 from functional.ffront import program_ast as past
+from functional.ffront import type_specifications as ts
 from functional.ffront.decorator import FieldOperator, Program, program
 from functional.iterator import ir as itir
 
@@ -163,7 +163,7 @@ def scan_for_offsets(fvprog: Program) -> list[eve.concepts.SymbolRef]:
     all_field_types = [
         symbol_type
         for symbol_type in all_types
-        if isinstance(symbol_type, ct.FieldType)
+        if isinstance(symbol_type, ts.FieldType)
     ]
     all_dims = set(i for j in all_field_types for i in j.dims)
     all_offset_labels = (


### PR DESCRIPTION
A recent [commit](https://github.com/GridTools/gt4py/commit/4e6368b3271b11dcec2848733444ee7ebb7e02a9) in the gt4py type system broke icon4py. This PR fixes this by adapting some imports. 