### PR TITLE
Update CI config to use new template for container build

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -16,7 +16,7 @@ variables:
 
 .build_template:
   stage: build
-  extends: .container-builder
+  extends: .container-builder-cscs-zen2
   variables:
     DOCKERFILE: ci/docker/Dockerfile.build
     DOCKER_BUILD_ARGS: '["PYVERSION=$PYVERSION"]'


### PR DESCRIPTION
The CSCS CI config was updated to use the new template for container build (`.container-builder` is deprecated).