### PR TITLE
Workaround a change in GT4Py

### DIFF
--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_nh_diffusion_stencil_15.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_nh_diffusion_stencil_15.py
@@ -28,7 +28,6 @@ from icon4py.common.dimension import C2E2C, C2E2CDim, CellDim, KDim, Koff
 from icon4py.icon4pygen.metadata import FieldInfo
 
 
-@fundef
 def step(i, geofac_n2s_nbh, vcoef, theta_v, zd_vertoffset):
     d_vcoef = list_get(i, deref(vcoef))
     s_theta_v = shift(C2E2C, i, Koff, list_get(i, deref(zd_vertoffset)))(theta_v)


### PR DESCRIPTION
Explanation:
- removing `@fundef` will change how the tracing of the iterator IR program works: it will execute the function and basically inline on tracing.
- after it's inlined in iterator IR, the `i` argument of `step` will be a `itir.OffsetLiteral` in the shift (instead of a `itir.Literal` 
- this will then correctly translate to `integral_constant`s (while the `Literal` would translate to `int`), which is not legal in the unstructured shift.

All this is triggered by cleaning up the `integral_constant` handling in https://github.com/GridTools/gt4py/pull/1204.