### PR TITLE
Clean up SimpleGridData e2c2v field #408

### DIFF
--- a/tools/tests/py2fgen/test_cli.py
+++ b/tools/tests/py2fgen/test_cli.py
@@ -80,10 +80,7 @@ def run_fortran_executable(function: str):
     return subprocess.run([f"./{function}"], capture_output=True, text=True, check=True)
 
 
-# All tests of this module will be parametrized based on "backend"
-pytestmark = pytest.mark.parametrize("backend", ("CPU", "ROUNDTRIP"))
-
-
+@pytest.mark.parametrize("backend", ("CPU", "ROUNDTRIP"))
 def test_py2fgen_compilation_and_execution_square(
     cli_runner, backend, samples_path, wrapper_module
 ):
@@ -97,6 +94,7 @@ def test_py2fgen_compilation_and_execution_square(
     )
 
 
+@pytest.mark.parametrize("backend", ("CPU", "ROUNDTRIP"))
 def test_py2fgen_compilation_and_execution_square_from_function(
     cli_runner, backend, samples_path, wrapper_module
 ):
@@ -111,6 +109,7 @@ def test_py2fgen_compilation_and_execution_square_from_function(
     )
 
 
+@pytest.mark.parametrize("backend", ("CPU", "ROUNDTRIP"))
 def test_py2fgen_compilation_and_execution_multi_return(
     cli_runner, backend, samples_path, wrapper_module
 ):


### PR DESCRIPTION
- `e2c2v_table` in `SimpleGridData` had an error for edge `#26` based on the torus representation in https://github.com/c2sm/icon4py/blob/main/model/common/src/icon4py/model/common/grid/simple.py#L56
- `diamond_table` was a duplicate of `e2c2v_table` without the issue so I've replaced the data of `e2c2v_table` with the data of `diamond_table` and removed `diamond_table`
```
- Duplicate of #408 to enable CI