### PR TITLE
Introduce `--grid` option to pytest and benchmark `gtfn_cpu` execution in CI

### DIFF
--- a/model/atmosphere/advection/tests/conftest.py
+++ b/model/atmosphere/advection/tests/conftest.py
@@ -11,12 +11,10 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from icon4py.model.common.test_utils.grid_utils import (  # noqa : F401  # fixtures from test_utils
+    grid,
+    simple_grid_gridfile,
+)
 from icon4py.model.common.test_utils.helpers import (  # noqa : F401  # fixtures from test_utils
     backend,
 )
-
-from icon4py.model.common.test_utils.grid_utils import (  # noqa : F401  # fixtures from test_utils
-    simple_grid_gridfile, grid
-)
-
-from icon4py.model.common.test_utils.datatest_helpers import *

--- a/model/atmosphere/diffusion/tests/conftest.py
+++ b/model/atmosphere/diffusion/tests/conftest.py
@@ -11,12 +11,10 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from icon4py.model.common.test_utils.grid_utils import (  # noqa : F401  # fixtures from test_utils
+    grid,
+    simple_grid_gridfile,
+)
 from icon4py.model.common.test_utils.helpers import (  # noqa : F401  # fixtures from test_utils
     backend,
 )
-
-from icon4py.model.common.test_utils.grid_utils import (  # noqa : F401  # fixtures from test_utils
-    simple_grid_gridfile, grid
-)
-
-from icon4py.model.common.test_utils.datatest_helpers import *

--- a/model/atmosphere/dycore/tests/conftest.py
+++ b/model/atmosphere/dycore/tests/conftest.py
@@ -11,12 +11,10 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from icon4py.model.common.test_utils.grid_utils import (  # noqa : F401  # fixtures from test_utils
+    grid,
+    simple_grid_gridfile,
+)
 from icon4py.model.common.test_utils.helpers import (  # noqa : F401  # fixtures from test_utils
     backend,
 )
-
-from icon4py.model.common.test_utils.grid_utils import (  # noqa : F401  # fixtures from test_utils
-    simple_grid_gridfile, grid
-)
-
-from icon4py.model.common.test_utils.datatest_helpers import *

--- a/model/common/pyproject.toml
+++ b/model/common/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics"
 ]
 dependencies = [
-  "gt4py>=1.0.1"
+  "gt4py>=1.0.1",
+  "netcdf4>=1.6.0"
 ]
 description = "Shared code for the icon4py model."
 dynamic = ['version']
@@ -29,9 +30,8 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-all = ["icon4py-common[ghex,netcdf]"]
+all = ["icon4py-common[ghex]"]
 ghex = ["pyghex>=0.3.0", "mpi4py<=3.1.4"]
-netcdf = ["netcdf4>=1.6.0"]
 
 [project.urls]
 repository = "https://github.com/C2SM/icon4py"

--- a/model/common/src/icon4py/model/common/grid/icon.py
+++ b/model/common/src/icon4py/model/common/grid/icon.py
@@ -183,7 +183,6 @@ class IconGrid(BaseGrid):
             "E2C2V": self.get_e2c2v_offset_provider(),
             "V2E": self.get_v2e_offset_provider(),
             "V2C": self.get_v2c_offset_provider(),
-            # "C2V": self.get_c2v_offset_provider(),
             "E2ECV": self.get_e2ecv_offset_provider(),
             "C2CEC": self.get_c2cec_offset_provider(),
             "C2CE": self.get_c2ce_offset_provider(),

--- a/model/common/src/icon4py/model/common/grid/simple.py
+++ b/model/common/src/icon4py/model/common/grid/simple.py
@@ -14,7 +14,7 @@
 from dataclasses import dataclass
 
 import numpy as np
