### PR TITLE
Add MANIFEST for testutils

### DIFF
--- a/testutils/MANIFEST.in
+++ b/testutils/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/icon4py/testutils/fortran/*

--- a/testutils/setup.py
+++ b/testutils/setup.py
@@ -15,4 +15,4 @@ from setuptools import setup
 
 
 if __name__ == "__main__":
-    setup()
+    setup(include_package_data=True)


### PR DESCRIPTION
Include Fortran test files in `testutils` distribution package.