### PR TITLE
Add full trace and local variables to pytest trace

### DIFF
--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -15,7 +15,7 @@ deps =
     -r {toxinidir}/requirements-dev.txt
 commands =
     -pytest -v -s -n auto -cache-clear --cov --cov-config=pyproject.toml --cov-reset --doctest-modules src/icon4pytools/
-    pytest -v -s -n auto --cov-config=pyproject.toml
+    pytest -vvv -l -s --full-trace -n auto --cov-config=pyproject.toml
 commands_post =
     rm -rf tests/_reports/coverage_html
     -coverage html


### PR DESCRIPTION
### Description

Errors are swallowed when running with click's `cli.invoke` in the `tools`  tests. This change will show the full trace and contents of local test variables on failed tests making debugging easier.