-from gt4py.next.iterator.embedded import NeighborTableOffsetProvider, StridedNeighborOffsetProvider
+from gt4py.next.iterator.embedded import NeighborTableOffsetProvider
 
 from icon4py.model.common.dimension import (
     C2E2C2E2CDim,
@@ -39,7 +39,6 @@ from icon4py.model.common.dimension import (
     VertexDim,
 )
 from icon4py.model.common.grid.base import BaseGrid, GridConfig
-from icon4py.model.common.grid.utils import neighbortable_offset_provider_for_1d_sparse_fields
 
 # periodic
 #
@@ -60,6 +59,7 @@ from icon4py.model.common.grid.utils import neighbortable_offset_provider_for_1d
 # |  15c  \ | 16c   \ | 17c  \
 # 0v       1v         2v        0v
 from icon4py.model.common.grid.horizontal import HorizontalGridSize
+from icon4py.model.common.grid.utils import neighbortable_offset_provider_for_1d_sparse_fields
 from icon4py.model.common.grid.vertical import VerticalGridSize
 
 
@@ -552,7 +552,13 @@ class SimpleGrid(BaseGrid):
             "C2CE": self.get_c2ce_offset_provider(),
             "Koff": KDim,
             "C2E2C2E2C": self.get_c2e2c2e2c_offset_provider(),
-            "E2ECV": neighbortable_offset_provider_for_1d_sparse_fields(self.connectivities[E2C2VDim].shape, EdgeDim, ECVDim),
-            "E2EC": neighbortable_offset_provider_for_1d_sparse_fields(self.connectivities[E2CDim].shape, EdgeDim, ECDim),
-            "C2CEC": neighbortable_offset_provider_for_1d_sparse_fields(self.connectivities[C2E2CDim].shape, CellDim, CECDim),
+            "E2ECV": neighbortable_offset_provider_for_1d_sparse_fields(
+                self.connectivities[E2C2VDim].shape, EdgeDim, ECVDim
+            ),
+            "E2EC": neighbortable_offset_provider_for_1d_sparse_fields(
+                self.connectivities[E2CDim].shape, EdgeDim, ECDim
+            ),
+            "C2CEC": neighbortable_offset_provider_for_1d_sparse_fields(
+                self.connectivities[C2E2CDim].shape, CellDim, CECDim
+            ),
         }

--- a/model/common/src/icon4py/model/common/grid/utils.py
+++ b/model/common/src/icon4py/model/common/grid/utils.py
@@ -1,3 +1,16 @@
+# ICON4Py - ICON inspired code in Python and GT4Py
+#
+# Copyright (c) 2022, ETH Zurich and MeteoSwiss
+# All rights reserved.
+#
+# This file is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 import numpy as np
 from gt4py.next import Dimension, NeighborTableOffsetProvider
 

--- a/model/common/src/icon4py/model/common/test_utils/datatest_helpers.py
+++ b/model/common/src/icon4py/model/common/test_utils/datatest_helpers.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 import pytest
 
-from .helpers import StencilTest
 from ..decomposition.definitions import SingleNodeRun, get_processor_properties
 from .data_handling import download_and_extract
 from .serialbox_utils import IconSerialDataProvider

--- a/model/common/src/icon4py/model/common/test_utils/grid_utils.py
+++ b/model/common/src/icon4py/model/common/test_utils/grid_utils.py
@@ -1,16 +1,42 @@
-import pytest
+# ICON4Py - ICON inspired code in Python and GT4Py
+#
+# Copyright (c) 2022, ETH Zurich and MeteoSwiss
+# All rights reserved.
+#
+# This file is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from uuid import uuid4
 
 import netCDF4
 import numpy as np
+import pytest
 
 from icon4py.model.common.decomposition.definitions import SingleNodeRun
-from icon4py.model.common.dimension import E2VDim, E2C2EDim, C2EDim, V2CDim, E2CDim, C2VDim, V2EDim, C2E2CDim
+from icon4py.model.common.dimension import (
+    C2E2CDim,
+    C2EDim,
+    C2VDim,
+    E2C2EDim,
+    E2CDim,
+    E2VDim,
+    V2CDim,
+    V2EDim,
+)
 from icon4py.model.common.grid.grid_manager import GridFile, GridFileName
 from icon4py.model.common.grid.simple import SimpleGrid
