### PR TITLE
add index abstract for the vertical grid

### DIFF
--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -328,7 +328,7 @@ class Diffusion:
         self.grid: Optional[icon_grid.IconGrid] = None
         self.config: Optional[DiffusionConfig] = None
         self.params: Optional[DiffusionParams] = None
-        self.vertical_params: Optional[v_grid.VerticalGrid] = None
+        self.vertical_grid: Optional[v_grid.VerticalGrid] = None
         self.interpolation_state: diffusion_states.DiffusionInterpolationState = None
         self.metric_state: diffusion_states.DiffusionMetricState = None
         self.diff_multfac_w: Optional[float] = None
@@ -346,7 +346,7 @@ class Diffusion:
         grid: icon_grid.IconGrid,
         config: DiffusionConfig,
         params: DiffusionParams,
-        vertical_params: v_grid.VerticalGrid,
+        vertical_grid: v_grid.VerticalGrid,
         metric_state: diffusion_states.DiffusionMetricState,
         interpolation_state: diffusion_states.DiffusionInterpolationState,
         edge_params: h_grid.EdgeParams,
@@ -361,7 +361,7 @@ class Diffusion:
             grid:
             config:
             params:
-            vertical_params:
+            vertical_grid:
             metric_state:
             interpolation_state:
             edge_params:
@@ -370,7 +370,7 @@ class Diffusion:
         self.config: DiffusionConfig = config
         self.params: DiffusionParams = params
         self.grid = grid
-        self.vertical_params = vertical_params
+        self.vertical_grid = vertical_grid
         self.metric_state: diffusion_states.DiffusionMetricState = metric_state
         self.interpolation_state: diffusion_states.DiffusionInterpolationState = interpolation_state
         self.edge_params = edge_params
@@ -402,7 +402,7 @@ class Diffusion:
             config.substep_as_float,
             *params.smagorinski_factor,
             *params.smagorinski_height,
-            self.vertical_params.interface_physical_height,
+            self.vertical_grid.interface_physical_height,
             self.diff_multfac_vn,
             self.smag_limit,
             self.enh_smag_fac,
@@ -413,10 +413,8 @@ class Diffusion:
         self.diff_multfac_n2w = diffusion_utils.init_nabla2_factor_in_upper_damping_zone(
             k_size=self.grid.num_levels,
             nshift=0,
-            physical_heights=self.vertical_params.interface_physical_height,
-            nrdmax=self.vertical_params.index(
-                v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.DAMPING)
-            ),
+            physical_heights=self.vertical_grid.interface_physical_height,
+            nrdmax=self.vertical_grid.end_index_of_damping_layer,
         )
         self._horizontal_start_index_w_diffusion = _get_start_index_for_w_diffusion()
         self._initialized = True
@@ -734,10 +732,7 @@ class Diffusion:
             k=self.vertical_index,
             cell=self.horizontal_cell_index,
             nrdmax=gtx.int32(
-                self.vertical_params.index(
-                    v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.DAMPING)
-                )
-                + 1
+                self.vertical_grid.end_index_of_damping_layer + 1
             ),  # +1 since Fortran includes boundaries
             interior_idx=gtx.int32(cell_start_interior),
             halo_idx=gtx.int32(cell_end_local),

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -328,7 +328,7 @@ class Diffusion:
         self.grid: Optional[icon_grid.IconGrid] = None
         self.config: Optional[DiffusionConfig] = None
         self.params: Optional[DiffusionParams] = None
-        self.vertical_params: Optional[v_grid.VerticalGridParams] = None
+        self.vertical_params: Optional[v_grid.VerticalGrid] = None
         self.interpolation_state: diffusion_states.DiffusionInterpolationState = None
         self.metric_state: diffusion_states.DiffusionMetricState = None
         self.diff_multfac_w: Optional[float] = None
@@ -346,7 +346,7 @@ class Diffusion:
         grid: icon_grid.IconGrid,
         config: DiffusionConfig,
         params: DiffusionParams,
-        vertical_params: v_grid.VerticalGridParams,
+        vertical_params: v_grid.VerticalGrid,
         metric_state: diffusion_states.DiffusionMetricState,
         interpolation_state: diffusion_states.DiffusionInterpolationState,
         edge_params: h_grid.EdgeParams,
@@ -402,7 +402,7 @@ class Diffusion:
             config.substep_as_float,
             *params.smagorinski_factor,
             *params.smagorinski_height,
-            self.vertical_params.inteface_physical_height,
+            self.vertical_params.interface_physical_height,
             self.diff_multfac_vn,
             self.smag_limit,
             self.enh_smag_fac,
@@ -413,8 +413,10 @@ class Diffusion:
         self.diff_multfac_n2w = diffusion_utils.init_nabla2_factor_in_upper_damping_zone(
             k_size=self.grid.num_levels,
             nshift=0,
-            physical_heights=self.vertical_params.inteface_physical_height,
-            nrdmax=self.vertical_params.end_index_of_damping_layer,
+            physical_heights=self.vertical_params.interface_physical_height,
+            nrdmax=self.vertical_params.index(
+                v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.DAMPING)
+            ),
         )
         self._horizontal_start_index_w_diffusion = _get_start_index_for_w_diffusion()
         self._initialized = True
@@ -732,7 +734,10 @@ class Diffusion:
             k=self.vertical_index,
             cell=self.horizontal_cell_index,
             nrdmax=gtx.int32(
-                self.vertical_params.end_index_of_damping_layer + 1
+                self.vertical_params.index(
+                    v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.DAMPING)
+                )
+                + 1
             ),  # +1 since Fortran includes boundaries
             interior_idx=gtx.int32(cell_start_interior),
             halo_idx=gtx.int32(cell_end_local),

--- a/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/conftest.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/conftest.py
@@ -1,0 +1,11 @@
+# ICON4Py - ICON inspired code in Python and GT4Py
+#
+# Copyright (c) 2022-2024, ETH Zurich and MeteoSwiss
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from icon4py.model.common.test_utils.parallel_helpers import (
+    processor_props,  # noqa: F401  # import fixtures from test_utils package
+)

--- a/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/test_parallel_diffusion.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/test_parallel_diffusion.py
@@ -8,27 +8,17 @@
 
 import pytest
 
-from icon4py.model.atmosphere.diffusion.diffusion import Diffusion, DiffusionParams
+import icon4py.model.atmosphere.diffusion.diffusion as diffu
 from icon4py.model.common import dimension as dims
 from icon4py.model.common.decomposition import definitions
-from icon4py.model.common.grid.vertical import VerticalGrid, VerticalGridConfig
-from icon4py.model.common.test_utils.datatest_utils import REGIONAL_EXPERIMENT
-from icon4py.model.common.test_utils.parallel_helpers import (  # noqa: F401  # import fixtures from test_utils package
-    check_comm_size,
-    processor_props,
-)
+from icon4py.model.common.grid import vertical as v_grid
+from icon4py.model.common.test_utils import datatest_utils, parallel_helpers
 
-from ..utils import (
-    construct_config,
-    construct_diagnostics,
-    construct_interpolation_state,
-    construct_metric_state,
-    verify_diffusion_fields,
-)
+from .. import utils
 
 
 @pytest.mark.mpi
