### PR TITLE
add class name to cache key

### DIFF
--- a/model/common/src/icon4py/model/common/grid/utils.py
+++ b/model/common/src/icon4py/model/common/grid/utils.py
@@ -30,7 +30,7 @@ class ClassLevelCache:
     @staticmethod
     def cache_method(method):
         def wrapper(self, *args, **kwargs):
-            key = f"{method.__name__}_{args}_{kwargs}"
+            key = f"{self.__class__.__name__}_{method.__name__}_{args}_{kwargs}"
             if key not in ClassLevelCache._cache:
                 ClassLevelCache._cache[key] = method(self, *args, **kwargs)
             return ClassLevelCache._cache[key]


### PR DESCRIPTION
Fix cache collision when running tests different grid implementations.