### PR TITLE
Remove lhdiff_rcf from solve_nonhydro config

### DIFF
--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -146,7 +146,6 @@ class DiffusionConfig:
         zdiffu_t: bool = True,
         thslp_zdiffu: float = 0.025,
         thhgtd_zdiffu: float = 200.0,
-        hdiff_rcf: bool = True,
         velocity_boundary_diffusion_denom: float = 200.0,
         temperature_boundary_diffusion_denom: float = 135.0,
         max_nudging_coeff: float = 0.02,
@@ -214,10 +213,6 @@ class DiffusionConfig:
         #       (constant!) one or the dynamical one. In the latter case it should be removed from
         #       DiffusionConfig and init()
         self.ndyn_substeps: int = n_substeps
-
-        #: If True, compute horizontal diffusion only at the large time step
-        #: Called 'lhdiff_rcf' in mo_nonhydrostatic_nml.f90
-        self.lhdiff_rcf: bool = hdiff_rcf
 
         # namelist mo_gridref_nml.f90
 
@@ -442,8 +437,6 @@ class Diffusion:
         self.bdy_diff: float = 0.015 / (params.scaled_nudge_max_coeff + sys.float_info.epsilon)
         self.fac_bdydiff_v: float = (
             math.sqrt(config.substep_as_float) / config.velocity_boundary_diffusion_denominator
-            if config.lhdiff_rcf
-            else 1.0 / config.velocity_boundary_diffusion_denominator
         )
 
         self.smag_offset: float = 0.25 * params.K4 * config.substep_as_float
@@ -559,15 +552,13 @@ class Diffusion:
             smag_limit=self.smag_limit,
             smag_offset=self.smag_offset,
         )
-        if not self.config.lhdiff_rcf:
-            self._sync_cell_fields(prognostic_state)
 
     def _sync_cell_fields(self, prognostic_state):
         """
         Communicate theta_v, exner and w.
 
         communication only done in original code if the following condition applies:
-        IF ( .NOT. lhdiff_rcf .OR. linit .OR. (iforcing /= inwp .AND. iforcing /= iaes) ) THEN
+        IF ( linit .OR. (iforcing /= inwp .AND. iforcing /= iaes) ) THEN
         """
         log.debug("communication of prognostic cell fields: theta, w, exner - start")
         self._exchange.exchange_and_wait(

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro.py
@@ -1538,6 +1538,7 @@ class SolveNonhydro:
             apply_2nd_order_divergence_damping(
                 z_graddiv_vn=z_fields.z_graddiv_vn,
                 vn=prognostic_state[nnew].vn,
+                scal_divdamp_o2=scal_divdamp_o2,
                 horizontal_start=start_edge_nudging_plus1,
                 horizontal_end=end_edge_local,
                 vertical_start=0,

--- a/tools/src/icon4pytools/py2fgen/wrappers/diffusion.py
+++ b/tools/src/icon4pytools/py2fgen/wrappers/diffusion.py
@@ -81,7 +81,6 @@ def diffusion_init(
     itype_sher: int,
     itype_vn_diffu: int,
     itype_t_diffu: int,
-    lhdiff_rcf: bool,
     lhdiff_w: bool,
     lhdiff_temp: bool,
     l_limited_area: bool,
@@ -192,7 +191,6 @@ def diffusion_init(
         smagorinski_scaling_factor=hdiff_smag_fac,
         n_substeps=n_dyn_substeps,
         zdiffu_t=l_zdiffu_t,
-        hdiff_rcf=lhdiff_rcf,
         velocity_boundary_diffusion_denom=denom_diffu_v,
         max_nudging_coeff=nudge_max_coeff,
     )


### PR DESCRIPTION
I remove the option `lhdiff_rcf` from `solve_nonhydro` and `diffusion` config because diffusion should only be applied at the full time step, and thus it is redundant after discussion with Anurag. 