### PR TITLE
Fix bug in metadata extraction: only consider offset labels

### DIFF
--- a/pyutils/src/icon4py/pyutils/metadata.py
+++ b/pyutils/src/icon4py/pyutils/metadata.py
@@ -212,6 +212,7 @@ def scan_for_offsets(fvprog: Program) -> list[eve.concepts.SymbolRef]:
         fvprog.itir.pre_walk_values()
         .if_isinstance(itir.OffsetLiteral)
         .getattr("value")
+        .if_isinstance(str)
         .to_list()
     )
     all_dim_labels = [dim.value for dim in all_dims if dim.kind == DimensionKind.LOCAL]


### PR DESCRIPTION
This bug was exposed by a fix in the GT4Py lowering https://github.com/GridTools/gt4py/pull/1196.