### PR TITLE
Greenline rename lateral boundary

### DIFF
--- a/atm_dyn_iconam/src/icon4py/diffusion/diffusion.py
+++ b/atm_dyn_iconam/src/icon4py/diffusion/diffusion.py
@@ -608,7 +608,7 @@ class Diffusion:
                 vertex_endindex_local,
             ) = self.grid.get_indices_from_to(
                 VertexDim,
-                HorizontalMarkerIndex.local_boundary(VertexDim) + 3,
+                HorizontalMarkerIndex.lateral_boundary(VertexDim) + 3,
                 HorizontalMarkerIndex.local(VertexDim),
             )
 
@@ -617,13 +617,13 @@ class Diffusion:
                 vertex_endindex_local_minus1,
             ) = self.grid.get_indices_from_to(
                 VertexDim,
-                HorizontalMarkerIndex.local_boundary(VertexDim) + 1,
+                HorizontalMarkerIndex.lateral_boundary(VertexDim) + 1,
                 HorizontalMarkerIndex.local(VertexDim) - 1,
             )
             edge_start_lb_plus4, _ = self.grid.get_indices_from_to(
                 EdgeDim,
-                HorizontalMarkerIndex.local_boundary(EdgeDim) + 4,
-                HorizontalMarkerIndex.local_boundary(EdgeDim) + 4,
+                HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 4,
+                HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 4,
             )
             log.info("diffusion program: start")
             diff_prog.diffusion_run(
@@ -777,8 +777,8 @@ class Diffusion:
 
         edge_start_lb_plus4, _ = self.grid.get_indices_from_to(
             EdgeDim,
-            HorizontalMarkerIndex.local_boundary(EdgeDim) + 4,
-            HorizontalMarkerIndex.local_boundary(EdgeDim) + 4,
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 4,
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 4,
         )
 
         (
@@ -795,7 +795,7 @@ class Diffusion:
             vertex_end_local,
         ) = self.grid.get_indices_from_to(
             VertexDim,
-            HorizontalMarkerIndex.local_boundary(VertexDim) + 3,
+            HorizontalMarkerIndex.lateral_boundary(VertexDim) + 3,
             HorizontalMarkerIndex.local(VertexDim),
         )
         (
@@ -803,7 +803,7 @@ class Diffusion:
             vertex_end_local_minus1,
         ) = self.grid.get_indices_from_to(
             VertexDim,
-            HorizontalMarkerIndex.local_boundary(VertexDim) + 1,
+            HorizontalMarkerIndex.lateral_boundary(VertexDim) + 1,
             HorizontalMarkerIndex.local(VertexDim) - 1,
         )
 

--- a/atm_dyn_iconam/src/icon4py/diffusion/horizontal.py
+++ b/atm_dyn_iconam/src/icon4py/diffusion/horizontal.py
@@ -58,7 +58,7 @@ class HorizontalMarkerIndex:
     _END_VERTICES: Final[int] = 0
 
     @classmethod
-    def local_boundary(cls, dim: Dimension) -> int:
+    def lateral_boundary(cls, dim: Dimension) -> int:
         match (dim):
             case (dimension.CellDim):
                 return cls._LOCAL_BOUNDARY_CELLS

--- a/atm_dyn_iconam/tests/test_icon_grid.py
+++ b/atm_dyn_iconam/tests/test_icon_grid.py
@@ -53,13 +53,13 @@ def test_horizontal_grid_cell_indices(icon_grid):
     )  # lb+1
     assert icon_grid.get_indices_from_to(
         CellDim,
-        HorizontalMarkerIndex.local_boundary(CellDim) + 1,
-        HorizontalMarkerIndex.local_boundary(CellDim) + 1,
+        HorizontalMarkerIndex.lateral_boundary(CellDim) + 1,
+        HorizontalMarkerIndex.lateral_boundary(CellDim) + 1,
     ) == (850, 1688)
     assert icon_grid.get_indices_from_to(
         CellDim,
-        HorizontalMarkerIndex.local_boundary(CellDim) + 2,
-        HorizontalMarkerIndex.local_boundary(CellDim) + 2,
+        HorizontalMarkerIndex.lateral_boundary(CellDim) + 2,
+        HorizontalMarkerIndex.lateral_boundary(CellDim) + 2,
     ) == (
         1688,
         2511,
@@ -125,64 +125,64 @@ def test_horizontal_edge_indices(icon_grid):
     )  # nudging
     assert icon_grid.get_indices_from_to(
         EdgeDim,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 7,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 7,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 7,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 7,
     ) == (
         4184,
         4989,
     )  # lb +7
     assert icon_grid.get_indices_from_to(
         EdgeDim,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 6,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 6,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 6,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 6,
     ) == (
         3777,
         4184,
     )  # lb +6
     assert icon_grid.get_indices_from_to(
         EdgeDim,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 5,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 5,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 5,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 5,
     ) == (
         2954,
         3777,
     )  # lb +5
     assert icon_grid.get_indices_from_to(
         EdgeDim,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 4,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 4,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 4,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 4,
     ) == (
         2538,
         2954,
     )  # lb +4
     assert icon_grid.get_indices_from_to(
         EdgeDim,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 3,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 3,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 3,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 3,
     ) == (
         1700,
         2538,
     )  # lb +3
     assert icon_grid.get_indices_from_to(
         EdgeDim,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 2,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 2,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 2,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 2,
     ) == (
         1278,
         1700,
     )  # lb +2
     assert icon_grid.get_indices_from_to(
         EdgeDim,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 1,
-        HorizontalMarkerIndex.local_boundary(EdgeDim) + 1,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 1,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 1,
     ) == (
         428,
         1278,
     )  # lb +1
     assert icon_grid.get_indices_from_to(
         EdgeDim,
-        HorizontalMarkerIndex.local_boundary(EdgeDim),
-        HorizontalMarkerIndex.local_boundary(EdgeDim),
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim),
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim),
     ) == (
         0,
         428,
@@ -209,28 +209,28 @@ def test_horizontal_vertex_indices(icon_grid):
 
     assert icon_grid.get_indices_from_to(
         VertexDim,
-        HorizontalMarkerIndex.local_boundary(VertexDim),
-        HorizontalMarkerIndex.local_boundary(VertexDim),
+        HorizontalMarkerIndex.lateral_boundary(VertexDim),
+        HorizontalMarkerIndex.lateral_boundary(VertexDim),
     ) == (0, 428)
     assert icon_grid.get_indices_from_to(
         VertexDim,
-        HorizontalMarkerIndex.local_boundary(VertexDim) + 1,
-        HorizontalMarkerIndex.local_boundary(VertexDim) + 1,
+        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 1,
+        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 1,
     ) == (428, 850)
     assert icon_grid.get_indices_from_to(
         VertexDim,
-        HorizontalMarkerIndex.local_boundary(VertexDim) + 2,
-        HorizontalMarkerIndex.local_boundary(VertexDim) + 2,
+        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 2,
+        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 2,
     ) == (850, 1266)
     assert icon_grid.get_indices_from_to(
         VertexDim,
-        HorizontalMarkerIndex.local_boundary(VertexDim) + 3,
-        HorizontalMarkerIndex.local_boundary(VertexDim) + 3,
+        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 3,
+        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 3,
     ) == (1266, 1673)
     assert icon_grid.get_indices_from_to(
         VertexDim,
-        HorizontalMarkerIndex.local_boundary(VertexDim) + 4,
-        HorizontalMarkerIndex.local_boundary(VertexDim) + 4,
+        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 4,
+        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 4,
     ) == (1673, 2071)
 
     assert icon_grid.get_indices_from_to(

--- a/atm_dyn_iconam/tests/test_mo_nh_diffusion_stencil_15.py
+++ b/atm_dyn_iconam/tests/test_mo_nh_diffusion_stencil_15.py
@@ -12,7 +12,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import numpy as np
-import pytest
 
 from icon4py.atm_dyn_iconam.mo_nh_diffusion_stencil_15 import (
     mo_nh_diffusion_stencil_15,


### PR DESCRIPTION
simple renaming of `local_boundary` to `lateral_boundary` since I misinterpreted the `lb` from `icon-dsl` log output in the first place.