### PR TITLE
clean up some of the confusion concerning halo markers

### DIFF
--- a/atm_dyn_iconam/src/icon4py/diffusion/horizontal.py
+++ b/atm_dyn_iconam/src/icon4py/diffusion/horizontal.py
@@ -42,23 +42,31 @@ class HorizontalMarkerIndex:
     _LOCAL_BOUNDARY_EDGES: Final[int] = 1 + _ICON_INDEX_OFFSET_EDGES
     _INTERIOR_EDGES: Final[int] = _ICON_INDEX_OFFSET_EDGES
     _NUDGING_EDGES: Final[int] = _GRF_BOUNDARY_WIDTH_EDGES + _ICON_INDEX_OFFSET_EDGES
-    _HALO_EDGES: Final[int] = _MIN_RL_EDGE_INT + _ICON_INDEX_OFFSET_EDGES
+    _HALO_EDGES: Final[int] = _MIN_RL_EDGE_INT - 1 + _ICON_INDEX_OFFSET_EDGES
+    _LOCAL_EDGES: Final[int] = _MIN_RL_EDGE_INT + _ICON_INDEX_OFFSET_EDGES
     _END_EDGES: Final[int] = 0
 
     _LOCAL_BOUNDARY_CELLS: Final[int] = 1 + _ICON_INDEX_OFFSET_CELLS
     _INTERIOR_CELLS: Final[int] = _ICON_INDEX_OFFSET_CELLS
     _NUDGING_CELLS: Final[int] = _GRF_BOUNDARY_WIDTH_CELL + 1 + _ICON_INDEX_OFFSET_CELLS
-    _HALO_CELLS: Final[int] = _MIN_RL_CELL_INT + _ICON_INDEX_OFFSET_CELLS
+    _HALO_CELLS: Final[int] = _MIN_RL_CELL_INT - 1 + _ICON_INDEX_OFFSET_CELLS
+    _LOCAL_CELLS: Final[int] = _MIN_RL_CELL_INT + _ICON_INDEX_OFFSET_CELLS
     _END_CELLS: Final[int] = 0
 
     _LOCAL_BOUNDARY_VERTICES = 1 + _ICON_INDEX_OFFSET_VERTEX
     _INTERIOR_VERTICES: Final[int] = _ICON_INDEX_OFFSET_VERTEX
     _NUDGING_VERTICES: Final[int] = 0
-    _HALO_VERTICES: Final[int] = _MIN_RL_VERTEX_INT + _ICON_INDEX_OFFSET_VERTEX
+    _HALO_VERTICES: Final[int] = _MIN_RL_VERTEX_INT - 1 + _ICON_INDEX_OFFSET_VERTEX
+    _LOCAL_VERTICES: Final[int] = _MIN_RL_VERTEX_INT + _ICON_INDEX_OFFSET_VERTEX
     _END_VERTICES: Final[int] = 0
 
     @classmethod
     def lateral_boundary(cls, dim: Dimension) -> int:
+        """Indicate lateral boundary.
+
+        These points correspond to the sorted points in ICON, the marker can be incremented in order
+        to accesss higher boundary lines
+        """
         match (dim):
             case (dimension.CellDim):
                 return cls._LOCAL_BOUNDARY_CELLS
@@ -69,6 +77,18 @@ class HorizontalMarkerIndex:
 
     @classmethod
     def local(cls, dim: Dimension) -> int:
+        """Indicate points that are owned by the processing unit, i.e. no halo points."""
+        match (dim):
+            case (dimension.CellDim):
+                return cls._LOCAL_CELLS
+            case (dimension.EdgeDim):
+                return cls._LOCAL_EDGES
+            case (dimension.VertexDim):
+                return cls._LOCAL_VERTICES
+
+    @classmethod
+    def halo(cls, dim: Dimension) -> int:
+        """Indicate the halo points."""
         match (dim):
             case (dimension.CellDim):
                 return cls._HALO_CELLS