-@pytest.mark.parametrize("experiment", [REGIONAL_EXPERIMENT])
+@pytest.mark.parametrize("experiment", [datatest_utils.REGIONAL_EXPERIMENT])
 @pytest.mark.parametrize("ndyn_substeps", [2])
 @pytest.mark.parametrize("linit", [True, False])
 def test_parallel_diffusion(
@@ -36,7 +26,7 @@ def test_parallel_diffusion(
     step_date_init,
     linit,
     ndyn_substeps,
-    processor_props,  # noqa: F811  # fixture
+    processor_props,  # fixture
     decomposition_info,
     icon_grid,
     diffusion_savepoint_init,
@@ -49,9 +39,9 @@ def test_parallel_diffusion(
     stretch_factor,
     damping_height,
 ):
-    check_comm_size(processor_props)
+    parallel_helpers.check_comm_size(processor_props)
     print(
-        f"rank={processor_props.rank}/{processor_props.comm_size}: inializing diffusion for experiment '{REGIONAL_EXPERIMENT}'"
+        f"rank={processor_props.rank}/{processor_props.comm_size}: inializing diffusion for experiment '{datatest_utils.REGIONAL_EXPERIMENT}'"
     )
     print(
         f"rank={processor_props.rank}/{processor_props.comm_size}: decomposition info : klevels = {decomposition_info.klevels}, "
@@ -66,39 +56,41 @@ def test_parallel_diffusion(
     print(
         f"rank={processor_props.rank}/{processor_props.comm_size}: using local grid with {icon_grid.num_cells} Cells, {icon_grid.num_edges} Edges, {icon_grid.num_vertices} Vertices"
     )
-    metric_state = construct_metric_state(metrics_savepoint)
+    metric_state = utils.construct_metric_state(metrics_savepoint)
     cell_geometry = grid_savepoint.construct_cell_geometry()
     edge_geometry = grid_savepoint.construct_edge_geometry()
-    interpolation_state = construct_interpolation_state(interpolation_savepoint)
-    vertical_config = VerticalGridConfig(
+    interpolation_state = utils.construct_interpolation_state(interpolation_savepoint)
+    vertical_config = v_grid.VerticalGridConfig(
         icon_grid.num_levels,
         lowest_layer_thickness=lowest_layer_thickness,
         model_top_height=model_top_height,
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    config = construct_config(experiment, ndyn_substeps=ndyn_substeps)
-    diffusion_params = DiffusionParams(config)
+    config = utils.construct_config(experiment, ndyn_substeps=ndyn_substeps)
+    diffusion_params = diffu.DiffusionParams(config)
     dtime = diffusion_savepoint_init.get_metadata("dtime").get("dtime")
     print(
         f"rank={processor_props.rank}/{processor_props.comm_size}:  setup: using {processor_props.comm_name} with {processor_props.comm_size} nodes"
     )
     exchange = definitions.create_exchange(processor_props, decomposition_info)
 
-    diffusion = Diffusion(exchange)
+    diffusion = diffu.Diffusion(exchange)
 
     diffusion.init(
         grid=icon_grid,
         config=config,
         params=diffusion_params,
-        vertical_grid=VerticalGrid(vertical_config, grid_savepoint.vct_a(), grid_savepoint.vct_b()),
+        vertical_grid=v_grid.VerticalGrid(
+            vertical_config, grid_savepoint.vct_a(), grid_savepoint.vct_b()
+        ),
         metric_state=metric_state,
         interpolation_state=interpolation_state,
         edge_params=edge_geometry,
         cell_params=cell_geometry,
     )
     print(f"rank={processor_props.rank}/{processor_props.comm_size}: diffusion initialized ")
-    diagnostic_state = construct_diagnostics(diffusion_savepoint_init)
+    diagnostic_state = utils.construct_diagnostics(diffusion_savepoint_init)
     prognostic_state = diffusion_savepoint_init.construct_prognostics()
     if linit:
         diffusion.initial_run(
@@ -114,7 +106,7 @@ def test_parallel_diffusion(
         )
     print(f"rank={processor_props.rank}/{processor_props.comm_size}: diffusion run ")
 
-    verify_diffusion_fields(
+    utils.verify_diffusion_fields(
         config=config,
         diagnostic_state=diagnostic_state,
         prognostic_state=prognostic_state,

--- a/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/test_parallel_diffusion.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/test_parallel_diffusion.py
@@ -91,9 +91,7 @@ def test_parallel_diffusion(
         grid=icon_grid,
         config=config,
         params=diffusion_params,
-        vertical_params=VerticalGrid(
-            vertical_config, grid_savepoint.vct_a(), grid_savepoint.vct_b()
-        ),
+        vertical_grid=VerticalGrid(vertical_config, grid_savepoint.vct_a(), grid_savepoint.vct_b()),
         metric_state=metric_state,
         interpolation_state=interpolation_state,
         edge_params=edge_geometry,

--- a/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/test_parallel_diffusion.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/test_parallel_diffusion.py
@@ -8,7 +8,7 @@
 
 import pytest
 
-import icon4py.model.atmosphere.diffusion.diffusion as diffu
+from icon4py.model.atmosphere.diffusion import diffusion as diffusion_
 from icon4py.model.common import dimension as dims
 from icon4py.model.common.decomposition import definitions
 from icon4py.model.common.grid import vertical as v_grid
@@ -68,14 +68,14 @@ def test_parallel_diffusion(
         rayleigh_damping_height=damping_height,
     )
     config = utils.construct_config(experiment, ndyn_substeps=ndyn_substeps)
-    diffusion_params = diffu.DiffusionParams(config)
+    diffusion_params = diffusion_.DiffusionParams(config)
     dtime = diffusion_savepoint_init.get_metadata("dtime").get("dtime")
     print(
         f"rank={processor_props.rank}/{processor_props.comm_size}:  setup: using {processor_props.comm_name} with {processor_props.comm_size} nodes"
     )
     exchange = definitions.create_exchange(processor_props, decomposition_info)
 
-    diffusion = diffu.Diffusion(exchange)
+    diffusion = diffusion_.Diffusion(exchange)
 
     diffusion.init(
         grid=icon_grid,

--- a/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/test_parallel_diffusion.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/test_parallel_diffusion.py
@@ -11,7 +11,7 @@ import pytest
 from icon4py.model.atmosphere.diffusion.diffusion import Diffusion, DiffusionParams
 from icon4py.model.common import dimension as dims
 from icon4py.model.common.decomposition import definitions
-from icon4py.model.common.grid.vertical import VerticalGridConfig, VerticalGridParams
+from icon4py.model.common.grid.vertical import VerticalGrid, VerticalGridConfig
 from icon4py.model.common.test_utils.datatest_utils import REGIONAL_EXPERIMENT
 from icon4py.model.common.test_utils.parallel_helpers import (  # noqa: F401  # import fixtures from test_utils package
     check_comm_size,
@@ -91,7 +91,7 @@ def test_parallel_diffusion(
         grid=icon_grid,
         config=config,
         params=diffusion_params,
-        vertical_params=VerticalGridParams(
+        vertical_params=VerticalGrid(
             vertical_config, grid_savepoint.vct_a(), grid_savepoint.vct_b()
         ),
         metric_state=metric_state,

--- a/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion.py
@@ -92,9 +92,7 @@ def test_smagorinski_factor_diffusion_type_5(experiment):
     assert np.all(params.smagorinski_factor >= np.zeros(len(params.smagorinski_factor)))
 
 
-def create_vertical_grid(
-    vertical_config: v_grid.VerticalGridConfig, grid_savepoint: sb.IconGridSavepoint
-):
+def vertical_grid(vertical_config: v_grid.VerticalGridConfig, grid_savepoint: sb.IconGridSavepoint):
     return v_grid.VerticalGrid(
         config=vertical_config,
         vct_a=grid_savepoint.vct_a(),
@@ -128,7 +126,7 @@ def test_diffusion_init(
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = create_vertical_grid(vertical_config, grid_savepoint)
+    vertical_params = vertical_grid(vertical_config, grid_savepoint)
 
     meta = diffusion_savepoint_init.get_metadata("linit", "date")
 
@@ -253,7 +251,7 @@ def test_verify_diffusion_init_against_savepoint(
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = create_vertical_grid(vertical_config, grid_savepoint)
+    vertical_params = vertical_grid(vertical_config, grid_savepoint)
     interpolation_state = construct_interpolation_state(interpolation_savepoint)
     metric_state = construct_metric_state(metrics_savepoint)
     edge_params = grid_savepoint.construct_edge_geometry()
@@ -311,7 +309,7 @@ def test_run_diffusion_single_step(
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = create_vertical_grid(vertical_config, grid_savepoint)
+    vertical_params = vertical_grid(vertical_config, grid_savepoint)
     config = construct_config(experiment, ndyn_substeps)
     additional_parameters = diffusion.DiffusionParams(config)
 
@@ -368,7 +366,7 @@ def test_run_diffusion_initial_step(
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = create_vertical_grid(vertical_config, grid_savepoint)
+    vertical_params = vertical_grid(vertical_config, grid_savepoint)
     config = construct_config(experiment, ndyn_substeps=2)
     additional_parameters = diffusion.DiffusionParams(config)
 

--- a/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion.py
@@ -92,14 +92,14 @@ def test_smagorinski_factor_diffusion_type_5(experiment):
     assert np.all(params.smagorinski_factor >= np.zeros(len(params.smagorinski_factor)))
 
 
-def create_vertical_params(vertical_config, grid_savepoint):
-    param = v_grid.VerticalGridParams(
-        vertical_config=vertical_config,
+def create_vertical_params(vertical_config:v_grid.VerticalGridConfig, grid_savepoint:sb.IconGridSavepoint):
+    return v_grid.VerticalGrid(
+        config=vertical_config,
         vct_a=grid_savepoint.vct_a(),
         vct_b=grid_savepoint.vct_b(),
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp(),
     )
-    return v_grid.VerticalGrid(vertical_config, param)
+   
 
 
 @pytest.mark.datatest

--- a/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion.py
@@ -93,12 +93,13 @@ def test_smagorinski_factor_diffusion_type_5(experiment):
 
 
 def create_vertical_params(vertical_config, grid_savepoint):
-    return v_grid.VerticalGridParams(
+    param = v_grid.VerticalGridParams(
         vertical_config=vertical_config,
         vct_a=grid_savepoint.vct_a(),
         vct_b=grid_savepoint.vct_b(),
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp(),
     )
+    return v_grid.VerticalGrid(vertical_config, param)
 
 
 @pytest.mark.datatest

--- a/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion.py
@@ -92,14 +92,15 @@ def test_smagorinski_factor_diffusion_type_5(experiment):
     assert np.all(params.smagorinski_factor >= np.zeros(len(params.smagorinski_factor)))
 
 
-def create_vertical_params(vertical_config:v_grid.VerticalGridConfig, grid_savepoint:sb.IconGridSavepoint):
+def create_vertical_grid(
+    vertical_config: v_grid.VerticalGridConfig, grid_savepoint: sb.IconGridSavepoint
+):
     return v_grid.VerticalGrid(
         config=vertical_config,
         vct_a=grid_savepoint.vct_a(),
         vct_b=grid_savepoint.vct_b(),
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp(),
     )
-   
 
 
 @pytest.mark.datatest
@@ -127,7 +128,7 @@ def test_diffusion_init(
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = create_vertical_params(vertical_config, grid_savepoint)
+    vertical_params = create_vertical_grid(vertical_config, grid_savepoint)
 
     meta = diffusion_savepoint_init.get_metadata("linit", "date")
 
@@ -144,7 +145,7 @@ def test_diffusion_init(
         grid=icon_grid,
         config=config,
         params=additional_parameters,
-        vertical_params=vertical_params,
+        vertical_grid=vertical_params,
         metric_state=metric_state,
         interpolation_state=interpolation_state,
         edge_params=edge_params,
@@ -252,7 +253,7 @@ def test_verify_diffusion_init_against_savepoint(
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = create_vertical_params(vertical_config, grid_savepoint)
+    vertical_params = create_vertical_grid(vertical_config, grid_savepoint)
     interpolation_state = construct_interpolation_state(interpolation_savepoint)
     metric_state = construct_metric_state(metrics_savepoint)
     edge_params = grid_savepoint.construct_edge_geometry()
@@ -310,7 +311,7 @@ def test_run_diffusion_single_step(
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = create_vertical_params(vertical_config, grid_savepoint)
+    vertical_params = create_vertical_grid(vertical_config, grid_savepoint)
     config = construct_config(experiment, ndyn_substeps)
     additional_parameters = diffusion.DiffusionParams(config)
 
@@ -319,7 +320,7 @@ def test_run_diffusion_single_step(
         grid=icon_grid,
         config=config,
         params=additional_parameters,
-        vertical_params=vertical_params,
+        vertical_grid=vertical_params,
         metric_state=metric_state,
         interpolation_state=interpolation_state,
         edge_params=edge_geometry,
@@ -367,7 +368,7 @@ def test_run_diffusion_initial_step(
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = create_vertical_params(vertical_config, grid_savepoint)
+    vertical_params = create_vertical_grid(vertical_config, grid_savepoint)
     config = construct_config(experiment, ndyn_substeps=2)
     additional_parameters = diffusion.DiffusionParams(config)
 
@@ -376,7 +377,7 @@ def test_run_diffusion_initial_step(
         grid=icon_grid,
         config=config,
         params=additional_parameters,
-        vertical_params=vertical_params,
+        vertical_grid=vertical_params,
         metric_state=metric_state,
         interpolation_state=interpolation_state,
         edge_params=edge_geometry,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro.py
@@ -476,7 +476,7 @@ class SolveNonhydro:
             self.jk_start = 0
 
         smagorinsky.en_smag_fac_for_zero_nshift(
-            self.vertical_params.inteface_physical_height,
+            self.vertical_params.interface_physical_height,
             self.config.divdamp_fac,
             self.config.divdamp_fac2,
             self.config.divdamp_fac3,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro.py
@@ -419,7 +419,7 @@ class SolveNonhydro:
         self.params: Optional[NonHydrostaticParams] = None
         self.metric_state_nonhydro: Optional[solve_nh_states.MetricStateNonHydro] = None
         self.interpolation_state: Optional[solve_nh_states.InterpolationState] = None
-        self.vertical_params: Optional[v_grid.VerticalGridParams] = None
+        self.vertical_params: Optional[v_grid.VerticalGrid] = None
         self.edge_geometry: Optional[h_grid.EdgeParams] = None
         self.cell_params: Optional[h_grid.CellParams] = None
         self.velocity_advection: Optional[VelocityAdvection] = None
@@ -439,7 +439,7 @@ class SolveNonhydro:
         params: NonHydrostaticParams,
         metric_state_nonhydro: solve_nh_states.MetricStateNonHydro,
         interpolation_state: solve_nh_states.InterpolationState,
-        vertical_params: v_grid.VerticalGridParams,
+        vertical_params: v_grid.VerticalGrid,
         edge_geometry: h_grid.EdgeParams,
         cell_geometry: h_grid.CellParams,
         owner_mask: fa.CellField[bool],

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity/velocity_advection.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity/velocity_advection.py
@@ -54,7 +54,7 @@ class VelocityAdvection:
         grid: icon_grid.IconGrid,
         metric_state: solve_nh_states.MetricStateNonHydro,
         interpolation_state: solve_nh_states.InterpolationState,
-        vertical_params: v_grid.VerticalGridParams,
+        vertical_params: v_grid.VerticalGrid,
         edge_params: h_grid.EdgeParams,
         owner_mask: fa.CellField[bool],
     ):

--- a/model/atmosphere/dycore/tests/dycore_tests/conftest.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/conftest.py
@@ -27,6 +27,7 @@ from icon4py.model.common.test_utils.datatest_fixtures import (  # noqa F401
     jstep_init,
     linit,
     metrics_savepoint,
+    decomposition_info,
     ndyn_substeps,
     processor_props,
     ranked_data_path,

--- a/model/atmosphere/dycore/tests/dycore_tests/mpi_tests/conftest.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/mpi_tests/conftest.py
@@ -1,0 +1,11 @@
+# ICON4Py - ICON inspired code in Python and GT4Py
+#
+# Copyright (c) 2022-2024, ETH Zurich and MeteoSwiss
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from icon4py.model.common.test_utils.parallel_helpers import (
+    processor_props,  # noqa: F401  # import fixtures from test_utils package
+)

--- a/model/atmosphere/dycore/tests/dycore_tests/mpi_tests/test_parallel_solve_nonhydro.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/mpi_tests/test_parallel_solve_nonhydro.py
@@ -9,33 +9,14 @@
 import numpy as np
 import pytest
 
-from icon4py.model.atmosphere.dycore.nh_solve.solve_nonhydro import (
-    NonHydrostaticParams,
-    SolveNonhydro,
-)
-from icon4py.model.atmosphere.dycore.state_utils.states import (
-    DiagnosticStateNonHydro,
-    PrepAdvection,
-)
+from icon4py.model.atmosphere.dycore.nh_solve import solve_nonhydro as nh
+from icon4py.model.atmosphere.dycore.state_utils import states
 from icon4py.model.common import dimension as dims
 from icon4py.model.common.decomposition import definitions
-from icon4py.model.common.grid.horizontal import CellParams, EdgeParams
-from icon4py.model.common.grid.vertical import VerticalGrid, VerticalGridConfig
-from icon4py.model.common.test_utils.datatest_fixtures import (  # noqa : F401 fixture
-    decomposition_info,
-)
-from icon4py.model.common.test_utils.helpers import dallclose, zero_field
-from icon4py.model.common.test_utils.parallel_helpers import (  # noqa : F401 fixture
-    check_comm_size,
-    processor_props,
-)
+from icon4py.model.common.grid import horizontal as h_grid, vertical as v_grid
+from icon4py.model.common.test_utils import helpers, parallel_helpers
 
-from ..test_solve_nonhydro import create_prognostic_states
-from ..utils import (
-    construct_config,
-    construct_interpolation_state_for_nonhydro,
-    construct_nh_metric_state,
-)
+from .. import test_solve_nonhydro, utils
 
 
 @pytest.mark.datatest
@@ -65,10 +46,10 @@ def test_run_solve_nonhydro_single_step(
     interpolation_savepoint,
     savepoint_nonhydro_exit,
     savepoint_nonhydro_step_exit,
-    processor_props,  # noqa : F811 fixture
-    decomposition_info,  # noqa : F811 fixture
+    processor_props,  # : F811 fixture
+    decomposition_info,  # : F811 fixture
 ):
-    check_comm_size(processor_props)
+    parallel_helpers.check_comm_size(processor_props)
     print(
         f"rank={processor_props.rank}/{processor_props.comm_size}: inializing dycore for experiment 'mch_ch_r04_b09_dsl"
     )
@@ -92,18 +73,18 @@ def test_run_solve_nonhydro_single_step(
         f"rank={processor_props.rank}/{processor_props.comm_size}: number of halo cells {np.count_nonzero(np.invert(owned_cells))}"
     )
 
-    config = construct_config(experiment, ndyn_substeps=ndyn_substeps)
+    config = utils.construct_config(experiment, ndyn_substeps=ndyn_substeps)
     sp = savepoint_nonhydro_init
     sp_step_exit = savepoint_nonhydro_step_exit
-    nonhydro_params = NonHydrostaticParams(config)
-    vertical_config = VerticalGridConfig(
+    nonhydro_params = nh.NonHydrostaticParams(config)
+    vertical_config = v_grid.VerticalGridConfig(
         icon_grid.num_levels,
         lowest_layer_thickness=lowest_layer_thickness,
         model_top_height=model_top_height,
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = VerticalGrid(
+    vertical_params = v_grid.VerticalGrid(
         config=vertical_config,
         vct_a=grid_savepoint.vct_a(),
         vct_b=grid_savepoint.vct_b(),
@@ -113,11 +94,11 @@ def test_run_solve_nonhydro_single_step(
     dtime = sp_v.get_metadata("dtime").get("dtime")
     lprep_adv = sp_v.get_metadata("prep_adv").get("prep_adv")
     clean_mflx = sp_v.get_metadata("clean_mflx").get("clean_mflx")
-    prep_adv = PrepAdvection(
+    prep_adv = states.PrepAdvection(
         vn_traj=sp.vn_traj(),
         mass_flx_me=sp.mass_flx_me(),
         mass_flx_ic=sp.mass_flx_ic(),
-        vol_flx_ic=zero_field(icon_grid, dims.CellDim, dims.KDim),
+        vol_flx_ic=helpers.zero_field(icon_grid, dims.CellDim, dims.KDim),
     )
 
     nnow = 0
@@ -125,7 +106,7 @@ def test_run_solve_nonhydro_single_step(
     recompute = sp_v.get_metadata("recompute").get("recompute")
     linit = sp_v.get_metadata("linit").get("linit")
 
-    diagnostic_state_nh = DiagnosticStateNonHydro(
+    diagnostic_state_nh = states.DiagnosticStateNonHydro(
         theta_v_ic=sp.theta_v_ic(),
         exner_pr=sp.exner_pr(),
         rho_ic=sp.rho_ic(),
@@ -149,18 +130,18 @@ def test_run_solve_nonhydro_single_step(
         exner_dyn_incr=sp.exner_dyn_incr(),
     )
     initial_divdamp_fac = sp.divdamp_fac_o2()
-    interpolation_state = construct_interpolation_state_for_nonhydro(interpolation_savepoint)
-    metric_state_nonhydro = construct_nh_metric_state(metrics_savepoint, icon_grid.num_levels)
+    interpolation_state = utils.construct_interpolation_state_for_nonhydro(interpolation_savepoint)
+    metric_state_nonhydro = utils.construct_nh_metric_state(metrics_savepoint, icon_grid.num_levels)
 
-    cell_geometry: CellParams = grid_savepoint.construct_cell_geometry()
-    edge_geometry: EdgeParams = grid_savepoint.construct_edge_geometry()
+    cell_geometry: h_grid.CellParams = grid_savepoint.construct_cell_geometry()
+    edge_geometry: h_grid.EdgeParams = grid_savepoint.construct_edge_geometry()
 
-    prognostic_state_ls = create_prognostic_states(sp)
+    prognostic_state_ls = test_solve_nonhydro.create_prognostic_states(sp)
     prognostic_state_nnew = prognostic_state_ls[1]
 
     exchange = definitions.create_exchange(processor_props, decomposition_info)
 
-    solve_nonhydro = SolveNonhydro(exchange)
+    solve_nonhydro = nh.SolveNonhydro(exchange)
     solve_nonhydro.init(
         grid=icon_grid,
         config=config,
@@ -196,53 +177,53 @@ def test_run_solve_nonhydro_single_step(
 
     expected_theta_v = sp_step_exit.theta_v_new().asnumpy()
     calculated_theta_v = prognostic_state_nnew.theta_v.asnumpy()
-    assert dallclose(
+    assert helpers.dallclose(
         expected_theta_v,
         calculated_theta_v,
     )
     expected_exner = sp_step_exit.exner_new().asnumpy()
     calculated_exner = prognostic_state_nnew.exner.asnumpy()
-    assert dallclose(
+    assert helpers.dallclose(
         expected_exner,
         calculated_exner,
     )
-    assert dallclose(
+    assert helpers.dallclose(
         savepoint_nonhydro_exit.vn_new().asnumpy(),
         prognostic_state_nnew.vn.asnumpy(),
         rtol=1e-10,
     )
-    assert dallclose(
+    assert helpers.dallclose(
         savepoint_nonhydro_exit.w_new().asnumpy(),
         prognostic_state_nnew.w.asnumpy(),
         atol=8e-14,
     )
-    assert dallclose(
+    assert helpers.dallclose(
         savepoint_nonhydro_exit.rho_new().asnumpy(),
         prognostic_state_nnew.rho.asnumpy(),
     )
 
-    assert dallclose(
+    assert helpers.dallclose(
         savepoint_nonhydro_exit.rho_ic().asnumpy(),
         diagnostic_state_nh.rho_ic.asnumpy(),
     )
 
-    assert dallclose(
+    assert helpers.dallclose(
         savepoint_nonhydro_exit.theta_v_ic().asnumpy(),
         diagnostic_state_nh.theta_v_ic.asnumpy(),
     )
 
-    assert dallclose(
+    assert helpers.dallclose(
         savepoint_nonhydro_exit.mass_fl_e().asnumpy(),
         diagnostic_state_nh.mass_fl_e.asnumpy(),
         rtol=1e-10,
     )
 
-    assert dallclose(
+    assert helpers.dallclose(
         savepoint_nonhydro_exit.mass_flx_me().asnumpy(),
         prep_adv.mass_flx_me.asnumpy(),
         rtol=1e-10,
     )
-    assert dallclose(
+    assert helpers.dallclose(
         savepoint_nonhydro_exit.vn_traj().asnumpy(),
         prep_adv.vn_traj.asnumpy(),
         rtol=1e-10,

--- a/model/atmosphere/dycore/tests/dycore_tests/mpi_tests/test_parallel_solve_nonhydro.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/mpi_tests/test_parallel_solve_nonhydro.py
@@ -20,7 +20,7 @@ from icon4py.model.atmosphere.dycore.state_utils.states import (
 from icon4py.model.common import dimension as dims
 from icon4py.model.common.decomposition import definitions
 from icon4py.model.common.grid.horizontal import CellParams, EdgeParams
-from icon4py.model.common.grid.vertical import VerticalGridConfig, VerticalGridParams
+from icon4py.model.common.grid.vertical import VerticalGrid, VerticalGridConfig
 from icon4py.model.common.test_utils.datatest_fixtures import (  # noqa : F401 fixture
     decomposition_info,
 )
@@ -103,8 +103,8 @@ def test_run_solve_nonhydro_single_step(
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = VerticalGridParams(
-        vertical_config=vertical_config,
+    vertical_params = VerticalGrid(
+        config=vertical_config,
         vct_a=grid_savepoint.vct_a(),
         vct_b=grid_savepoint.vct_b(),
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp(),

--- a/model/atmosphere/dycore/tests/dycore_tests/test_solve_nonhydro.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/test_solve_nonhydro.py
@@ -482,8 +482,8 @@ def construct_diagnostics(init_savepoint: sb.IconNonHydroInitSavepoint):
 
 
 def create_vertical_params(vertical_config, grid_savepoint):
-    return v_grid.VerticalGridParams(
-        vertical_config=vertical_config,
+    return v_grid.VerticalGrid(
+        config=vertical_config,
         vct_a=grid_savepoint.vct_a(),
         vct_b=grid_savepoint.vct_b(),
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp(),

--- a/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
@@ -19,8 +19,8 @@ from .utils import construct_interpolation_state_for_nonhydro, construct_nh_metr
 
 
 def create_vertical_params(vertical_config, grid_savepoint):
-    return v_grid.VerticalGridParams(
-        vertical_config=vertical_config,
+    return v_grid.VerticalGrid(
+        config=vertical_config,
         vct_a=grid_savepoint.vct_a(),
         vct_b=grid_savepoint.vct_b(),
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp(),

--- a/model/common/src/icon4py/model/common/dimension.py
+++ b/model/common/src/icon4py/model/common/dimension.py
@@ -5,6 +5,7 @@
 #
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
+from typing import TypeAlias, Union
 
 from gt4py.next.common import DimensionKind
 from gt4py.next.ffront.fbuiltins import Dimension, FieldOffset
@@ -56,3 +57,6 @@ C2CECEC = FieldOffset("C2CECEC", source=CECECDim, target=(CellDim, C2E2C2E2CDim)
 V2E2V = FieldOffset("V2E2V", source=VertexDim, target=(VertexDim, V2E2VDim))
 Koff = FieldOffset("Koff", source=KDim, target=(KDim,))
 KHalfOff = FieldOffset("KHalfOff", source=KHalfDim, target=(KHalfDim,))
+
+
+VerticalDim: TypeAlias = Union[KDim, KHalfDim]

--- a/model/common/src/icon4py/model/common/grid/vertical.py
+++ b/model/common/src/icon4py/model/common/grid/vertical.py
@@ -157,6 +157,23 @@ class VerticalGrid:
             icon_var_name="vct_a",
         )
 
+    def index(self, domain: Domain) -> gtx.int32:
+        match domain.marker:
+            case Zone.TOP:
+                return gtx.int32(0)
+            case Zone.BOTTOM:
+                return (
+                    gtx.int32(self.config.num_levels)
+                    if domain.dim == dims.KDim
+                    else gtx.int32(self.config.num_levels + 1)
+                )
+            case Zone.MOIST:
+                return self._start_index_for_moist_physics
+            case Zone.FLAT:
+                return self._end_index_of_flat_layer
+            case Zone.DAMPING:
+                return self._end_index_of_damping_layer
+
     @property
     def interface_physical_height(self) -> fa.KField[float]:
         return self._vct_a
@@ -187,28 +204,13 @@ class VerticalGrid:
 
     def size(self, dim: dims.VerticalDim) -> int:
         assert dim.kind == gtx.DimensionKind.VERTICAL, "Only vertical dimensions are supported"
-        if dim == dims.KDim:
-            return self.config.num_levels
-        if dim == dims.KHalfDim:
-            return self.config.num_levels + 1
-        else:
-            raise ValueError(f"Unkown dimension {dim}.")
-
-    def index(self, domain: Domain) -> gtx.int32:
-        if domain.marker == Zone.TOP:
-            return gtx.int32(0)
-        if domain.marker == Zone.BOTTOM:
-            return (
-                gtx.int32(self.config.num_levels)
-                if domain.dim == dims.KDim
-                else gtx.int32(self.config.num_levels + 1)
-            )
-        if domain.marker == Zone.MOIST:
-            return self._start_index_for_moist_physics
-        if domain.marker == Zone.FLAT:
-            return self._end_index_of_flat_layer
-        if domain.marker == Zone.DAMPING:
-            return self._end_index_of_damping_layer
+        match dim:
+            case dims.KDim:
+                return self.config.num_levels
+            case dims.KHalfDim:
+                return self.config.num_levels + 1
+            case _:
+                raise ValueError(f"Unkown dimension {dim}.")
 
     @classmethod
     def _determine_start_level_of_moist_physics(

--- a/model/common/src/icon4py/model/common/grid/vertical.py
+++ b/model/common/src/icon4py/model/common/grid/vertical.py
@@ -39,6 +39,10 @@ class Zone(enum.IntEnum):
 
 @dataclasses.dataclass(frozen=True)
 class Domain:
+    """
+    Simple data class used to specify a vertical domain such that index lookup and domain specification can be separated.
+    """
+
     dim: dims.KDim
     marker: Zone
 

--- a/model/common/src/icon4py/model/common/io/io.py
+++ b/model/common/src/icon4py/model/common/io/io.py
@@ -148,7 +148,7 @@ class IOMonitor(monitor.Monitor):
     def __init__(
         self,
         config: IOConfig,
-        vertical_size: v_grid.VerticalGridParams,
+        vertical_size: v_grid.VerticalGrid,
         horizontal_size: h_grid.HorizontalGridSize,
         grid_file_name: str,
         grid_id: uuid.UUID,
@@ -301,7 +301,7 @@ class FieldGroupMonitor(monitor.Monitor):
 
     def _init_dataset(
         self,
-        vertical_params: v_grid.VerticalGridParams,
+        vertical_params: v_grid.VerticalGrid,
         horizontal_size: h_grid.HorizontalGridSize,
     ) -> None:
         """Initialise the dataset with global attributes and dimensions.

--- a/model/common/src/icon4py/model/common/io/writers.py
+++ b/model/common/src/icon4py/model/common/io/writers.py
@@ -70,11 +70,11 @@ class NETCDFWriter:
 
     @functools.cached_property
     def num_levels(self) -> int:
-        return self._vertical_params.inteface_physical_height.ndarray.shape[0] - 1
+        return self._vertical_params.interface_physical_height.ndarray.shape[0] - 1
 
     @functools.cached_property
     def num_interfaces(self) -> int:
-        return self._vertical_params.inteface_physical_height.ndarray.shape[0]
+        return self._vertical_params.interface_physical_height.ndarray.shape[0]
 
     def initialize_dataset(self) -> None:
         self.dataset = nc.Dataset(
@@ -125,7 +125,7 @@ class NETCDFWriter:
         heights.axis = cf_utils.COARDS_VERTICAL_COORDINATE_NAME
         heights.long_name = "height value of half levels without topography"
         heights.standard_name = cf_utils.INTERFACE_LEVEL_HEIGHT_STANDARD_NAME
-        heights[:] = self._vertical_params.inteface_physical_height.ndarray
+        heights[:] = self._vertical_params.interface_physical_height.ndarray
 
     def append(self, state_to_append: dict[str, xr.DataArray], model_time: dt.datetime) -> None:
         """

--- a/model/common/src/icon4py/model/common/io/writers.py
+++ b/model/common/src/icon4py/model/common/io/writers.py
@@ -51,7 +51,7 @@ class NETCDFWriter:
     def __init__(
         self,
         file_name: pathlib.Path,
-        vertical: v_grid.VerticalGridParams,
+        vertical: v_grid.VerticalGrid,
         horizontal: h_grid.HorizontalGridSize,
         time_properties: TimeProperties,
         global_attrs: dict,

--- a/model/common/tests/grid_tests/test_vertical.py
+++ b/model/common/tests/grid_tests/test_vertical.py
@@ -68,9 +68,7 @@ def test_damping_layer_calculation_from_icon_input(
     a_array = a.asnumpy()
     assert a_array[nrdmax] > damping_height
     assert a_array[nrdmax + 1] < damping_height
-    assert (
-        vertical_grid.index(v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.DAMPING)) == nrdmax
-    )
+    assert vertical_grid.index(v_grid.Domain(dims.KDim, v_grid.Zone.DAMPING)) == nrdmax
 
 
 @pytest.mark.datatest
@@ -82,7 +80,7 @@ def test_grid_size(grid_savepoint):
         vct_b=grid_savepoint.vct_b(),
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp,
     )
-    
+
     assert 65 == vertical_grid.size(dims.KDim)
     assert 66 == vertical_grid.size(dims.KHalfDim)
 
@@ -115,7 +113,7 @@ def configure_vertical_grid(grid_savepoint, top_moist_threshold=22500.0):
         vct_b=grid_savepoint.vct_b(),
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp,
     )
-    
+
     return vertical_grid
 
 
@@ -127,16 +125,17 @@ def test_moist_level_calculation(grid_savepoint, experiment, expected_moist_leve
     threshold = 22500.0
     vertical_grid = configure_vertical_grid(grid_savepoint, top_moist_threshold=threshold)
     assert expected_moist_level == vertical_grid.kstart_moist
-    assert expected_moist_level == vertical_grid.index(
-        v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.MOIST)
-    )
+    assert expected_moist_level == vertical_grid.index(v_grid.Domain(dims.KDim, v_grid.Zone.MOIST))
+
 
 @pytest.mark.datatest
 def test_interface_physical_height(grid_savepoint):
     vertical_grid = configure_vertical_grid(grid_savepoint)
-    assert dallclose(grid_savepoint.vct_a().asnumpy(), vertical_grid.interface_physical_height.asnumpy())
-    
-    
+    assert dallclose(
+        grid_savepoint.vct_a().asnumpy(), vertical_grid.interface_physical_height.asnumpy()
+    )
+
+
 @pytest.mark.datatest
 @pytest.mark.parametrize("experiment", [REGIONAL_EXPERIMENT, GLOBAL_EXPERIMENT])
 def test_flat_level_calculation(grid_savepoint, experiment, flat_height):
@@ -144,34 +143,26 @@ def test_flat_level_calculation(grid_savepoint, experiment, flat_height):
 
     assert grid_savepoint.nflatlev() == vertical_grid.nflatlev
     assert grid_savepoint.nflatlev() == vertical_grid.index(
-        v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.FLAT)
+        v_grid.Domain(dims.KDim, v_grid.Zone.FLAT)
     )
 
 
 @pytest.mark.parametrize("experiment, levels", [(REGIONAL_EXPERIMENT, 65), (GLOBAL_EXPERIMENT, 60)])
 def test_grid_index_top(grid_savepoint, experiment, levels):
     vertical_grid = configure_vertical_grid(grid_savepoint)
-    assert 0 == vertical_grid.index(v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.TOP))
-    assert levels == vertical_grid.index(
-        v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.BOTTOM)
-    )
-    assert levels + 1 == vertical_grid.index(
-        v_grid.VerticalDomain(dims.KHalfDim, v_grid.VerticalZone.BOTTOM)
-    )
-    assert 0 == vertical_grid.index(v_grid.VerticalDomain(dims.KHalfDim, v_grid.VerticalZone.TOP))
+    assert 0 == vertical_grid.index(v_grid.Domain(dims.KDim, v_grid.Zone.TOP))
+    assert levels == vertical_grid.index(v_grid.Domain(dims.KDim, v_grid.Zone.BOTTOM))
+    assert levels + 1 == vertical_grid.index(v_grid.Domain(dims.KHalfDim, v_grid.Zone.BOTTOM))
+    assert 0 == vertical_grid.index(v_grid.Domain(dims.KHalfDim, v_grid.Zone.TOP))
 
 
 @pytest.mark.parametrize("experiment, levels", [(REGIONAL_EXPERIMENT, 65), (GLOBAL_EXPERIMENT, 60)])
 def test_grid_index_bottom(grid_savepoint, experiment, levels):
     vertical_grid = configure_vertical_grid(grid_savepoint)
-    assert levels == vertical_grid.index(
-        v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.BOTTOM)
-    )
-    assert levels + 1 == vertical_grid.index(
-        v_grid.VerticalDomain(dims.KHalfDim, v_grid.VerticalZone.BOTTOM)
-    )
-   
-    
+    assert levels == vertical_grid.index(v_grid.Domain(dims.KDim, v_grid.Zone.BOTTOM))
+    assert levels + 1 == vertical_grid.index(v_grid.Domain(dims.KHalfDim, v_grid.Zone.BOTTOM))
+
+
 @pytest.mark.datatest
 @pytest.mark.parametrize("experiment", [REGIONAL_EXPERIMENT, GLOBAL_EXPERIMENT])
 def test_vct_a_vct_b_calculation_from_icon_input(

--- a/model/common/tests/grid_tests/test_vertical.py
+++ b/model/common/tests/grid_tests/test_vertical.py
@@ -21,6 +21,9 @@ from icon4py.model.common.test_utils.datatest_utils import (
 from icon4py.model.common.test_utils.helpers import dallclose
 
 
+NUM_LEVELS = 65
+
+
 @pytest.mark.parametrize(
     "max_h,damping_height,delta",
     [(60000, 34000, 612), (12000, 10000, 100), (109050, 45000, 123)],
@@ -29,7 +32,7 @@ def test_damping_layer_calculation(max_h, damping_height, delta, flat_height):
     vct_a = np.arange(0, max_h, delta)
     vct_a_field = gtx.as_field((dims.KDim,), data=vct_a[::-1])
     vertical_config = v_grid.VerticalGridConfig(
-        num_levels=65,
+        num_levels=NUM_LEVELS,
         flat_height=flat_height,
         rayleigh_damping_height=damping_height,
     )
@@ -81,8 +84,8 @@ def test_grid_size(grid_savepoint):
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp,
     )
 
-    assert 65 == vertical_grid.size(dims.KDim)
-    assert 66 == vertical_grid.size(dims.KHalfDim)
+    assert NUM_LEVELS == vertical_grid.size(dims.KDim)
+    assert NUM_LEVELS + 1 == vertical_grid.size(dims.KHalfDim)
 
 
 @pytest.mark.parametrize(

--- a/model/common/tests/grid_tests/test_vertical.py
+++ b/model/common/tests/grid_tests/test_vertical.py
@@ -25,19 +25,19 @@ from icon4py.model.common.test_utils.helpers import dallclose
     "max_h,damping_height,delta",
     [(60000, 34000, 612), (12000, 10000, 100), (109050, 45000, 123)],
 )
-def test_nrdmax_calculation(max_h, damping_height, delta, flat_height, grid_savepoint):
+def test_damping_layer_calculation(max_h, damping_height, delta, flat_height):
     vct_a = np.arange(0, max_h, delta)
     vct_a_field = gtx.as_field((dims.KDim,), data=vct_a[::-1])
     vertical_config = v_grid.VerticalGridConfig(
-        num_levels=grid_savepoint.num(dims.KDim),
+        num_levels=65,
         flat_height=flat_height,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = v_grid.VerticalGridParams(
-        vertical_config=vertical_config,
+    vertical_params = v_grid.VerticalGrid(
+        config=vertical_config,
         vct_a=vct_a_field,
         vct_b=None,
-        _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp,
+        _min_index_flat_horizontal_grad_pressure=10,
     )
     assert (
         vertical_params.end_index_of_damping_layer
@@ -47,7 +47,7 @@ def test_nrdmax_calculation(max_h, damping_height, delta, flat_height, grid_save
 
 @pytest.mark.datatest
 @pytest.mark.parametrize("experiment", [REGIONAL_EXPERIMENT, GLOBAL_EXPERIMENT])
-def test_nrdmax_calculation_from_icon_input(
+def test_damping_layer_calculation_from_icon_input(
     grid_savepoint, experiment, damping_height, flat_height
 ):
     a = grid_savepoint.vct_a()
@@ -58,14 +58,13 @@ def test_nrdmax_calculation_from_icon_input(
         flat_height=flat_height,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = v_grid.VerticalGridParams(
-        vertical_config=vertical_config,
+    vertical_grid = v_grid.VerticalGrid(
+        config=vertical_config,
         vct_a=a,
         vct_b=b,
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp,
     )
-    vertical_grid = v_grid.VerticalGrid(vertical_config, vertical_params)
-    assert nrdmax == vertical_params.end_index_of_damping_layer
+    assert nrdmax == vertical_grid.end_index_of_damping_layer
     a_array = a.asnumpy()
     assert a_array[nrdmax] > damping_height
     assert a_array[nrdmax + 1] < damping_height
@@ -77,13 +76,13 @@ def test_nrdmax_calculation_from_icon_input(
 @pytest.mark.datatest
 def test_grid_size(grid_savepoint):
     config = v_grid.VerticalGridConfig(num_levels=grid_savepoint.num(dims.KDim))
-    vertical_params = v_grid.VerticalGridParams(
-        vertical_config=config,
+    vertical_grid = v_grid.VerticalGrid(
+        config=config,
         vct_a=grid_savepoint.vct_a(),
         vct_b=grid_savepoint.vct_b(),
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp,
     )
-    vertical_grid = v_grid.VerticalGrid(config, vertical_params)
+    
     assert 65 == vertical_grid.size(dims.KDim)
     assert 66 == vertical_grid.size(dims.KHalfDim)
 
@@ -110,47 +109,47 @@ def configure_vertical_grid(grid_savepoint, top_moist_threshold=22500.0):
     config = v_grid.VerticalGridConfig(
         num_levels=grid_savepoint.num(dims.KDim), htop_moist_proc=top_moist_threshold
     )
-    vertical_params = v_grid.VerticalGridParams(
-        vertical_config=config,
+    vertical_grid = v_grid.VerticalGrid(
+        config=config,
         vct_a=grid_savepoint.vct_a(),
         vct_b=grid_savepoint.vct_b(),
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp,
     )
-    vertical_grid = v_grid.VerticalGrid(config, vertical_params)
+    
     return vertical_grid
 
 
 @pytest.mark.datatest
 @pytest.mark.parametrize(
-    "experiment, kmoist_level", [(REGIONAL_EXPERIMENT, 0), (GLOBAL_EXPERIMENT, 25)]
+    "experiment, expected_moist_level", [(REGIONAL_EXPERIMENT, 0), (GLOBAL_EXPERIMENT, 25)]
 )
-def test_kmoist_calculation(grid_savepoint, experiment, kmoist_level):
+def test_moist_level_calculation(grid_savepoint, experiment, expected_moist_level):
     threshold = 22500.0
     vertical_grid = configure_vertical_grid(grid_savepoint, top_moist_threshold=threshold)
-    vct_a = grid_savepoint.vct_a().asnumpy()
-    assert kmoist_level == v_grid.VerticalGridParams._determine_kstart_moist(
-        vct_a, threshold, nshift_total=0
-    )
-    assert kmoist_level == vertical_grid.index(
+    assert expected_moist_level == vertical_grid.kstart_moist
+    assert expected_moist_level == vertical_grid.index(
         v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.MOIST)
     )
 
-
+@pytest.mark.datatest
+def test_interface_physical_height(grid_savepoint):
+    vertical_grid = configure_vertical_grid(grid_savepoint)
+    assert dallclose(grid_savepoint.vct_a().asnumpy(), vertical_grid.interface_physical_height.asnumpy())
+    
+    
 @pytest.mark.datatest
 @pytest.mark.parametrize("experiment", [REGIONAL_EXPERIMENT, GLOBAL_EXPERIMENT])
-def test_kflat_calculation(grid_savepoint, experiment, flat_height):
+def test_flat_level_calculation(grid_savepoint, experiment, flat_height):
     vertical_grid = configure_vertical_grid(grid_savepoint)
-    vct_a = grid_savepoint.vct_a().asnumpy()
-    assert grid_savepoint.nflatlev() == v_grid.VerticalGridParams._determine_kstart_flat(
-        vct_a, flat_height
-    )
+
+    assert grid_savepoint.nflatlev() == vertical_grid.nflatlev
     assert grid_savepoint.nflatlev() == vertical_grid.index(
         v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.FLAT)
     )
 
 
 @pytest.mark.parametrize("experiment, levels", [(REGIONAL_EXPERIMENT, 65), (GLOBAL_EXPERIMENT, 60)])
-def test_vertical_grid_index(grid_savepoint, experiment, levels):
+def test_grid_index_top(grid_savepoint, experiment, levels):
     vertical_grid = configure_vertical_grid(grid_savepoint)
     assert 0 == vertical_grid.index(v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.TOP))
     assert levels == vertical_grid.index(
@@ -162,6 +161,17 @@ def test_vertical_grid_index(grid_savepoint, experiment, levels):
     assert 0 == vertical_grid.index(v_grid.VerticalDomain(dims.KHalfDim, v_grid.VerticalZone.TOP))
 
 
+@pytest.mark.parametrize("experiment, levels", [(REGIONAL_EXPERIMENT, 65), (GLOBAL_EXPERIMENT, 60)])
+def test_grid_index_bottom(grid_savepoint, experiment, levels):
+    vertical_grid = configure_vertical_grid(grid_savepoint)
+    assert levels == vertical_grid.index(
+        v_grid.VerticalDomain(dims.KDim, v_grid.VerticalZone.BOTTOM)
+    )
+    assert levels + 1 == vertical_grid.index(
+        v_grid.VerticalDomain(dims.KHalfDim, v_grid.VerticalZone.BOTTOM)
+    )
+   
+    
 @pytest.mark.datatest
 @pytest.mark.parametrize("experiment", [REGIONAL_EXPERIMENT, GLOBAL_EXPERIMENT])
 def test_vct_a_vct_b_calculation_from_icon_input(

--- a/model/common/tests/io_tests/test_io.py
+++ b/model/common/tests/io_tests/test_io.py
@@ -128,8 +128,8 @@ def is_valid_uxgrid(file: Union[pathlib.Path, str]) -> bool:
 def test_io_monitor_create_output_path(test_path):
     path_name = test_path.absolute().as_posix() + "/output"
     vertical_config = v_grid.VerticalGridConfig(num_levels=simple_grid.num_levels)
-    vertical_params = v_grid.VerticalGridParams(
-        vertical_config=vertical_config,
+    vertical_params = v_grid.VerticalGrid(
+        config=vertical_config,
         vct_a=gtx.as_field((dims.KDim,), np.linspace(12000.0, 0.0, simple_grid.num_levels + 1)),
         vct_b=None,
     )
@@ -148,8 +148,8 @@ def test_io_monitor_create_output_path(test_path):
 def test_io_monitor_write_ugrid_file(test_path):
     path_name = test_path.absolute().as_posix() + "/output"
     vertical_config = v_grid.VerticalGridConfig(num_levels=simple_grid.num_levels)
-    vertical_params = v_grid.VerticalGridParams(
-        vertical_config=vertical_config,
+    vertical_params = v_grid.VerticalGrid(
+        config=vertical_config,
         vct_a=gtx.as_field((dims.KDim,), np.linspace(12000.0, 0.0, simple_grid.num_levels + 1)),
         vct_b=None,
     )
@@ -178,8 +178,8 @@ def test_io_monitor_write_and_read_ugrid_dataset(test_path, variables):
     path_name = test_path.absolute().as_posix() + "/output"
     grid = grid_utils.get_icon_grid_from_gridfile(datatest_utils.GLOBAL_EXPERIMENT, on_gpu=False)
     vertical_config = v_grid.VerticalGridConfig(num_levels=grid.num_levels)
-    vertical_params = v_grid.VerticalGridParams(
-        vertical_config=vertical_config,
+    vertical_params = v_grid.VerticalGrid(
+        config=vertical_config,
         vct_a=gtx.as_field((dims.KDim,), np.linspace(12000.0, 0.0, grid.num_levels + 1)),
         vct_b=None,
     )
@@ -228,8 +228,8 @@ def test_io_monitor_write_and_read_ugrid_dataset(test_path, variables):
 def test_fieldgroup_monitor_write_dataset_file_roll(test_path):
     grid = grid_utils.get_icon_grid_from_gridfile(datatest_utils.GLOBAL_EXPERIMENT, on_gpu=False)
     vertical_config = v_grid.VerticalGridConfig(num_levels=grid.num_levels)
-    vertical_params = v_grid.VerticalGridParams(
-        vertical_config=vertical_config,
+    vertical_params = v_grid.VerticalGrid(
+        config=vertical_config,
         vct_a=gtx.as_field((dims.KDim,), np.linspace(12000.0, 0.0, grid.num_levels + 1)),
         vct_b=None,
     )
@@ -352,8 +352,8 @@ def create_field_group_monitor(test_path, grid, start_time="2024-01-01T00:00:00"
         variables=["exner_function", "air_density"],
     )
     vertical_config = v_grid.VerticalGridConfig(num_levels=simple_grid.num_levels)
-    vertical_params = v_grid.VerticalGridParams(
-        vertical_config=vertical_config,
+    vertical_params = v_grid.VerticalGrid(
+        config=vertical_config,
         vct_a=gtx.as_field((dims.KDim,), np.linspace(12000.0, 0.0, simple_grid.num_levels + 1)),
         vct_b=None,
     )

--- a/model/common/tests/io_tests/test_writers.py
+++ b/model/common/tests/io_tests/test_writers.py
@@ -50,7 +50,7 @@ def initialized_writer(
     num_levels = grid.config.vertical_size
     heights = np.linspace(start=12000.0, stop=0.0, num=num_levels + 1)
     vertical_config = v_grid.VerticalGridConfig(num_levels=num_levels)
-    vertical_params = v_grid.VerticalGridParams(
+    vertical_params = v_grid.VerticalGrid(
         vertical_config,
         vct_a=gtx.as_field((dims.KDim,), heights),
         vct_b=None,

--- a/model/driver/src/icon4py/model/driver/initialization_utils.py
+++ b/model/driver/src/icon4py/model/driver/initialization_utils.py
@@ -273,7 +273,7 @@ def read_geometry_fields(
     grid_id=GLOBAL_GRID_ID,
     grid_root=GRID_ROOT,
     grid_level=GRID_LEVEL,
-) -> tuple[h_grid.EdgeParams, h_grid.CellParams, v_grid.VerticalGridParams, fa.CellField[bool]]:
+) -> tuple[h_grid.EdgeParams, h_grid.CellParams, v_grid.VerticalGrid, fa.CellField[bool]]:
     """
     Read fields containing grid properties.
 
@@ -294,8 +294,8 @@ def read_geometry_fields(
         edge_geometry = sp.construct_edge_geometry()
         cell_geometry = sp.construct_cell_geometry()
         vct_a, vct_b = v_grid.get_vct_a_and_vct_b(vertical_grid_config)
-        vertical_geometry = v_grid.VerticalGridParams(
-            vertical_config=vertical_grid_config,
+        vertical_geometry = v_grid.VerticalGrid(
+            config=vertical_grid_config,
             vct_a=vct_a,
             vct_b=vct_b,
             _min_index_flat_horizontal_grad_pressure=sp.nflat_gradp(),

--- a/model/driver/tests/driver_tests/test_timeloop.py
+++ b/model/driver/tests/driver_tests/test_timeloop.py
@@ -157,8 +157,8 @@ def test_run_timeloop_single_step(
         stretch_factor=stretch_factor,
         rayleigh_damping_height=damping_height,
     )
-    vertical_params = v_grid.VerticalGridParams(
-        vertical_config=vertical_config,
+    vertical_params = v_grid.VerticalGrid(
+        config=vertical_config,
         vct_a=grid_savepoint.vct_a(),
         vct_b=grid_savepoint.vct_b(),
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp(),

--- a/model/driver/tests/driver_tests/test_timeloop.py
+++ b/model/driver/tests/driver_tests/test_timeloop.py
@@ -170,7 +170,7 @@ def test_run_timeloop_single_step(
         grid=icon_grid,
         config=diffusion_config,
         params=additional_parameters,
-        vertical_params=vertical_params,
+        vertical_grid=vertical_params,
         metric_state=diffusion_metric_state,
         interpolation_state=diffusion_interpolation_state,
         edge_params=edge_geometry,

--- a/tools/src/icon4pytools/py2fgen/wrappers/diffusion.py
+++ b/tools/src/icon4pytools/py2fgen/wrappers/diffusion.py
@@ -22,6 +22,9 @@ import pstats
 
 from gt4py.next.common import Field
 from gt4py.next.ffront.fbuiltins import float64, int32
+from icon4pytools.common.logger import setup_logger
+from icon4pytools.py2fgen.utils import get_grid_filename, get_icon_grid_loc
+
 from icon4py.model.atmosphere.diffusion.diffusion import (
     Diffusion,
     DiffusionConfig,
@@ -36,14 +39,11 @@ from icon4py.model.atmosphere.diffusion.diffusion_states import (
 from icon4py.model.common import dimension as dims
 from icon4py.model.common.constants import DEFAULT_PHYSICS_DYNAMICS_TIMESTEP_RATIO
 from icon4py.model.common.grid.horizontal import CellParams, EdgeParams
-from icon4py.model.common.grid.vertical import VerticalGridConfig, VerticalGridParams
+from icon4py.model.common.grid.vertical import VerticalGrid, VerticalGridConfig
 from icon4py.model.common.settings import device, limited_area
 from icon4py.model.common.states.prognostic_state import PrognosticState
 from icon4py.model.common.test_utils.grid_utils import load_grid_from_file
 from icon4py.model.common.test_utils.helpers import as_1D_sparse_field, flatten_first_two_dims
-
-from icon4pytools.common.logger import setup_logger
-from icon4pytools.py2fgen.utils import get_grid_filename, get_icon_grid_loc
 
 
 logger = setup_logger(__name__)
@@ -185,8 +185,8 @@ def diffusion_init(
     )
 
     # vertical parameters
-    vertical_params = VerticalGridParams(
-        vertical_config=vertical_config,
+    vertical_params = VerticalGrid(
+        config=vertical_config,
         vct_a=vct_a,
         vct_b=None,
         _min_index_flat_horizontal_grad_pressure=nflat_gradp,

--- a/tools/src/icon4pytools/py2fgen/wrappers/diffusion.py
+++ b/tools/src/icon4pytools/py2fgen/wrappers/diffusion.py
@@ -22,9 +22,6 @@ import pstats
 
 from gt4py.next.common import Field
 from gt4py.next.ffront.fbuiltins import float64, int32
-from icon4pytools.common.logger import setup_logger
-from icon4pytools.py2fgen.utils import get_grid_filename, get_icon_grid_loc
-
 from icon4py.model.atmosphere.diffusion.diffusion import (
     Diffusion,
     DiffusionConfig,
@@ -44,6 +41,9 @@ from icon4py.model.common.settings import device, limited_area
 from icon4py.model.common.states.prognostic_state import PrognosticState
 from icon4py.model.common.test_utils.grid_utils import load_grid_from_file
 from icon4py.model.common.test_utils.helpers import as_1D_sparse_field, flatten_first_two_dims
+
+from icon4pytools.common.logger import setup_logger
+from icon4pytools.py2fgen.utils import get_grid_filename, get_icon_grid_loc
 
 
 logger = setup_logger(__name__)
@@ -217,7 +217,7 @@ def diffusion_init(
         grid=icon_grid,
         config=config,
         params=diffusion_params,
-        vertical_params=vertical_params,
+        vertical_grid=vertical_params,
         metric_state=metric_state,
         interpolation_state=interpolation_state,
         edge_params=edge_params,


### PR DESCRIPTION
Refactoring and extension of the vertical grid:
We need a way to separate the specification of vertical indices from their explicit computation on a given vertical configuration.
In order to achieve this, a vertical `Domain` class and a enum specifying several `Zone`s is introduced. An index can then be looked up via
```python
domain = vertical.Domain(KDim, Zone.Bottom)
vertical_grid = VerticalGrid(config)
index = vertical_grid.index(domain)
``` 
Naming (eg `Zone` , `Domain` ) was chosen to match the lookup of `start_index` and `end_index` in the horizontal grid with [PR 531](https://github.com/C2SM/icon4py/pull/531)

I chose to add this to the `VerticalParams` and rename those to `VerticalGrid`


## additional changes
- fix typo in a function
- fix imports in parallel diffusion and dycore tests