### PR TITLE
Fixed code generation bug in case there are no tolerance fields

### DIFF
--- a/pyutils/src/icon4py/icon4pygen/bindings/codegen/header.py
+++ b/pyutils/src/icon4py/icon4pygen/bindings/codegen/header.py
@@ -42,7 +42,11 @@ run_verify_func_declaration = as_jinja(
     {%- for field in _this_node.out_fields -%}
     {{ field.renderer.render_ctype('c++') }} {{ field.renderer.render_pointer() }} {{ field.name }}_{{ suffix }},
     {%- endfor -%}
+    {%- if _this_node.tol_fields -%}
     const int verticalStart, const int verticalEnd, const int horizontalStart, const int horizontalEnd,
+    {%- else -%}
+    const int verticalStart, const int verticalEnd, const int horizontalStart, const int horizontalEnd
+    {%- endif -%}
     {%- for field in _this_node.tol_fields -%}
     const double {{ field.name }}_rel_tol,
     const double {{ field.name }}_abs_tol


### PR DESCRIPTION
For integer or boolean field verification, no tolerance values are generated, since the comparison is perfect.
If a stencil has only integer or boolean fields as output, no tolerance values are generated at all, which leads to a bug in the code generation because of a trailing comma.

This is a fix for that.