@@ -79,6 +99,7 @@ class HorizontalMarkerIndex:
 
     @classmethod
     def nudging(cls, dim: Dimension) -> int:
+        """Indicate the nudging zone."""
         match (dim):
             case (dimension.CellDim):
                 return cls._NUDGING_CELLS
@@ -89,6 +110,7 @@ class HorizontalMarkerIndex:
 
     @classmethod
     def interior(cls, dim: Dimension) -> int:
+        """Indicate interior i.e. unordered prognostic cells in ICON."""
         match (dim):
             case (dimension.CellDim):
                 return cls._INTERIOR_CELLS

--- a/atm_dyn_iconam/tests/test_icon_grid.py
+++ b/atm_dyn_iconam/tests/test_icon_grid.py
@@ -17,224 +17,289 @@ from icon4py.diffusion.horizontal import HorizontalMarkerIndex
 
 
 @pytest.mark.datatest
-def test_horizontal_grid_cell_indices(icon_grid):
+@pytest.mark.parametrize(
+    "start_marker, end_marker, expected_bounds",
+    [
+        (
+            HorizontalMarkerIndex.lateral_boundary(CellDim),
+            HorizontalMarkerIndex.lateral_boundary(CellDim),
+            (0, 850),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(CellDim) + 1,
+            HorizontalMarkerIndex.lateral_boundary(CellDim) + 1,
+            (850, 1688),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(CellDim) + 2,
+            HorizontalMarkerIndex.lateral_boundary(CellDim) + 2,
+            (1688, 2511),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(CellDim) + 3,
+            HorizontalMarkerIndex.lateral_boundary(CellDim) + 3,
+            (2511, 3316),
+        ),
+        (
+            HorizontalMarkerIndex.interior(CellDim),
+            HorizontalMarkerIndex.interior(CellDim),
+            (4104, 20896),
+        ),
+        (
+            HorizontalMarkerIndex.interior(CellDim) + 1,
+            HorizontalMarkerIndex.interior(CellDim) + 1,
+            (0, 850),
+        ),
+        (
+            HorizontalMarkerIndex.nudging(CellDim),
+            HorizontalMarkerIndex.nudging(CellDim),
+            (
+                3316,
+                4104,
+            ),
+        ),
+        (
+            HorizontalMarkerIndex.end(CellDim),
+            HorizontalMarkerIndex.end(CellDim),
+            (
+                20896,
+                20896,
+            ),
+        ),
+        (
+            HorizontalMarkerIndex.halo(CellDim),
+            HorizontalMarkerIndex.halo(CellDim),
+            (
+                20896,
+                20896,
+            ),
+        ),
+        (
+            HorizontalMarkerIndex.local(CellDim),
+            HorizontalMarkerIndex.local(CellDim),
+            (-1, 20896),
+        ),
+    ],
+)
+def test_horizontal_cell_markers(icon_grid, start_marker, end_marker, expected_bounds):
+    assert (
+        icon_grid.get_indices_from_to(
+            CellDim,
+            start_marker,
+            end_marker,
+        )
+        == expected_bounds
+    )
+
+
+@pytest.mark.datatest
+@pytest.mark.parametrize(
+    "start_marker, end_marker, expected_bounds",
+    [
+        (
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim),
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim),
+            (0, 428),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 1,
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 1,
+            (428, 1278),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 2,
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 2,
+            (1278, 1700),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 3,
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 3,
+            (1700, 2538),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 4,
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 4,
+            (2538, 2954),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 5,
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 5,
+            (2954, 3777),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 6,
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 6,
+            (3777, 4184),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 7,
+            HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 7,
+            (4184, 4989),
+        ),
+        (
+            HorizontalMarkerIndex.interior(EdgeDim),
+            HorizontalMarkerIndex.interior(EdgeDim),
+            (6176, 31558),
+        ),
+        (
+            HorizontalMarkerIndex.nudging(EdgeDim),
+            HorizontalMarkerIndex.nudging(EdgeDim),
+            (
+                4989,
+                5387,
+            ),
+        ),
+        (
+            HorizontalMarkerIndex.nudging(EdgeDim) + 1,
+            HorizontalMarkerIndex.nudging(EdgeDim) + 1,
+            (5387, 6176),
+        ),
+        (
+            HorizontalMarkerIndex.end(EdgeDim),
+            HorizontalMarkerIndex.end(EdgeDim),
+            (
+                31558,
+                31558,
+            ),
+        ),
+        (
+            HorizontalMarkerIndex.halo(EdgeDim),
+            HorizontalMarkerIndex.halo(EdgeDim),
+            (
+                31558,
+                31558,
+            ),
+        ),
+        (
+            HorizontalMarkerIndex.local(EdgeDim),
+            HorizontalMarkerIndex.local(EdgeDim),
+            (-1, 31558),
+        ),
+    ],
+)
+def test_horizontal_edge_markers(icon_grid, start_marker, end_marker, expected_bounds):
+    assert (
+        icon_grid.get_indices_from_to(
+            EdgeDim,
+            start_marker,
+            end_marker,
+        )
+        == expected_bounds
+    )
+
+
+@pytest.mark.datatest
+@pytest.mark.parametrize(
+    "start_marker, end_marker, expected_bounds",
+    [
+        (
+            HorizontalMarkerIndex.lateral_boundary(VertexDim),
+            HorizontalMarkerIndex.lateral_boundary(VertexDim),
+            (0, 428),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(VertexDim) + 1,
+            HorizontalMarkerIndex.lateral_boundary(VertexDim) + 1,
+            (428, 850),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(VertexDim) + 2,
+            HorizontalMarkerIndex.lateral_boundary(VertexDim) + 2,
+            (850, 1266),
+        ),
+        (
+            HorizontalMarkerIndex.lateral_boundary(VertexDim) + 3,
+            HorizontalMarkerIndex.lateral_boundary(VertexDim) + 3,
+            (1266, 1673),
+        ),
+        (
+            HorizontalMarkerIndex.interior(VertexDim),
+            HorizontalMarkerIndex.interior(VertexDim),
+            (2071, 10663),
+        ),
+        (
+            HorizontalMarkerIndex.interior(VertexDim) + 1,
+            HorizontalMarkerIndex.interior(VertexDim) + 1,
+            (0, 428),
+        ),
+        (
+            HorizontalMarkerIndex.end(CellDim),
+            HorizontalMarkerIndex.end(CellDim),
+            (
+                10663,
+                10663,
+            ),
+        ),
+        (
+            HorizontalMarkerIndex.halo(VertexDim),
+            HorizontalMarkerIndex.halo(VertexDim),
+            (
+                10663,
+                10663,
+            ),
+        ),
+        (
+            HorizontalMarkerIndex.local(VertexDim),
+            HorizontalMarkerIndex.local(VertexDim),
+            (-1, 10663),
+        ),
+    ],
+)
+def test_horizontal_vertex_markers(
+    icon_grid, start_marker, end_marker, expected_bounds
+):
+    assert (
+        icon_grid.get_indices_from_to(
+            VertexDim,
+            start_marker,
+            end_marker,
+        )
+        == expected_bounds
+    )
+
+
+@pytest.mark.datatest
+def test_cross_check_marker_equivalences(icon_grid):
+    """
+    Check actual equivalences of calculated markers.
+
+    TODO [magdalena] This should go away once we refactor these markers in a good way, such that no
+    calculation need to be done with them anymore.
+    """
     assert icon_grid.get_indices_from_to(
         CellDim,
         HorizontalMarkerIndex.local(CellDim) - 1,
         HorizontalMarkerIndex.local(CellDim) - 1,
-    ) == (
-        20896,
-        20896,
-    )  # halo + 1
-
-    assert icon_grid.get_indices_from_to(
+    ) == icon_grid.get_indices_from_to(
         CellDim,
-        HorizontalMarkerIndex.local(CellDim),
-        HorizontalMarkerIndex.local(CellDim),
-    ) == (
-        -1,
-        20896,
-    )  # halo in icon is (1,20896)
-    assert icon_grid.get_indices_from_to(
-        CellDim,
-        HorizontalMarkerIndex.interior(CellDim),
-        HorizontalMarkerIndex.interior(CellDim),
-    ) == (
-        4104,
-        20896,
-    )  # interior
-    assert icon_grid.get_indices_from_to(
-        CellDim,
-        HorizontalMarkerIndex.interior(CellDim) + 1,
-        HorizontalMarkerIndex.interior(CellDim) + 1,
-    ) == (
-        0,
-        850,
-    )  # lb+1
-    assert icon_grid.get_indices_from_to(
-        CellDim,
-        HorizontalMarkerIndex.lateral_boundary(CellDim) + 1,
-        HorizontalMarkerIndex.lateral_boundary(CellDim) + 1,
-    ) == (850, 1688)
-    assert icon_grid.get_indices_from_to(
-        CellDim,
-        HorizontalMarkerIndex.lateral_boundary(CellDim) + 2,
-        HorizontalMarkerIndex.lateral_boundary(CellDim) + 2,
-    ) == (
-        1688,
-        2511,
-    )  # lb+2
+        HorizontalMarkerIndex.halo(CellDim),
+        HorizontalMarkerIndex.halo(CellDim),
+    )
     assert icon_grid.get_indices_from_to(
         CellDim,
         HorizontalMarkerIndex.nudging(CellDim) - 1,
         HorizontalMarkerIndex.nudging(CellDim) - 1,
-    ) == (
-        2511,
-        3316,
-    )  # lb+3
-    assert icon_grid.get_indices_from_to(
+    ) == icon_grid.get_indices_from_to(
         CellDim,
-        HorizontalMarkerIndex.nudging(CellDim),
-        HorizontalMarkerIndex.nudging(CellDim),
-    ) == (
-        3316,
-        4104,
-    )  # nudging
-
-
-@pytest.mark.datatest
-def test_horizontal_edge_indices(icon_grid):
-    assert icon_grid.get_indices_from_to(
-        EdgeDim,
-        HorizontalMarkerIndex.interior(EdgeDim),
-        HorizontalMarkerIndex.interior(EdgeDim),
-    ) == (6176, 31558)
-    assert icon_grid.get_indices_from_to(
-        EdgeDim,
-        HorizontalMarkerIndex.local(EdgeDim) - 2,
-        HorizontalMarkerIndex.local(EdgeDim) - 2,
-    ) == (31558, 31558)
+        HorizontalMarkerIndex.lateral_boundary(CellDim) + 3,
+        HorizontalMarkerIndex.lateral_boundary(CellDim) + 3,
+    )
     assert icon_grid.get_indices_from_to(
         EdgeDim,
         HorizontalMarkerIndex.local(EdgeDim) - 1,
         HorizontalMarkerIndex.local(EdgeDim) - 1,
-    ) == (31558, 31558)
+    ) == icon_grid.get_indices_from_to(
+        EdgeDim,
+        HorizontalMarkerIndex.halo(EdgeDim),
+        HorizontalMarkerIndex.halo(EdgeDim),
+    )
+
     assert icon_grid.get_indices_from_to(
         EdgeDim,
-        HorizontalMarkerIndex.local(EdgeDim),
-        HorizontalMarkerIndex.local(EdgeDim),
-    ) == (
-        -1,
-        31558,
-    )  # halo in icon is  (1, 31558)
-    assert icon_grid.get_indices_from_to(
-        EdgeDim,
-        HorizontalMarkerIndex.nudging(EdgeDim) + 1,
-        HorizontalMarkerIndex.nudging(EdgeDim) + 1,
-    ) == (
-        5387,
-        6176,
-    )  # nudging +1
-    assert icon_grid.get_indices_from_to(
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 8,
+        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 8,
+    ) == icon_grid.get_indices_from_to(
         EdgeDim,
         HorizontalMarkerIndex.nudging(EdgeDim),
         HorizontalMarkerIndex.nudging(EdgeDim),
-    ) == (
-        4989,
-        5387,
-    )  # nudging
-    assert icon_grid.get_indices_from_to(
-        EdgeDim,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 7,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 7,
-    ) == (
-        4184,
-        4989,
-    )  # lb +7
-    assert icon_grid.get_indices_from_to(
-        EdgeDim,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 6,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 6,
-    ) == (
-        3777,
-        4184,
-    )  # lb +6
-    assert icon_grid.get_indices_from_to(
-        EdgeDim,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 5,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 5,
-    ) == (
-        2954,
-        3777,
-    )  # lb +5
-    assert icon_grid.get_indices_from_to(
-        EdgeDim,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 4,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 4,
-    ) == (
-        2538,
-        2954,
-    )  # lb +4
-    assert icon_grid.get_indices_from_to(
-        EdgeDim,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 3,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 3,
-    ) == (
-        1700,
-        2538,
-    )  # lb +3
-    assert icon_grid.get_indices_from_to(
-        EdgeDim,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 2,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 2,
-    ) == (
-        1278,
-        1700,
-    )  # lb +2
-    assert icon_grid.get_indices_from_to(
-        EdgeDim,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 1,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim) + 1,
-    ) == (
-        428,
-        1278,
-    )  # lb +1
-    assert icon_grid.get_indices_from_to(
-        EdgeDim,
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim),
-        HorizontalMarkerIndex.lateral_boundary(EdgeDim),
-    ) == (
-        0,
-        428,
-    )  # lb +0
-
-
-@pytest.mark.datatest
-def test_horizontal_vertex_indices(icon_grid):
-    assert icon_grid.get_indices_from_to(
-        VertexDim,
-        HorizontalMarkerIndex.end(VertexDim),
-        HorizontalMarkerIndex.end(VertexDim),
-    ) == (10663, 10663)
-    assert icon_grid.get_indices_from_to(
-        VertexDim,
-        HorizontalMarkerIndex.local(VertexDim),
-        HorizontalMarkerIndex.local(VertexDim),
-    ) == (-1, 10663)
-    assert icon_grid.get_indices_from_to(
-        VertexDim,
-        HorizontalMarkerIndex.local(VertexDim) - 1,
-        HorizontalMarkerIndex.local(VertexDim) - 1,
-    ) == (10663, 10663)
-
-    assert icon_grid.get_indices_from_to(
-        VertexDim,
-        HorizontalMarkerIndex.lateral_boundary(VertexDim),
-        HorizontalMarkerIndex.lateral_boundary(VertexDim),
-    ) == (0, 428)
-    assert icon_grid.get_indices_from_to(
-        VertexDim,
-        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 1,
-        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 1,
-    ) == (428, 850)
-    assert icon_grid.get_indices_from_to(
-        VertexDim,
-        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 2,
-        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 2,
-    ) == (850, 1266)
-    assert icon_grid.get_indices_from_to(
-        VertexDim,
-        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 3,
-        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 3,
-    ) == (1266, 1673)
-    assert icon_grid.get_indices_from_to(
-        VertexDim,
-        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 4,
-        HorizontalMarkerIndex.lateral_boundary(VertexDim) + 4,
-    ) == (1673, 2071)
-
-    assert icon_grid.get_indices_from_to(
-        VertexDim,
-        HorizontalMarkerIndex.interior(VertexDim),
-        HorizontalMarkerIndex.interior(VertexDim),
-    ) == (2071, 10663)
+    )


### PR DESCRIPTION
- fixed the constants `_HALO_[CELLS|VERTICES|EDGES]` horizontal.py to reflect the `min_rlxx_int -1` in ICON and introduced a new one `_LOCAL_[CELLS|VERTICES|EDGES]` for the `min_rlxx_int`. 
- added a correnspondig `halo(dim)` marker function that returns the marker for the first halo line
- refactored the test to use parametrization