### PR TITLE
change TEST_DATA_PATH

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -42,4 +42,4 @@ variables:
     NUM_PROCESSES: auto
     VIRTUALENV_SYSTEM_SITE_PACKAGES: 1
     CSCS_NEEDED_DATA: icon4py
-    TEST_DATA_PATH: "/apps/daint/UES/jenkssl/ciext/icon4py"
+    TEST_DATA_PATH: "/project/d121/icon4py/ci/testdata"


### PR DESCRIPTION
change `TEST_DATA_PATH` for cscs-ci runs to the new location on `/project/d121/icon4py/ci/testdata`