### PR TITLE
Add error for missing command

### DIFF
--- a/liskov/src/icon4py/liskov/cli.py
+++ b/liskov/src/icon4py/liskov/cli.py
@@ -16,6 +16,7 @@ import pathlib
 import click
 
 from icon4py.common.logger import setup_logger
+from icon4py.liskov.external.exceptions import MissingCommandError
 from icon4py.liskov.pipeline.collection import (
     load_gt4py_stencils,
     parse_fortran_file,
@@ -31,7 +32,7 @@ logger = setup_logger(__name__)
 def main(ctx):
     """Command line interface for interacting with the ICON-Liskov DSL Preprocessor."""
     if ctx.invoked_subcommand is None:
-        click.echo(
+        raise MissingCommandError(
             "Need to choose one of the following commands:\nintegrate\nserialise"
         )
 

--- a/liskov/src/icon4py/liskov/external/exceptions.py
+++ b/liskov/src/icon4py/liskov/external/exceptions.py
@@ -22,3 +22,7 @@ class UnknownStencilError(Exception):
 
 class IncompatibleFieldError(Exception):
     pass
+
+
+class MissingCommandError(Exception):
+    pass

--- a/liskov/tests/test_cli.py
+++ b/liskov/tests/test_cli.py
@@ -16,6 +16,7 @@ import itertools
 import pytest
 
 from icon4py.liskov.cli import main
+from icon4py.liskov.external.exceptions import MissingCommandError
 from icon4py.testutils.liskov_fortran_samples import (
     CONSECUTIVE_STENCIL,
     FREE_FORM_STENCIL,
@@ -67,3 +68,10 @@ def test_cli(make_f90_tmpfile, cli, outfile, file_name, file_content, cmd, cmd_f
     args = [cmd, *cmd_flags, fpath, outfile]
     result = cli.invoke(main, args)
     assert result.exit_code == 0
+
+
+def test_cli_missing_command(cli):
+    args = []
+    result = cli.invoke(main, args)
+    assert result.exit_code == 1
+    assert isinstance(result.exception, MissingCommandError)


### PR DESCRIPTION
Throw an error if `icon_liskov` is run without a command.