### PR TITLE
use int32 instead of unqualified int in domain args

### DIFF
--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/apply_diffusion_to_w_and_compute_horizontal_gradients_for_turbulance.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/apply_diffusion_to_w_and_compute_horizontal_gradients_for_turbulance.py
@@ -96,10 +96,10 @@ def apply_diffusion_to_w_and_compute_horizontal_gradients_for_turbulance(
     nrdmax: int32,
     interior_idx: int32,
     halo_idx: int32,
-    horizontal_start: int,
-    horizontal_end: int,
-    vertical_start: int,
-    vertical_end: int,
+    horizontal_start: int32,
+    horizontal_end: int32,
+    vertical_start: int32,
+    vertical_end: int32,
 ):
     _apply_diffusion_to_w_and_compute_horizontal_gradients_for_turbulance(
         area,

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/apply_nabla2_and_nabla4_to_vn.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/apply_nabla2_and_nabla4_to_vn.py
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gt4py.next.ffront.decorator import field_operator, program
-from gt4py.next.ffront.fbuiltins import Field, maximum
+from gt4py.next.ffront.fbuiltins import Field, int32, maximum
 
 from icon4py.common.dimension import EdgeDim, KDim
 
@@ -39,10 +39,10 @@ def mo_nh_diffusion_stencil_05_global_mode(
     z_nabla4_e2: Field[[EdgeDim, KDim], float],
     diff_multfac_vn: Field[[KDim], float],
     vn: Field[[EdgeDim, KDim], float],
-    horizontal_start: int,
-    horizontal_end: int,
-    vertical_start: int,
-    vertical_end: int,
+    horizontal_start: int32,
+    horizontal_end: int32,
+    vertical_start: int32,
+    vertical_end: int32,
 ):
     _mo_nh_diffusion_stencil_05_global_mode(
         area_edge,

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/calculate_diagnostic_quantities_for_turbulence.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/calculate_diagnostic_quantities_for_turbulence.py
@@ -12,7 +12,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from gt4py.next.ffront.decorator import field_operator, program
-from gt4py.next.ffront.fbuiltins import Field
+from gt4py.next.ffront.fbuiltins import Field, int32
 
 from icon4py.atm_dyn_iconam.calculate_diagnostics_for_turbulence import (
     _calculate_diagnostics_for_turbulence,
@@ -49,10 +49,10 @@ def calculate_diagnostic_quantities_for_turbulence(
     wgtfac_c: Field[[CellDim, KDim], float],
     div_ic: Field[[CellDim, KDim], float],
     hdef_ic: Field[[CellDim, KDim], float],
-    horizontal_start: int,
-    horizontal_end: int,
-    vertical_start: int,
-    vertical_end: int,
+    horizontal_start: int32,
+    horizontal_end: int32,
+    vertical_start: int32,
+    vertical_end: int32,
 ):
     _calculate_diagnostic_quantities_for_turbulence(
         kh_smag_ec,

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/calculate_enhanced_diffusion_coefficients_for_grid_point_cold_pools.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/calculate_enhanced_diffusion_coefficients_for_grid_point_cold_pools.py
@@ -12,7 +12,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from gt4py.next.ffront.decorator import field_operator, program
-from gt4py.next.ffront.fbuiltins import Field
+from gt4py.next.ffront.fbuiltins import Field, int32
 
 from icon4py.atm_dyn_iconam.enhance_diffusion_coefficient_for_grid_point_cold_pools import (
     _enhance_diffusion_coefficient_for_grid_point_cold_pools,
@@ -45,10 +45,10 @@ def calculate_enhanced_diffusion_coefficients_for_grid_point_cold_pools(
     theta_ref_mc: Field[[CellDim, KDim], float],
     thresh_tdiff: float,
     kh_smag_e: Field[[EdgeDim, KDim], float],
-    horizontal_start: int,
-    horizontal_end: int,
-    vertical_start: int,
-    vertical_end: int,
+    horizontal_start: int32,
+    horizontal_end: int32,
+    vertical_start: int32,
+    vertical_end: int32,
 ):
     _calculate_enhanced_diffusion_coefficients_for_grid_point_cold_pools(
         theta_v,

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/calculate_nabla2_and_smag_coefficients_for_vn.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/calculate_nabla2_and_smag_coefficients_for_vn.py
@@ -12,7 +12,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from gt4py.next.ffront.decorator import field_operator, program
-from gt4py.next.ffront.fbuiltins import Field, maximum, minimum, sqrt
+from gt4py.next.ffront.fbuiltins import Field, int32, maximum, minimum, sqrt
 
 from icon4py.common.dimension import (
     E2C2V,
@@ -153,10 +153,10 @@ def calculate_nabla2_and_smag_coefficients_for_vn(
     kh_smag_ec: Field[[EdgeDim, KDim], float],
     z_nabla2_e: Field[[EdgeDim, KDim], float],
     smag_offset: float,
-    horizontal_start: int,
-    horizontal_end: int,
-    vertical_start: int,
-    vertical_end: int,
+    horizontal_start: int32,
+    horizontal_end: int32,
+    vertical_start: int32,
+    vertical_end: int32,
 ):
     _calculate_nabla2_and_smag_coefficients_for_vn(
         diff_multfac_smag,

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/calculate_nabla2_for_theta.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/calculate_nabla2_for_theta.py
@@ -12,7 +12,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from gt4py.next.ffront.decorator import field_operator, program
-from gt4py.next.ffront.fbuiltins import Field
+from gt4py.next.ffront.fbuiltins import Field, int32
 
 from icon4py.atm_dyn_iconam.calculate_nabla2_for_z import _calculate_nabla2_for_z
 from icon4py.atm_dyn_iconam.calculate_nabla2_of_theta import (
@@ -40,10 +40,10 @@ def calculate_nabla2_for_theta(
     theta_v: Field[[CellDim, KDim], float],
     geofac_div: Field[[CEDim], float],
     z_temp: Field[[CellDim, KDim], float],
-    horizontal_start: int,
-    horizontal_end: int,
-    vertical_start: int,
-    vertical_end: int,
+    horizontal_start: int32,
+    horizontal_end: int32,
+    vertical_start: int32,
+    vertical_end: int32,
 ):
     _calculate_nabla2_for_theta(
         kh_smag_e,

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/fused_mo_nh_diffusion_stencil_04_05_06.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/fused_mo_nh_diffusion_stencil_04_05_06.py
@@ -92,10 +92,10 @@ def fused_mo_nh_diffusion_stencil_04_05_06(
     nudgezone_diff: float,
     fac_bdydiff_v: float,
     start_2nd_nudge_line_idx_e: int32,
-    horizontal_start: int,
-    horizontal_end: int,
-    vertical_start: int,
-    vertical_end: int,
+    horizontal_start: int32,
+    horizontal_end: int32,
+    vertical_start: int32,
+    vertical_end: int32,
 ):
     _fused_mo_nh_diffusion_stencil_04_05_06(
         u_vert,

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/fused_mo_nh_diffusion_stencil_13_14.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/fused_mo_nh_diffusion_stencil_13_14.py
@@ -18,7 +18,7 @@ from icon4py.atm_dyn_iconam.calculate_nabla2_for_z import _calculate_nabla2_for_
 from icon4py.atm_dyn_iconam.calculate_nabla2_of_theta import (
     _calculate_nabla2_of_theta,
 )
-from icon4py.common.dimension import CellDim, EdgeDim, KDim, CEDim
+from icon4py.common.dimension import CEDim, CellDim, EdgeDim, KDim
 
 
 @field_operator

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_intp_rbf_rbf_vec_interpol_vertex.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/mo_intp_rbf_rbf_vec_interpol_vertex.py
@@ -12,7 +12,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from gt4py.next.ffront.decorator import field_operator, program
-from gt4py.next.ffront.fbuiltins import Field, neighbor_sum
+from gt4py.next.ffront.fbuiltins import Field, int32, neighbor_sum
 
 from icon4py.common.dimension import V2E, EdgeDim, KDim, V2EDim, VertexDim
 
@@ -35,10 +35,10 @@ def mo_intp_rbf_rbf_vec_interpol_vertex(
     ptr_coeff_2: Field[[VertexDim, V2EDim], float],
     p_u_out: Field[[VertexDim, KDim], float],
     p_v_out: Field[[VertexDim, KDim], float],
-    horizontal_start: int,
-    horizontal_end: int,
-    vertical_start: int,
-    vertical_end: int,
+    horizontal_start: int32,
+    horizontal_end: int32,
+    vertical_start: int32,
+    vertical_end: int32,
 ):
     _mo_intp_rbf_rbf_vec_interpol_vertex(
         p_e_in,

--- a/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/update_theta_and_exner.py
+++ b/atm_dyn_iconam/src/icon4py/atm_dyn_iconam/update_theta_and_exner.py
@@ -12,7 +12,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from gt4py.next.ffront.decorator import field_operator, program
-from gt4py.next.ffront.fbuiltins import Field
+from gt4py.next.ffront.fbuiltins import Field, int32
 
 from icon4py.common.dimension import CellDim, KDim
 
@@ -38,10 +38,10 @@ def update_theta_and_exner(
     theta_v: Field[[CellDim, KDim], float],
     exner: Field[[CellDim, KDim], float],
     rd_o_cvd: float,
-    horizontal_start: int,
-    horizontal_end: int,
-    vertical_start: int,
-    vertical_end: int,
+    horizontal_start: int32,
+    horizontal_end: int32,
+    vertical_start: int32,
+    vertical_end: int32,
 ):
     _update_theta_and_exner(
         z_temp,

--- a/atm_dyn_iconam/src/icon4py/diffusion/diffusion.py
+++ b/atm_dyn_iconam/src/icon4py/diffusion/diffusion.py
@@ -23,21 +23,23 @@ from gt4py.next.iterator.embedded import np_as_located_field
 from gt4py.next.program_processors.runners.gtfn_cpu import run_gtfn
 
 import icon4py.diffusion.diffusion_program as diff_prog
-from icon4py.atm_dyn_iconam import calculate_diagnostic_quantities_for_turbulence
+from icon4py.atm_dyn_iconam.apply_diffusion_to_w_and_compute_horizontal_gradients_for_turbulance import (
+    apply_diffusion_to_w_and_compute_horizontal_gradients_for_turbulance,
+)
+from icon4py.atm_dyn_iconam.calculate_diagnostic_quantities_for_turbulence import (
+    calculate_diagnostic_quantities_for_turbulence,
+)
+from icon4py.atm_dyn_iconam.calculate_enhanced_diffusion_coefficients_for_grid_point_cold_pools import (
+    calculate_enhanced_diffusion_coefficients_for_grid_point_cold_pools,
+)
 from icon4py.atm_dyn_iconam.calculate_nabla2_and_smag_coefficients_for_vn import (
     calculate_nabla2_and_smag_coefficients_for_vn,
 )
+from icon4py.atm_dyn_iconam.calculate_nabla2_for_theta import (
+    calculate_nabla2_for_theta,
+)
 from icon4py.atm_dyn_iconam.fused_mo_nh_diffusion_stencil_04_05_06 import (
     fused_mo_nh_diffusion_stencil_04_05_06,
-)
-from icon4py.atm_dyn_iconam.fused_mo_nh_diffusion_stencil_07_08_09_10 import (
-    apply_diffusion_to_w_and_compute_horizontal_gradients_for_turbulance,
-)
-from icon4py.atm_dyn_iconam.fused_mo_nh_diffusion_stencil_11_12 import (
-    calculate_enhanced_diffusion_coefficients_for_grid_point_cold_pools,
-)
-from icon4py.atm_dyn_iconam.fused_mo_nh_diffusion_stencil_13_14 import (
-    calculate_nabla2_for_theta,
 )
 from icon4py.atm_dyn_iconam.mo_intp_rbf_rbf_vec_interpol_vertex import (
     mo_intp_rbf_rbf_vec_interpol_vertex,
@@ -815,7 +817,7 @@ class Diffusion:
         set_zero_v_k.with_backend(run_gtfn)(self.v_vert, offset_provider={})
         log.debug("rbf interpolation: start")
         # # 1.  CALL rbf_vec_interpol_vertex
-        mo_intp_rbf_rbf_vec_interpol_vertex(
+        mo_intp_rbf_rbf_vec_interpol_vertex.with_backend(run_gtfn)(
             p_e_in=prognostic_state.vn,
             ptr_coeff_1=self.interpolation_state.rbf_coeff_1,
             ptr_coeff_2=self.interpolation_state.rbf_coeff_2,

--- a/atm_dyn_iconam/src/icon4py/diffusion/diffusion_program.py
+++ b/atm_dyn_iconam/src/icon4py/diffusion/diffusion_program.py
@@ -16,7 +16,6 @@
 from gt4py.next.common import Field
 from gt4py.next.ffront.decorator import program
 from gt4py.next.ffront.fbuiltins import int32
-from gt4py.next.program_processors.runners import gtfn_cpu
 
 from icon4py.atm_dyn_iconam.apply_diffusion_to_w_and_compute_horizontal_gradients_for_turbulance import (
     _apply_diffusion_to_w_and_compute_horizontal_gradients_for_turbulance,
@@ -24,14 +23,14 @@ from icon4py.atm_dyn_iconam.apply_diffusion_to_w_and_compute_horizontal_gradient
 from icon4py.atm_dyn_iconam.calculate_diagnostic_quantities_for_turbulence import (
     _calculate_diagnostic_quantities_for_turbulence,
 )
+from icon4py.atm_dyn_iconam.calculate_enhanced_diffusion_coefficients_for_grid_point_cold_pools import (
+    _calculate_enhanced_diffusion_coefficients_for_grid_point_cold_pools,
+)
 from icon4py.atm_dyn_iconam.calculate_nabla2_and_smag_coefficients_for_vn import (
     _calculate_nabla2_and_smag_coefficients_for_vn,
 )
 from icon4py.atm_dyn_iconam.fused_mo_nh_diffusion_stencil_04_05_06 import (
     _fused_mo_nh_diffusion_stencil_04_05_06,
-)
-from icon4py.atm_dyn_iconam.fused_mo_nh_diffusion_stencil_11_12 import (
-    _calculate_enhanced_diffusion_coefficients_for_grid_point_cold_pools,
 )
 from icon4py.atm_dyn_iconam.mo_intp_rbf_rbf_vec_interpol_vertex import (
     _mo_intp_rbf_rbf_vec_interpol_vertex,
@@ -110,20 +109,20 @@ def diffusion_run(
     local_horizontal_edge_index: Field[[EdgeDim], int32],
     cell_startindex_interior: int32,
     cell_halo_idx: int32,
-    cell_startindex_nudging: int,
-    cell_endindex_local_plus1: int,
-    cell_endindex_local: int,
-    edge_startindex_nudging_plus1: int,
+    cell_startindex_nudging: int32,
+    cell_endindex_local_plus1: int32,
+    cell_endindex_local: int32,
+    edge_startindex_nudging_plus1: int32,
     edge_startindex_nudging_minus1: int32,
-    edge_endindex_local: int,
-    edge_endindex_local_minus2: int,
-    vertex_startindex_lb_plus3: int,
-    vertex_startindex_lb_plus1: int,
-    vertex_endindex_local: int,
-    vertex_endindex_local_minus1: int,
+    edge_endindex_local: int32,
+    edge_endindex_local_minus2: int32,
+    vertex_startindex_lb_plus3: int32,
+    vertex_startindex_lb_plus1: int32,
+    vertex_endindex_local: int32,
+    vertex_endindex_local_minus1: int32,
     index_of_damping_height: int32,
-    nlev: int,
-    boundary_diffusion_start_index_edges: int,
+    nlev: int32,
+    boundary_diffusion_start_index_edges: int32,
 ):
     _scale_k(local_enh_smag_fac, dtime, out=local_diff_multfac_smag)
 

--- a/atm_dyn_iconam/src/icon4py/diffusion/icon_grid.py
+++ b/atm_dyn_iconam/src/icon4py/diffusion/icon_grid.py
@@ -100,8 +100,8 @@ class IconGrid:
     def with_start_end_indices(
         self, dim: Dimension, start_indices: np.ndarray, end_indices: np.ndarray
     ):
-        self.start_indices[dim] = start_indices.astype(int)
-        self.end_indices[dim] = end_indices.astype(int)
+        self.start_indices[dim] = start_indices.astype(int32)
+        self.end_indices[dim] = end_indices.astype(int32)
 
     @builder
     def with_connectivities(self, connectivity: Dict[Dimension, np.ndarray]):
@@ -128,7 +128,7 @@ class IconGrid:
 
     def get_indices_from_to(
         self, dim: Dimension, start_marker: int, end_marker: int
-    ) -> Tuple[int, int]:
+    ) -> Tuple[int32, int32]:
         """
         Use to specify domains of a field for field_operator.
 


### PR DESCRIPTION
https://github.com/GridTools/gt4py/pull/1255 removes unspecified integer types from `gt4py`, hence `ScalarKind.INT` was removed from the type system.

- use `int32` instead of `int` domain args. 