### PR TITLE
update PAST node access pattern from Program instance

### DIFF
--- a/tools/src/icon4pytools/py2fgen/parsing.py
+++ b/tools/src/icon4pytools/py2fgen/parsing.py
@@ -95,7 +95,7 @@ def _get_gt4py_func_params(func: Program, type_hints: dict[str, str]) -> List[Fu
             dimensions=parse_type_spec(p.type)[0],
             py_type_hint=type_hints[p.id],
         )
-        for p in func.past_node.params
+        for p in func.past_stage.past_node.params
     ]
 
 


### PR DESCRIPTION
GT4Py is introducing some changes in https://github.com/GridTools/gt4py/pull/1500 which means the lowered PAST node is accessed differently from a `Program` instance. This PR updates the access pattern in Icon4Py.

Note that CI will only pass, once this has been merged in the GT4Py version used in there.