### PR TITLE
Fix include order

### DIFF
--- a/pyutils/src/icon4py/bindings/codegen/cpp.py
+++ b/pyutils/src/icon4py/bindings/codegen/cpp.py
@@ -50,6 +50,8 @@ class CppDefGenerator(TemplatedGenerator):
 
     IncludeStatements = as_jinja(
         """\
+        #include <gridtools/fn/backend/gpu.hpp>
+
         #include "driver-includes/cuda_utils.hpp"
         #include "driver-includes/cuda_verify.hpp"
         #include "driver-includes/defs.hpp"
@@ -58,7 +60,6 @@ class CppDefGenerator(TemplatedGenerator):
         #include "driver-includes/unstructured_domain.hpp"
         #include "driver-includes/unstructured_interface.hpp"
         #include "driver-includes/verification_metrics.hpp"
-        #include <gridtools/fn/backend/gpu.hpp>
         #include \"{{ funcname }}.hpp\"
         #include <gridtools/common/array.hpp>
         #include <gridtools/stencil/global_parameter.hpp>


### PR DESCRIPTION
Prevent clang-format from re-ordering by separating with newline