### PR TITLE
lifting mypy version to the minimal version that works

### DIFF
--- a/base-requirements-dev.txt
+++ b/base-requirements-dev.txt
@@ -5,7 +5,7 @@ git+https://github.com/GridTools/serialbox#egg=serialbox&subdirectory=src/serial
 # PyPI
 bump2version>=1.0.1
 coverage[toml]>=5.0
-mypy>=0.942
+mypy>=1.7.0
 pre-commit~=2.15
 pytest>=6.1
 pytest-benchmark>=4.0.0


### PR DESCRIPTION
(FIX) lifting minimal required `mypy` version to >=1.7 