### PR TITLE
fix gt4py to version before type inference change

### DIFF
--- a/base-requirements-dev.txt
+++ b/base-requirements-dev.txt
@@ -1,5 +1,5 @@
 # VCS
--e git+https://github.com/GridTools/gt4py.git@main#egg=gt4py
+-e git+https://github.com/GridTools/gt4py.git@b8f7f7273e3a4b4770f163f4c244e4c3a2065dbe#egg=gt4py
 git+https://github.com/GridTools/serialbox#egg=serialbox&subdirectory=src/serialbox-python
 
 # PyPI

--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -1,3 +1,3 @@
 # VCS
-gt4py @ git+https://github.com/GridTools/gt4py.git@main
+gt4py @ git+https://github.com/GridTools/gt4py.git@b8f7f7273e3a4b4770f163f4c244e4c3a2065dbe
 


### PR DESCRIPTION
(FIX) fix gt4py version to https://github.com/GridTools/gt4py/commit/b8f7f7273e3a4b4770f163f4c244e4c3a2065dbe

to avoid problems from type inference.


