### PR TITLE
Revert "(fix) workaround: restrict numpy to version below 2.0"

### DIFF
--- a/base-requirements-dev.txt
+++ b/base-requirements-dev.txt
@@ -3,7 +3,6 @@
 git+https://github.com/GridTools/serialbox#egg=serialbox&subdirectory=src/serialbox-python
 
 # PyPI
-numpy<2.0.0
 bump2version>=1.0.1
 coverage[toml]>=5.0
 mypy>=1.7.0

--- a/model/atmosphere/advection/tests/conftest.py
+++ b/model/atmosphere/advection/tests/conftest.py
@@ -10,7 +10,6 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-import pytest
 
 from icon4py.model.common.test_utils.grid_utils import (  # noqa : F401  # fixtures from test_utils
     grid,
@@ -18,12 +17,3 @@ from icon4py.model.common.test_utils.grid_utils import (  # noqa : F401  # fixtu
 from icon4py.model.common.test_utils.helpers import (  # noqa : F401  # fixtures from test_utils
     backend,
 )
-
-
-def pytest_collection_modifyitems(config, items):
-    if config.getoption("--backend") == "gtfn_gpu":
-        skip_marker = pytest.mark.skip(
-            reason="FIXME: advection tests need to be fixed for GPU. Skipping"
-        )
-        for item in items:
-            item.add_marker(skip_marker)


### PR DESCRIPTION
Reverts C2SM/icon4py#483