### PR TITLE
Raise error in case connectivity matrices of GridManager are not int32

### DIFF
--- a/model/common/src/icon4py/model/common/grid/base.py
+++ b/model/common/src/icon4py/model/common/grid/base.py
@@ -19,6 +19,7 @@ from typing import Callable, Dict
 
 import numpy as np
 from gt4py.next.common import Dimension
+from gt4py.next.ffront.fbuiltins import int32
 from gt4py.next.iterator.embedded import NeighborTableOffsetProvider
 
 from icon4py.model.common.dimension import CellDim, EdgeDim, KDim, VertexDim
@@ -111,7 +112,7 @@ class BaseGrid(ABC):
 
     @builder
     def with_connectivities(self, connectivity: Dict[Dimension, np.ndarray]):
-        self.connectivities.update({d: k.astype(np.int32) for d, k in connectivity.items()})
+        self.connectivities.update({d: k.astype(int32) for d, k in connectivity.items()})
         self.size.update({d: t.shape[1] for d, t in connectivity.items()})
 
     @builder
@@ -129,7 +130,7 @@ class BaseGrid(ABC):
         if dim not in self.connectivities:
             raise MissingConnectivity()
         assert (
-            self.connectivities[dim].dtype == np.int32
+            self.connectivities[dim].dtype == int32
         ), 'Neighbor table\'s "{}" data type must be int32. Instead it\'s "{}"'.format(
             dim, self.connectivities[dim].dtype
         )

--- a/model/common/src/icon4py/model/common/grid/grid_manager.py
+++ b/model/common/src/icon4py/model/common/grid/grid_manager.py
@@ -18,6 +18,7 @@ from uuid import UUID
 
 import numpy as np
 from gt4py.next.common import Dimension, DimensionKind
+from gt4py.next.ffront.fbuiltins import int32
 
 
 try:
@@ -185,7 +186,7 @@ class GridFile:
     def dimension(self, name: GridFileName) -> int:
         return self._dataset.dimensions[name].size
 
-    def int_field(self, name: GridFileName, transpose=True, dtype=np.int32) -> np.ndarray:
+    def int_field(self, name: GridFileName, transpose=True, dtype=int32) -> np.ndarray:
         try:
             nc_variable = self._dataset.variables[name]
 
@@ -208,7 +209,7 @@ class IndexTransformation:
         self,
         array: np.ndarray,
     ):
-        return np.zeros(array.shape, dtype=np.int32)
+        return np.zeros(array.shape, dtype=int32)
 
 
 class ToGt4PyTransformation(IndexTransformation):
@@ -219,7 +220,7 @@ class ToGt4PyTransformation(IndexTransformation):
         Fortran indices are 1-based, hence the offset is -1 for 0-based ness of python except for
         INVALID values which are marked with -1 in the grid file and are kept such.
         """
-        return np.asarray(np.where(array == GridFile.INVALID_INDEX, 0, -1), dtype=np.int32)
+        return np.asarray(np.where(array == GridFile.INVALID_INDEX, 0, -1), dtype=int32)
 
 
 class GridManager:
@@ -278,13 +279,13 @@ class GridManager:
                 reader,
                 GridFile.GridRefinementName.START_INDEX_EDGES,
                 transpose=False,
-                dtype=np.int32,
+                dtype=int32,
             )[_CHILD_DOM],
             VertexDim: self._get_index_field(
                 reader,
                 GridFile.GridRefinementName.START_INDEX_VERTICES,
                 transpose=False,
-                dtype=np.int32,
+                dtype=int32,
             )[_CHILD_DOM],
         }
         end_indices = {
@@ -293,21 +294,21 @@ class GridManager:
                 GridFile.GridRefinementName.END_INDEX_CELLS,
                 transpose=False,
                 apply_offset=False,
-                dtype=np.int32,
+                dtype=int32,
             )[_CHILD_DOM],
             EdgeDim: self._get_index_field(
                 reader,
                 GridFile.GridRefinementName.END_INDEX_EDGES,
                 transpose=False,
                 apply_offset=False,
-                dtype=np.int32,
+                dtype=int32,
             )[_CHILD_DOM],
             VertexDim: self._get_index_field(
                 reader,
                 GridFile.GridRefinementName.END_INDEX_VERTICES,
                 transpose=False,
                 apply_offset=False,
-                dtype=np.int32,
+                dtype=int32,
             )[_CHILD_DOM],
         }
 
@@ -351,7 +352,7 @@ class GridManager:
         field: GridFileName,
         transpose=True,
         apply_offset=True,
-        dtype=np.int32,
+        dtype=int32,
     ):
         field = reader.int_field(field, transpose=transpose, dtype=dtype)
         if apply_offset:
@@ -507,7 +508,7 @@ class GridManager:
         flattened = expanded.reshape(sh[0], sh[1] * sh[2])
 
         diamond_sides = 4
-        e2c2e = GridFile.INVALID_INDEX * np.ones((sh[0], diamond_sides), dtype=np.int32)
+        e2c2e = GridFile.INVALID_INDEX * np.ones((sh[0], diamond_sides), dtype=int32)
         for i in range(sh[0]):
             var = flattened[i, (~np.in1d(flattened[i, :], np.asarray([i, GridFile.INVALID_INDEX])))]
             e2c2e[i, : var.shape[0]] = var
@@ -556,7 +557,7 @@ def _patch_with_dummy_lastline(ar):
     """
     patched_ar = np.append(
         ar,
-        GridFile.INVALID_INDEX * np.ones((1, ar.shape[1]), dtype=np.int32),
+        GridFile.INVALID_INDEX * np.ones((1, ar.shape[1]), dtype=int32),
         axis=0,
     )
     return patched_ar

