### PR TITLE
[CI] add Jenkinsfile to test icon-exclaim

### DIFF
--- a/jenkins/spack-PR-icon
+++ b/jenkins/spack-PR-icon
@@ -21,7 +21,7 @@ triggerPhrase.each {
 }
 triggerPhrase.each {
     if(it.contains("spack${repo_identifier}")) {
-        (icon_fork, icon_branch) = parseTriggerPhrase(it)
+        (spack_fork, spack_branch) = parseTriggerPhrase(it)
         spack_default = false
     }
 }


### PR DESCRIPTION
The plan is able to use a custome fork/branch of both spack-c2sm and icon-exclaim.

The trigger phrase looks as follows:
`launch jenkins icon iconProject=C2SM/ci_cross_repo spackProject=C2SM/libicon4py`