-from icon4py.model.common.test_utils.datatest_helpers import get_processor_properties_for_run, get_ranked_data_path, \
-    get_datapath_for_ranked_data, create_icon_serial_data_provider, SER_DATA_BASEPATH
-from icon4py.model.common.test_utils.serialbox_utils import IconSerialDataProvider
+from icon4py.model.common.test_utils.datatest_helpers import (
+    SER_DATA_BASEPATH,
+    create_icon_serial_data_provider,
+    get_datapath_for_ranked_data,
+    get_processor_properties_for_run,
+    get_ranked_data_path,
+)
 
 
 def _add_to_dataset(

--- a/model/common/src/icon4py/model/common/test_utils/helpers.py
+++ b/model/common/src/icon4py/model/common/test_utils/helpers.py
@@ -20,6 +20,7 @@ from gt4py.next import common as gt_common
 from gt4py.next.ffront.decorator import Program
 from gt4py.next.iterator import embedded as it_embedded
 
+
 try:
     import pytest_benchmark
 except ModuleNotFoundError:

--- a/model/common/src/icon4py/model/common/test_utils/pytest_config.py
+++ b/model/common/src/icon4py/model/common/test_utils/pytest_config.py
@@ -46,7 +46,10 @@ def pytest_addoption(parser):
 
     try:
         parser.addoption(
-            "--grid", action="store", default="simple_grid", help="Grid to use. Defaults to simple_grid, other options include icon_grid"
+            "--grid",
+            action="store",
+            default="simple_grid",
+            help="Grid to use. Defaults to simple_grid, other options include icon_grid",
         )
     except ValueError:
         pass
@@ -75,7 +78,8 @@ def pytest_generate_tests(metafunc):
         # TODO (skellerhals): add gpu support
         else:
             raise Exception(
-                "Need to select a backend. Select from: ['embedded', 'gtfn_cpu'] and pass it as an argument to --backend when invoking pytest.")
+                "Need to select a backend. Select from: ['embedded', 'gtfn_cpu'] and pass it as an argument to --backend when invoking pytest."
+            )
 
         metafunc.parametrize("backend", params, ids=ids)
 

--- a/model/common/tests/conftest.py
+++ b/model/common/tests/conftest.py
@@ -11,7 +11,9 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from icon4py.model.common.test_utils.helpers import backend  # noqa: F401 # fixtures
-from icon4py.model.common.test_utils.grid_utils import grid, simple_grid_gridfile
 
-from icon4py.model.common.test_utils.datatest_helpers import *
+from icon4py.model.common.test_utils.grid_utils import (  # noqa: F401 # fixtures
+    grid,
+    simple_grid_gridfile,
+)
+from icon4py.model.common.test_utils.helpers import backend  # noqa: F401 # fixtures

--- a/model/common/tests/grid_tests/conftest.py
+++ b/model/common/tests/grid_tests/conftest.py
@@ -27,8 +27,9 @@ from icon4py.model.common.test_utils.datatest_helpers import (  # noqa: F401
     ranked_data_path,
 )
 from icon4py.model.common.test_utils.grid_utils import (  # noqa : F401  # fixtures from test_utils
-   simple_grid_gridfile
+    simple_grid_gridfile,
 )
+
 
 grids_path = BASE_PATH.joinpath("grids")
 r04b09_dsl_grid_path = grids_path.joinpath("mch_ch_r04b09_dsl")

--- a/model/common/tests/grid_tests/test_grid_manager.py
+++ b/model/common/tests/grid_tests/test_grid_manager.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 import numpy as np
 import pytest
 
+
 if typing.TYPE_CHECKING:
     import netCDF4
 
@@ -27,8 +28,6 @@ try:
 except ImportError:
     pytest.skip("optional netcdf dependency not installed", allow_module_level=True)
 
-from icon4py.model.common.dimension import CellDim, EdgeDim, VertexDim, C2EDim, V2CDim, E2CDim, \
-    V2EDim
 from icon4py.model.common.dimension import (
     C2E2CDim,
     C2EDim,
@@ -44,6 +43,7 @@ from icon4py.model.common.dimension import (
 )
 from icon4py.model.common.grid.grid_manager import (
     GridFile,
+    GridFileName,
     GridManager,
     IndexTransformation,
     ToGt4PyTransformation,
@@ -445,7 +445,8 @@ def test_grid_manager_diamond_offset(simple_grid_gridfile):
     gm()
     icon_grid = gm.get_grid()
     assert np.allclose(
-        np.sort(icon_grid.get_e2c2v_offset_provider().table, 1), np.sort(simple_grid.diamond_table, 1)
+        np.sort(icon_grid.get_e2c2v_offset_provider().table, 1),
+        np.sort(simple_grid.diamond_table, 1),
     )
 
 


### PR DESCRIPTION
## `--grid` option

Enables setting the grid in tests using the `--grid` option in pytest.

Available grids: `icon_grid`, `simple_grid`

Default grid: `simple_grid`

Example usage: `pytest model --grid=icon_grid`

**Note:** To run tests with the icon grid the serialised grid data must be available. This can be done by running with `--datatest` if it is not available. Also since in the future we will shift the data storage away from Polybox to CSCS storage this mechanism is temporary and will likely change.

## `gtfn_cpu` benchmark

Modified the CI benchmark stage to benchmark `gtfn_cpu` execution on `SimpleGrid`. Running `gtfn_cpu` with the current `IconGrid` results in some test failures, which will be fixed in a future PR.