### PR TITLE
[icon4pygen]: Print error message when codegen fails in tests

### DIFF
--- a/tools/tests/icon4pygen/test_codegen.py
+++ b/tools/tests/icon4pygen/test_codegen.py
@@ -137,10 +137,9 @@ def test_codegen(cli, stencil_module, stencil_name, flags) -> None:
     with cli.isolated_filesystem():
         cli_args = [module_path, BLOCK_SIZE, LEVELS_PER_THREAD, OUTPATH, *flags]
         result = cli.invoke(main, cli_args)
-        if not result.exit_code == 0:
-            assert (
-                result.exit_code == 0
-            ), f"Codegen failed with error:\n{''.join(traceback.format_exception(*result.exc_info))}"
+        assert (
+            result.exit_code == 0
+        ), f"Codegen failed with error:\n{''.join(traceback.format_exception(*result.exc_info))}"
         check_code_was_generated(stencil_name)
 
 


### PR DESCRIPTION
When code generation fails we previously just printed the processes exit code in the tests. This PR forwards the exception for easier debugging.