--- a/model/common/src/icon4py/model/common/grid/simple.py
+++ b/model/common/src/icon4py/model/common/grid/simple.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 
 import numpy as np
 from gt4py.next import Dimension
+from gt4py.next.ffront.fbuiltins import int32
 
 from icon4py.model.common.dimension import (
     C2E2C2E2CDim,
@@ -86,7 +87,7 @@ class SimpleGridData:
             [7, 1, 2],
             [8, 2, 0],
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     e2c2v_table = np.asarray(
@@ -119,7 +120,7 @@ class SimpleGridData:
             [8, 0, 6, 2],  # 25
             [8, 2, 7, 0],  # 26
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     e2c_table = np.asarray(
@@ -152,7 +153,7 @@ class SimpleGridData:
             [14, 17],
             [13, 17],
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     e2v_table = np.asarray(
@@ -185,7 +186,7 @@ class SimpleGridData:
             [8, 0],
             [8, 2],
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     e2c2e_table = np.asarray(
@@ -218,7 +219,7 @@ class SimpleGridData:
             [24, 20, 26, 6],
             [25, 6, 21, 22],
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     e2c2eO_table = np.asarray(
@@ -251,7 +252,7 @@ class SimpleGridData:
             [24, 25, 20, 26, 6],
             [25, 26, 6, 21, 22],
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     c2e_table = np.asarray(
@@ -275,7 +276,7 @@ class SimpleGridData:
             [22, 23, 3],  # cell 16
             [25, 26, 6],  # cell 17
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     v2c_table = np.asarray(
@@ -290,7 +291,7 @@ class SimpleGridData:
             [12, 16, 13, 10, 6, 9],
             [13, 17, 14, 11, 7, 10],
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     v2e_table = np.asarray(
@@ -305,7 +306,7 @@ class SimpleGridData:
             [21, 22, 23, 18, 10, 14],
             [24, 25, 26, 21, 13, 17],
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     c2e2cO_table = np.asarray(
@@ -329,7 +330,7 @@ class SimpleGridData:
             [13, 1, 12, 16],
             [14, 2, 13, 17],
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     c2e2c_table = np.asarray(
@@ -353,7 +354,7 @@ class SimpleGridData:
             [13, 1, 12],
             [14, 2, 13],
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     c2e2c2e_table = np.asarray(
@@ -377,7 +378,7 @@ class SimpleGridData:
             [21, 22, 26, 18, 19, 23, 3, 4, 8],
             [24, 25, 20, 21, 22, 26, 6, 7, 2],  # 17c
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
     c2e2c2e2c_table = np.asarray(
@@ -401,7 +402,7 @@ class SimpleGridData:
             [13, 1, 12, 9, 15, 10, 17, 4, 5],
             [14, 2, 13, 10, 16, 5, 3, 11, 15],
         ],
-        dtype=np.int32,
+        dtype=int32,
     )
 
 

--- a/model/common/src/icon4py/model/common/grid/utils.py
+++ b/model/common/src/icon4py/model/common/grid/utils.py
@@ -13,6 +13,7 @@
 
 import numpy as np
 from gt4py.next import Dimension, NeighborTableOffsetProvider
+from gt4py.next.ffront.fbuiltins import int32
 
 from icon4py.model.common.settings import xp
 
@@ -23,9 +24,9 @@ def neighbortable_offset_provider_for_1d_sparse_fields(
     neighbor_axis: Dimension,
     has_skip_values: bool,
 ):
-    table = xp.asarray(np.arange(old_shape[0] * old_shape[1], dtype=np.int32).reshape(old_shape))
+    table = xp.asarray(np.arange(old_shape[0] * old_shape[1], dtype=int32).reshape(old_shape))
     assert (
-        table.dtype == xp.int32
+        table.dtype == int32
     ), 'Neighbor table\'s ("{}" to "{}") data type for 1d sparse fields must be int32. Instead it\'s "{}"'.format(
         origin_axis, neighbor_axis, table.dtype
     )


### PR DESCRIPTION
- Motivation for this PR is to avoid unnecessary memory traffic when loading the neighbor tables to memory since more than 32 bits are not necessary to represent their indexes
- Throw `AssertionError` in `_get_offset_provider` and `neighbortable_offset_provider_for_1d_sparse_fields` if the neighbor tables' data type is not `int32`
- Edit `SimpleGrid` to use `int32` in it's neighbor table data
- Generate `int32` arrays in necessary places
- Fix return type of `diamond_table`

Replaces #474 to allow the `pre-commit-icon4py-model` CI to launch.