### PR TITLE
Fix CI (0d field slice)

### DIFF
--- a/model/atmosphere/advection/tests/stencil_tests/test_face_val_ppm_stencil_01.py
+++ b/model/atmosphere/advection/tests/stencil_tests/test_face_val_ppm_stencil_01.py
@@ -73,10 +73,6 @@ class TestFaceValPpmStencil01(StencilTest):
         p_cc = random_field(grid, CellDim, KDim, extend={KDim: 1})
         p_cellhgt_mc_now = random_field(grid, CellDim, KDim, extend={KDim: 1})
         k = as_field((KDim,), np.arange(0, _shape(grid, KDim, extend={KDim: 1})[0], dtype=int32))
-        elev = k[-2]
-        if hasattr(
-            elev, "as_scalar"
-        ):  # for backwards compatibility, use `as_scalar` unconditionally once minimum gt4py is >= 1.0.4
-            elev = elev.as_scalar()
+        elev = k[-2].as_scalar()
 
         return dict(p_cc=p_cc, p_cellhgt_mc_now=p_cellhgt_mc_now, k=k, elev=elev, z_slope=z_slope)

--- a/model/atmosphere/advection/tests/stencil_tests/test_face_val_ppm_stencil_02.py
+++ b/model/atmosphere/advection/tests/stencil_tests/test_face_val_ppm_stencil_02.py
@@ -60,11 +60,7 @@ class TestFaceValPpmStencil02(StencilTest):
         k = as_field((KDim,), np.arange(0, _shape(grid, KDim)[0], dtype=int32))
         slev = int32(1)
         slevp1 = slev + int32(1)
-        elev = k[-3]
-        if hasattr(
-            elev, "as_scalar"
-        ):  # for backwards compatibility, use `as_scalar` unconditionally once minimum gt4py is >= 1.0.4
-            elev = int32(elev.as_scalar())
+        elev = int32(k[-3].as_scalar())
         elevp1 = elev + int32(1)
 
         return dict(

--- a/spack/gt4py-stable/spack.yaml
+++ b/spack/gt4py-stable/spack.yaml
@@ -1,10 +1,10 @@
 spack:
     specs:
-        - py-icon4py@main%gcc@9.3.0 ^py-gt4py@1.0.1.7%gcc@9.3.0
+        - py-icon4py@main%gcc@9.3.0 ^py-gt4py@1.0.3.1%gcc@9.3.0
     view: false
     concretizer:
         unify: true
     develop:
         py-icon4py:
-            spec: py-icon4py@main%gcc@9.3.0 ^py-gt4py@1.0.1.7%gcc@9.3.0
+            spec: py-icon4py@main%gcc@9.3.0 ^py-gt4py@1.0.3.1%gcc@9.3.0
             path: ../../


### PR DESCRIPTION
The latest commit on gt4py introduces a syntax feature: if you slice a field with full indexing, the result is still a field, a 0d field specifically. In order to use it as a scalar, the DSL program has to call `.as_scalar()`. Before this gt4py commit, the result of slicing would have been a scalar.

This PR adopts the new gt4py syntax feature. In order to do this, we bump the version of gt4py Spack package in stable CI job to 1.0.3.1. 