### PR TITLE
Push index resolution to init

### DIFF
--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -407,7 +407,7 @@ class Diffusion:
             nrdmax=self.vertical_grid.end_index_of_damping_layer,
         )
         self._determine_horizontal_domains()
-        
+
         self._initialized = True
 
     @property
@@ -437,8 +437,6 @@ class Diffusion:
             xp.zeros((self.grid.num_cells, self.grid.num_levels + 1), dtype=float),
         )
 
-    
-        
     def _determine_horizontal_domains(self):
         cell_domain = h_grid.domain(dims.CellDim)
         edge_domain = h_grid.domain(dims.EdgeDim)
@@ -451,29 +449,28 @@ class Diffusion:
                 else self.grid.start_index(cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_4))
             )
 
-    
-        
         self._cell_start_interior = self.grid.start_index(cell_domain(h_grid.Zone.INTERIOR))
         self._cell_start_nudging = self.grid.start_index(cell_domain(h_grid.Zone.NUDGING))
         self._cell_end_local = self.grid.end_index(cell_domain(h_grid.Zone.LOCAL))
         self._cell_end_halo = self.grid.end_index(cell_domain(h_grid.Zone.HALO))
-        
-        self._edge_start_nudging_level_2 = self.grid.start_index(
-            edge_domain(h_grid.Zone.NUDGING_LEVEL_2))
-        self._edge_start_nudging = self.grid.start_index(edge_domain(h_grid.Zone.NUDGING))
+
         self._edge_start_lateral_boundary_level_5 = self.grid.start_index(
             edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5)
         )
+        self._edge_start_nudging = self.grid.start_index(edge_domain(h_grid.Zone.NUDGING))
+        self._edge_start_nudging_level_2 = self.grid.start_index(
+            edge_domain(h_grid.Zone.NUDGING_LEVEL_2)
+        )
         self._edge_end_local = self.grid.end_index(edge_domain(h_grid.Zone.LOCAL))
-        self._edge_end_halo_level_2 = self.grid.end_index(edge_domain(h_grid.Zone.HALO_LEVEL_2))
         self._edge_end_halo = self.grid.end_index(edge_domain(h_grid.Zone.HALO))
-        
+        self._edge_end_halo_level_2 = self.grid.end_index(edge_domain(h_grid.Zone.HALO_LEVEL_2))
+
         self._vertex_start_lateral_boundary_level_2 = self.grid.start_index(
             vertex_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2)
         )
         self._vertex_end_local = self.grid.end_index(vertex_domain(h_grid.Zone.LOCAL))
+
         self._horizontal_start_index_w_diffusion = _get_start_index_for_w_diffusion()
- 
 
     def initial_run(
         self,
@@ -809,5 +806,3 @@ class Diffusion:
         log.debug("running stencil 16 (update_theta_and_exner): end")
         handle_edge_comm.wait()  # need to do this here, since we currently only use 1 communication object.
         log.debug("communication of prognogistic.vn - end")
-
-

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -378,14 +378,6 @@ class Diffusion:
 
         self._allocate_temporary_fields()
 
-        def _get_start_index_for_w_diffusion() -> gtx.int32:
-            cell_domain = h_grid.domain(dims.CellDim)
-            return (
-                self.grid.start_index(cell_domain(h_grid.Zone.NUDGING))
-                if self.grid.limited_area
-                else self.grid.start_index(cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_4))
-            )
-
         self.nudgezone_diff: float = 0.04 / (params.scaled_nudge_max_coeff + sys.float_info.epsilon)
         self.bdy_diff: float = 0.015 / (params.scaled_nudge_max_coeff + sys.float_info.epsilon)
         self.fac_bdydiff_v: float = (
@@ -414,7 +406,8 @@ class Diffusion:
             physical_heights=self.vertical_grid.interface_physical_height,
             nrdmax=self.vertical_grid.end_index_of_damping_layer,
         )
-        self._horizontal_start_index_w_diffusion = _get_start_index_for_w_diffusion()
+        self._determine_horizontal_domains()
+        
         self._initialized = True
 
     @property
@@ -443,6 +436,44 @@ class Diffusion:
             (dims.CellDim, dims.KDim),
             xp.zeros((self.grid.num_cells, self.grid.num_levels + 1), dtype=float),
         )
+
+    
+        
+    def _determine_horizontal_domains(self):
+        cell_domain = h_grid.domain(dims.CellDim)
+        edge_domain = h_grid.domain(dims.EdgeDim)
+        vertex_domain = h_grid.domain(dims.VertexDim)
+
+        def _get_start_index_for_w_diffusion() -> gtx.int32:
+            return (
+                self.grid.start_index(cell_domain(h_grid.Zone.NUDGING))
+                if self.grid.limited_area
+                else self.grid.start_index(cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_4))
+            )
+
+    
+        
+        self._cell_start_interior = self.grid.start_index(cell_domain(h_grid.Zone.INTERIOR))
+        self._cell_start_nudging = self.grid.start_index(cell_domain(h_grid.Zone.NUDGING))
+        self._cell_end_local = self.grid.end_index(cell_domain(h_grid.Zone.LOCAL))
+        self._cell_end_halo = self.grid.end_index(cell_domain(h_grid.Zone.HALO))
+        
+        self._edge_start_nudging_level_2 = self.grid.start_index(
+            edge_domain(h_grid.Zone.NUDGING_LEVEL_2))
+        self._edge_start_nudging = self.grid.start_index(edge_domain(h_grid.Zone.NUDGING))
+        self._edge_start_lateral_boundary_level_5 = self.grid.start_index(
+            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5)
+        )
+        self._edge_end_local = self.grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+        self._edge_end_halo_level_2 = self.grid.end_index(edge_domain(h_grid.Zone.HALO_LEVEL_2))
+        self._edge_end_halo = self.grid.end_index(edge_domain(h_grid.Zone.HALO))
+        
+        self._vertex_start_lateral_boundary_level_2 = self.grid.start_index(
+            vertex_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2)
+        )
+        self._vertex_end_local = self.grid.end_index(vertex_domain(h_grid.Zone.LOCAL))
+        self._horizontal_start_index_w_diffusion = _get_start_index_for_w_diffusion()
+ 
 
     def initial_run(
         self,
@@ -540,30 +571,6 @@ class Diffusion:
 
         """
         num_levels = self.grid.num_levels
-        cell_domain = h_grid.domain(dims.CellDim)
-        cell_start_interior = self.grid.start_index(cell_domain(h_grid.Zone.INTERIOR))
-
-        cell_start_nudging = self.grid.start_index(cell_domain(h_grid.Zone.NUDGING))
-        cell_end_local = self.grid.end_index(cell_domain(h_grid.Zone.LOCAL))
-        cell_end_halo = self.grid.end_index(cell_domain(h_grid.Zone.HALO))
-
-        edge_domain = h_grid.domain(dims.EdgeDim)
-        edge_start_nudging_level_2 = self.grid.start_index(edge_domain(h_grid.Zone.NUDGING_LEVEL_2))
-        edge_start_nudging = self.grid.start_index(edge_domain(h_grid.Zone.NUDGING))
-
-        edge_start_lateral_boundary_level_5 = self.grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5)
-        )
-        edge_end_local = self.grid.end_index(edge_domain(h_grid.Zone.LOCAL))
-        edge_end_halo_level_2 = self.grid.end_index(edge_domain(h_grid.Zone.HALO_LEVEL_2))
-        edge_end_halo = self.grid.end_index(edge_domain(h_grid.Zone.HALO))
-
-        vertex_domain = h_grid.domain(dims.VertexDim)
-        vertex_start_lateral_boundary_level_2 = self.grid.start_index(
-            vertex_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2)
-        )
-        vertex_end_local = self.grid.end_index(vertex_domain(h_grid.Zone.LOCAL))
-
         # dtime dependent: enh_smag_factor,
         cached.scale_k(self.enh_smag_fac, dtime, self.diff_multfac_smag, offset_provider={})
 
@@ -574,8 +581,8 @@ class Diffusion:
             ptr_coeff_2=self.interpolation_state.rbf_coeff_2,
             p_u_out=self.u_vert,
             p_v_out=self.v_vert,
-            horizontal_start=vertex_start_lateral_boundary_level_2,
-            horizontal_end=vertex_end_local,
+            horizontal_start=self._vertex_start_lateral_boundary_level_2,
+            horizontal_end=self._vertex_end_local,
             vertical_start=0,
             vertical_end=num_levels,
             offset_provider=self.grid.offset_providers,
@@ -605,8 +612,8 @@ class Diffusion:
             kh_smag_ec=self.kh_smag_ec,
             z_nabla2_e=self.z_nabla2_e,
             smag_offset=smag_offset,
-            horizontal_start=edge_start_lateral_boundary_level_5,
-            horizontal_end=edge_end_halo_level_2,
+            horizontal_start=self._edge_start_lateral_boundary_level_5,
+            horizontal_end=self._edge_end_halo_level_2,
             vertical_start=0,
             vertical_end=num_levels,
             offset_provider=self.grid.offset_providers,
@@ -628,8 +635,8 @@ class Diffusion:
                 wgtfac_c=self.metric_state.wgtfac_c,
                 div_ic=diagnostic_state.div_ic,
                 hdef_ic=diagnostic_state.hdef_ic,
-                horizontal_start=cell_start_nudging,
-                horizontal_end=cell_end_local,
+                horizontal_start=self._cell_start_nudging,
+                horizontal_end=self._cell_end_local,
                 vertical_start=1,
                 vertical_end=num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -652,8 +659,8 @@ class Diffusion:
             ptr_coeff_2=self.interpolation_state.rbf_coeff_2,
             p_u_out=self.u_vert,
             p_v_out=self.v_vert,
-            horizontal_start=vertex_start_lateral_boundary_level_2,
-            horizontal_end=vertex_end_local,
+            horizontal_start=self._vertex_start_lateral_boundary_level_2,
+            horizontal_end=self._vertex_end_local,
             vertical_start=0,
             vertical_end=num_levels,
             offset_provider=self.grid.offset_providers,
@@ -682,10 +689,10 @@ class Diffusion:
             edge=self.horizontal_edge_index,
             nudgezone_diff=self.nudgezone_diff,
             fac_bdydiff_v=self.fac_bdydiff_v,
-            start_2nd_nudge_line_idx_e=gtx.int32(edge_start_nudging_level_2),
+            start_2nd_nudge_line_idx_e=self._edge_start_nudging_level_2,
             limited_area=self.grid.limited_area,
-            horizontal_start=edge_start_lateral_boundary_level_5,
-            horizontal_end=edge_end_local,
+            horizontal_start=self._edge_start_lateral_boundary_level_5,
+            horizontal_end=self._edge_end_local,
             vertical_start=0,
             vertical_end=num_levels,
             offset_provider=self.grid.offset_providers,
@@ -717,10 +724,10 @@ class Diffusion:
             nrdmax=gtx.int32(
                 self.vertical_grid.end_index_of_damping_layer + 1
             ),  # +1 since Fortran includes boundaries
-            interior_idx=gtx.int32(cell_start_interior),
-            halo_idx=gtx.int32(cell_end_local),
+            interior_idx=self._cell_start_interior,
+            halo_idx=self._cell_end_local,
             horizontal_start=self._horizontal_start_index_w_diffusion,
-            horizontal_end=cell_end_halo,
+            horizontal_end=self._cell_end_halo,
             vertical_start=0,
             vertical_end=num_levels,
             offset_provider=self.grid.offset_providers,
@@ -739,8 +746,8 @@ class Diffusion:
             thresh_tdiff=self.thresh_tdiff,
             smallest_vpfloat=constants.DBL_EPS,
             kh_smag_e=self.kh_smag_e,
-            horizontal_start=edge_start_nudging,
-            horizontal_end=edge_end_halo,
+            horizontal_start=self._edge_start_nudging,
+            horizontal_end=self._edge_end_halo,
             vertical_start=(num_levels - 2),
             vertical_end=num_levels,
             offset_provider=self.grid.offset_providers,
@@ -756,8 +763,8 @@ class Diffusion:
             theta_v=prognostic_state.theta_v,
             geofac_div=self.interpolation_state.geofac_div,
             z_temp=self.z_temp,
-            horizontal_start=cell_start_nudging,
-            horizontal_end=cell_end_local,
+            horizontal_start=self._cell_start_nudging,
+            horizontal_end=self._cell_end_local,
             vertical_start=0,
             vertical_end=num_levels,
             offset_provider=self.grid.offset_providers,
@@ -776,8 +783,8 @@ class Diffusion:
                 vcoef=self.metric_state.zd_intcoef,
                 theta_v=prognostic_state.theta_v,
                 z_temp=self.z_temp,
-                horizontal_start=cell_start_nudging,
-                horizontal_end=cell_end_local,
+                horizontal_start=self._cell_start_nudging,
+                horizontal_end=self._cell_end_local,
                 vertical_start=0,
                 vertical_end=num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -793,8 +800,8 @@ class Diffusion:
             theta_v=prognostic_state.theta_v,
             exner=prognostic_state.exner,
             rd_o_cvd=self.rd_o_cvd,
-            horizontal_start=cell_start_nudging,
-            horizontal_end=cell_end_local,
+            horizontal_start=self._cell_start_nudging,
+            horizontal_end=self._cell_end_local,
             vertical_start=0,
             vertical_end=num_levels,
             offset_provider={},
@@ -802,3 +809,5 @@ class Diffusion:
         log.debug("running stencil 16 (update_theta_and_exner): end")
         handle_edge_comm.wait()  # need to do this here, since we currently only use 1 communication object.
         log.debug("communication of prognogistic.vn - end")
+
+

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro.py
@@ -467,7 +467,7 @@ class SolveNonhydro:
             owner_mask,
         )
         self._allocate_local_fields()
-
+        self._determine_local_domains()
         # TODO (magdalena) vertical nesting is only relevant in the context of
         #      horizontal nesting, since we don't support this we should remove this option
         if grid.lvert_nest:
@@ -551,6 +551,61 @@ class SolveNonhydro:
         self.scal_divdamp = field_alloc.allocate_zero_field(dims.KDim, grid=self.grid)
         self.intermediate_fields = IntermediateFields.allocate(self.grid)
 
+    def _determine_local_domains(self):
+        vertex_domain = h_grid.domain(dims.VertexDim)
+        cell_domain = h_grid.domain(dims.CellDim)
+        cell_halo_level_2 = cell_domain(h_grid.Zone.HALO_LEVEL_2)
+        edge_domain = h_grid.domain(dims.EdgeDim)
+        edge_halo_level_2 = edge_domain(h_grid.Zone.HALO_LEVEL_2)
+
+        self._start_cell_lateral_boundary = self.grid.start_index(
+            cell_domain(h_grid.Zone.LATERAL_BOUNDARY)
+        )
+        self._start_cell_lateral_boundary_level_3 = self.grid.start_index(
+            cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_3)
+        )
+        self._start_cell_nudging = self.grid.start_index(cell_domain(h_grid.Zone.NUDGING))
+        self._start_cell_local = self.grid.start_index(cell_domain(h_grid.Zone.LOCAL))
+        self._start_cell_halo = self.grid.start_index(cell_domain(h_grid.Zone.HALO))
+        self._start_cell_halo_level_2 = self.grid.start_index(cell_halo_level_2)
+        self._end_cell_lateral_boundary_level_4 = self.grid.end_index(
+            cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_4)
+        )
+        self._end_cell_nudging = self.grid.end_index(cell_domain(h_grid.Zone.NUDGING))
+        self._end_cell_local = self.grid.end_index(cell_domain(h_grid.Zone.LOCAL))
+        self._end_cell_halo = self.grid.end_index(cell_domain(h_grid.Zone.HALO))
+        self._end_cell_halo_level_2 = self.grid.end_index(cell_halo_level_2)
+        self._end_cell_end = self.grid.end_index(cell_domain(h_grid.Zone.END))
+
+        self._start_edge_lateral_boundary = self.grid.start_index(
+            edge_domain(h_grid.Zone.LATERAL_BOUNDARY)
+        )
+        self._start_edge_lateral_boundary_level_5 = self.grid.start_index(
+            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5)
+        )
+        self._start_edge_lateral_boundary_level_7 = self.grid.start_index(
+            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_7)
+        )
+        self._start_edge_nudging_level_2 = self.grid.start_index(
+            edge_domain(h_grid.Zone.NUDGING_LEVEL_2)
+        )
+
+        self._start_edge_halo_level_2 = self.grid.start_index(edge_halo_level_2)
+
+        self._end_cell_lateral_boundary_level_4 = self.grid.end_index(
+            cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_4)
+        )
+        self._end_edge_nudging = self.grid.end_index(edge_domain(h_grid.Zone.NUDGING))
+        self._end_edge_local = self.grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+        self._end_edge_halo = self.grid.end_index(edge_domain(h_grid.Zone.HALO))
+        self._end_edge_halo_level_2 = self.grid.end_index(edge_halo_level_2)
+        self._end_edge_end = self.grid.end_index(edge_domain(h_grid.Zone.END))
+
+        self._start_vertex_lateral_boundary_level_2 = self.grid.start_index(
+            vertex_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2)
+        )
+        self._end_vertex_halo = self.grid.end_index(vertex_domain(h_grid.Zone.HALO))
+
     def set_timelevels(self, nnow, nnew):
         #  Set time levels of ddt_adv fields for call to velocity_tendencies
         if self.config.itime_scheme == TimeSteppingScheme.MOST_EFFICIENT:
@@ -579,16 +634,6 @@ class SolveNonhydro:
         log.info(
             f"running timestep: dtime = {dtime}, init = {l_init}, recompute = {l_recompute}, prep_adv = {lprep_adv}  clean_mflx={lclean_mflx} "
         )
-        cell_domain = h_grid.domain(dims.CellDim)
-        start_cell_lateral_boundary = self.grid.start_index(
-            cell_domain(h_grid.Zone.LATERAL_BOUNDARY)
-        )
-        end_cell_end = self.grid.end_index(cell_domain(h_grid.Zone.END))
-        edge_domain = h_grid.domain(dims.EdgeDim)
-        start_edge_lateral_boundary = self.grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY)
-        )
-        end_edge_local = self.grid.end_index(edge_domain(h_grid.Zone.LOCAL))
 
         # # TODO: abishekg7 move this to tests
         if self.p_test_run:
@@ -597,10 +642,10 @@ class SolveNonhydro:
                 self.intermediate_fields.z_theta_v_e,
                 self.intermediate_fields.z_dwdz_dd,
                 self.intermediate_fields.z_graddiv_vn,
-                start_edge_lateral_boundary,
-                end_edge_local,
-                start_cell_lateral_boundary,
-                end_cell_end,
+                self._start_edge_lateral_boundary,
+                self._end_edge_local,
+                self._start_cell_lateral_boundary,
+                self._end_cell_end,
                 vertical_start=gtx.int32(0),
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -634,13 +679,6 @@ class SolveNonhydro:
             at_last_substep=at_last_substep,
         )
 
-        end_cell_lateral_boundary_level_4 = self.grid.end_index(
-            cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_4)
-        )
-        start_cell_halo = self.grid.start_index(cell_domain(h_grid.Zone.HALO))
-
-        end_cell_end = self.grid.end_index(cell_domain(h_grid.Zone.END))
-
         if self.grid.limited_area:
             compute_theta_and_exner(
                 bdy_halo_c=self.metric_state_nonhydro.bdy_halo_c,
@@ -649,8 +687,8 @@ class SolveNonhydro:
                 exner=prognostic_state_ls[nnew].exner,
                 rd_o_cvd=self.params.rd_o_cvd,
                 rd_o_p0ref=self.params.rd_o_p0ref,
-                horizontal_start=0,
-                horizontal_end=end_cell_end,
+                horizontal_start=self._start_cell_local,
+                horizontal_end=self._end_cell_end,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -662,8 +700,8 @@ class SolveNonhydro:
                 exner=prognostic_state_ls[nnew].exner,
                 rd_o_cvd=self.params.rd_o_cvd,
                 rd_o_p0ref=self.params.rd_o_p0ref,
-                horizontal_start=start_cell_lateral_boundary,
-                horizontal_end=end_cell_lateral_boundary_level_4,
+                horizontal_start=self._start_cell_lateral_boundary,
+                horizontal_end=self._end_cell_lateral_boundary_level_4,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -678,8 +716,8 @@ class SolveNonhydro:
             rho_new=prognostic_state_ls[nnew].rho,
             theta_v_new=prognostic_state_ls[nnew].theta_v,
             cvd_o_rd=self.params.cvd_o_rd,
-            horizontal_start=start_cell_halo,
-            horizontal_end=end_cell_end,
+            horizontal_start=self._start_cell_halo,
+            horizontal_end=self._end_cell_end,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider={},
@@ -719,57 +757,6 @@ class SolveNonhydro:
                 cell_areas=self.cell_params.area,
             )
 
-        cell_domain = h_grid.domain(dims.CellDim)
-        edge_domain = h_grid.domain(dims.EdgeDim)
-        vertex_domain = h_grid.domain(dims.VertexDim)
-        end_cell_end = self.grid.end_index(cell_domain(h_grid.Zone.END))
-
-        cell_halo_level_2 = cell_domain(h_grid.Zone.HALO_LEVEL_2)
-        start_cell_halo_level_2 = self.grid.start_index(cell_halo_level_2)
-        end_cell_halo_level_2 = self.grid.end_index(cell_halo_level_2)
-
-        start_vertex_lateral_boundary_level_2 = self.grid.start_index(
-            vertex_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2)
-        )
-        end_vertex_halo = self.grid.end_index(vertex_domain(h_grid.Zone.HALO))
-
-        start_cell_lateral_boundary = self.grid.start_index(
-            cell_domain(h_grid.Zone.LATERAL_BOUNDARY)
-        )
-        end_cell_lateral_boundary_level_4 = self.grid.end_index(
-            cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_4)
-        )
-
-        start_edge_lateral_boundary_level_7 = self.grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_7)
-        )
-        end_edge_halo = self.grid.end_index(edge_domain(h_grid.Zone.HALO))
-        end_edge_local = self.grid.end_index(edge_domain(h_grid.Zone.LOCAL))
-
-        start_edge_nudging_level_2 = self.grid.start_index(edge_domain(h_grid.Zone.NUDGING_LEVEL_2))
-        end_edge_end = self.grid.end_index(edge_domain(h_grid.Zone.END))
-
-        start_edge_lateral_boundary = self.grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY)
-        )
-
-        end_edge_nudging = self.grid.end_index(edge_domain(h_grid.Zone.NUDGING))
-
-        start_edge_lateral_boundary_level_5 = self.grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5)
-        )
-        edge_halo_level_2 = edge_domain(h_grid.Zone.HALO_LEVEL_2)
-        start_edge_halo_level_2 = self.grid.start_index(edge_halo_level_2)
-        end_edge_halo_level_2 = self.grid.end_index(edge_halo_level_2)
-
-        start_cell_lateral_boundary_level_3 = self.grid.start_index(
-            cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_3)
-        )
-        end_cell_halo = self.grid.end_index(cell_domain(h_grid.Zone.HALO))
-        start_cell_nudging = self.grid.start_index(cell_domain(h_grid.Zone.NUDGING))
-
-        end_cell_local = self.grid.end_index(cell_domain(h_grid.Zone.LOCAL))
-
         #  Precompute Rayleigh damping factor
         solve_nh_utils.compute_z_raylfac(
             rayleigh_w=self.metric_state_nonhydro.rayleigh_w,
@@ -783,8 +770,8 @@ class SolveNonhydro:
             init_two_cell_kdim_fields_with_zero_vp(
                 cell_kdim_field_with_zero_vp_1=self.z_rth_pr_1,
                 cell_kdim_field_with_zero_vp_2=self.z_rth_pr_2,
-                horizontal_start=start_cell_lateral_boundary,
-                horizontal_end=end_cell_end,
+                horizontal_start=self._start_cell_lateral_boundary,
+                horizontal_end=self._end_cell_end,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -796,8 +783,8 @@ class SolveNonhydro:
             exner_ref_mc=self.metric_state_nonhydro.exner_ref_mc,
             exner_pr=diagnostic_state_nh.exner_pr,
             z_exner_ex_pr=self.z_exner_ex_pr,
-            horizontal_start=start_cell_lateral_boundary_level_3,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_3,
+            horizontal_end=self._end_cell_halo,
             k_field=self.k_field,
             nlev=self.grid.num_levels,
             vertical_start=0,
@@ -815,8 +802,8 @@ class SolveNonhydro:
                 z_dexner_dz_c_1=self.z_dexner_dz_c_1,
                 k_field=self.k_field,
                 nlev=self.grid.num_levels,
-                horizontal_start=start_cell_lateral_boundary_level_3,
-                horizontal_end=end_cell_halo,
+                horizontal_start=self._start_cell_lateral_boundary_level_3,
+                horizontal_end=self._end_cell_halo,
                 vertical_start=max(1, self.vertical_params.nflatlev),
                 vertical_end=self.grid.num_levels + 1,
                 offset_provider=self.grid.offset_providers,
@@ -844,8 +831,8 @@ class SolveNonhydro:
             z_th_ddz_exner_c=self.z_th_ddz_exner_c,
             k_field=self.k_field,
             nlev=self.grid.num_levels,
-            horizontal_start=start_cell_lateral_boundary_level_3,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_3,
+            horizontal_end=self._end_cell_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -860,8 +847,8 @@ class SolveNonhydro:
             theta_v_ic=diagnostic_state_nh.theta_v_ic,
             k_field=self.k_field,
             nlev=self.grid.num_levels,
-            horizontal_start=start_cell_lateral_boundary_level_3,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_3,
+            horizontal_end=self._end_cell_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels + 1,
             offset_provider=self.grid.offset_providers,
@@ -875,8 +862,8 @@ class SolveNonhydro:
                 d2dexdz2_fac2_mc=self.metric_state_nonhydro.d2dexdz2_fac2_mc,
                 z_rth_pr_2=self.z_rth_pr_2,
                 z_dexner_dz_c_2=self.z_dexner_dz_c_2,
-                horizontal_start=start_cell_lateral_boundary_level_3,
-                horizontal_end=end_cell_halo,
+                horizontal_start=self._start_cell_lateral_boundary_level_3,
+                horizontal_end=self._end_cell_halo,
                 vertical_start=self.vertical_params.nflat_gradp,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -892,8 +879,8 @@ class SolveNonhydro:
             theta_ref_mc=self.metric_state_nonhydro.theta_ref_mc,
             z_rth_pr_1=self.z_rth_pr_1,
             z_rth_pr_2=self.z_rth_pr_2,
-            horizontal_start=start_cell_halo_level_2,
-            horizontal_end=end_cell_halo_level_2,
+            horizontal_start=self._start_cell_halo_level_2,
+            horizontal_end=self._end_cell_halo_level_2,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider={},
@@ -905,8 +892,8 @@ class SolveNonhydro:
                 p_cell_in=prognostic_state[nnow].rho,
                 c_intp=self.interpolation_state.c_intp,
                 p_vert_out=self.z_rho_v,
-                horizontal_start=start_vertex_lateral_boundary_level_2,
-                horizontal_end=end_vertex_halo,
+                horizontal_start=self._start_vertex_lateral_boundary_level_2,
+                horizontal_end=self._end_vertex_halo,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,  # UBOUND(p_cell_in,2)
                 offset_provider=self.grid.offset_providers,
@@ -915,8 +902,8 @@ class SolveNonhydro:
                 p_cell_in=prognostic_state[nnow].theta_v,
                 c_intp=self.interpolation_state.c_intp,
                 p_vert_out=self.z_theta_v_v,
-                horizontal_start=start_vertex_lateral_boundary_level_2,
-                horizontal_end=end_vertex_halo,
+                horizontal_start=self._start_vertex_lateral_boundary_level_2,
+                horizontal_end=self._end_vertex_halo,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -932,8 +919,8 @@ class SolveNonhydro:
                 p_ccpr2=self.z_rth_pr_2,
                 geofac_grg_x=self.interpolation_state.geofac_grg_x,
                 geofac_grg_y=self.interpolation_state.geofac_grg_y,
-                horizontal_start=start_cell_lateral_boundary_level_3,
-                horizontal_end=end_cell_halo,
+                horizontal_start=self._start_cell_lateral_boundary_level_3,
+                horizontal_end=self._end_cell_halo,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,  # UBOUND(p_ccpr,2)
                 offset_provider=self.grid.offset_providers,
@@ -942,8 +929,8 @@ class SolveNonhydro:
             init_two_edge_kdim_fields_with_zero_wp(
                 edge_kdim_field_with_zero_wp_1=z_fields.z_rho_e,
                 edge_kdim_field_with_zero_wp_2=z_fields.z_theta_v_e,
-                horizontal_start=start_edge_halo_level_2,
-                horizontal_end=end_edge_halo_level_2,
+                horizontal_start=self._start_edge_halo_level_2,
+                horizontal_end=self._end_edge_halo_level_2,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -953,8 +940,8 @@ class SolveNonhydro:
                 init_two_edge_kdim_fields_with_zero_wp(
                     edge_kdim_field_with_zero_wp_1=z_fields.z_rho_e,
                     edge_kdim_field_with_zero_wp_2=z_fields.z_theta_v_e,
-                    horizontal_start=start_edge_lateral_boundary,
-                    horizontal_end=end_edge_halo,
+                    horizontal_start=self._start_edge_lateral_boundary,
+                    horizontal_end=self._end_edge_halo,
                     vertical_start=0,
                     vertical_end=self.grid.num_levels,
                     offset_provider={},
@@ -984,8 +971,8 @@ class SolveNonhydro:
                     z_rth_pr_2=self.z_rth_pr_2,
                     z_rho_e=z_fields.z_rho_e,
                     z_theta_v_e=z_fields.z_theta_v_e,
-                    horizontal_start=start_edge_lateral_boundary_level_7,
-                    horizontal_end=end_edge_halo,
+                    horizontal_start=self._start_edge_lateral_boundary_level_7,
+                    horizontal_end=self._end_edge_halo,
                     vertical_start=0,
                     vertical_end=self.grid.num_levels,
                     offset_provider=self.grid.offset_providers,
@@ -996,8 +983,8 @@ class SolveNonhydro:
             inv_dual_edge_length=self.edge_geometry.inverse_dual_edge_lengths,
             z_exner_ex_pr=self.z_exner_ex_pr,
             z_gradh_exner=z_fields.z_gradh_exner,
-            horizontal_start=start_edge_nudging_level_2,
-            horizontal_end=end_edge_local,
+            horizontal_start=self._start_edge_nudging_level_2,
+            horizontal_end=self._end_edge_local,
             vertical_start=0,
             vertical_end=self.vertical_params.nflatlev,
             offset_provider=self.grid.offset_providers,
@@ -1014,8 +1001,8 @@ class SolveNonhydro:
                 c_lin_e=self.interpolation_state.c_lin_e,
                 z_dexner_dz_c_1=self.z_dexner_dz_c_1,
                 z_gradh_exner=z_fields.z_gradh_exner,
-                horizontal_start=start_edge_nudging_level_2,
-                horizontal_end=end_edge_local,
+                horizontal_start=self._start_edge_nudging_level_2,
+                horizontal_end=self._end_edge_local,
                 vertical_start=self.vertical_params.nflatlev,
                 vertical_end=gtx.int32(self.vertical_params.nflat_gradp + 1),
                 offset_provider=self.grid.offset_providers,
@@ -1029,8 +1016,8 @@ class SolveNonhydro:
                 z_dexner_dz_c_1=self.z_dexner_dz_c_1,
                 z_dexner_dz_c_2=self.z_dexner_dz_c_2,
                 z_gradh_exner=z_fields.z_gradh_exner,
-                horizontal_start=start_edge_nudging_level_2,
-                horizontal_end=end_edge_local,
+                horizontal_start=self._start_edge_nudging_level_2,
+                horizontal_end=self._end_edge_local,
                 vertical_start=gtx.int32(self.vertical_params.nflat_gradp + 1),
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -1046,8 +1033,8 @@ class SolveNonhydro:
                 inv_dual_edge_length=self.edge_geometry.inverse_dual_edge_lengths,
                 z_hydro_corr=self.z_hydro_corr,
                 grav_o_cpd=self.params.grav_o_cpd,
-                horizontal_start=start_edge_nudging_level_2,
-                horizontal_end=end_edge_local,
+                horizontal_start=self._start_edge_nudging_level_2,
+                horizontal_end=self._end_edge_local,
                 vertical_start=self.grid.num_levels - 1,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -1064,8 +1051,8 @@ class SolveNonhydro:
                 pg_exdist=self.metric_state_nonhydro.pg_exdist,
                 z_hydro_corr=hydro_corr_horizontal,
                 z_gradh_exner=z_fields.z_gradh_exner,
-                horizontal_start=start_edge_nudging_level_2,
-                horizontal_end=end_edge_end,
+                horizontal_start=self._start_edge_nudging_level_2,
+                horizontal_end=self._end_edge_end,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -1080,8 +1067,8 @@ class SolveNonhydro:
             vn_nnew=prognostic_state[nnew].vn,
             dtime=dtime,
             cpd=constants.CPD,
-            horizontal_start=start_edge_nudging_level_2,
-            horizontal_end=end_edge_local,
+            horizontal_start=self._start_edge_nudging_level_2,
+            horizontal_end=self._end_edge_local,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider={},
@@ -1092,8 +1079,8 @@ class SolveNonhydro:
                 vn_incr=diagnostic_state_nh.vn_incr,
                 vn=prognostic_state[nnew].vn,
                 iau_wgt_dyn=self.config.iau_wgt_dyn,
-                horizontal_start=start_edge_nudging_level_2,
-                horizontal_end=end_edge_local,
+                horizontal_start=self._start_edge_nudging_level_2,
+                horizontal_end=self._end_edge_local,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -1105,8 +1092,8 @@ class SolveNonhydro:
                 vn_now=prognostic_state[nnow].vn,
                 vn_new=prognostic_state[nnew].vn,
                 dtime=dtime,
-                horizontal_start=start_edge_lateral_boundary,
-                horizontal_end=end_edge_nudging,
+                horizontal_start=self._start_edge_lateral_boundary,
+                horizontal_end=self._end_edge_nudging,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -1122,8 +1109,8 @@ class SolveNonhydro:
             z_vn_avg=self.z_vn_avg,
             z_graddiv_vn=z_fields.z_graddiv_vn,
             vt=diagnostic_state_nh.vt,
-            horizontal_start=start_edge_lateral_boundary_level_5,
-            horizontal_end=end_edge_halo_level_2,
+            horizontal_start=self._start_edge_lateral_boundary_level_5,
+            horizontal_end=self._end_edge_halo_level_2,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -1136,8 +1123,8 @@ class SolveNonhydro:
             z_theta_v_e=z_fields.z_theta_v_e,
             mass_fl_e=diagnostic_state_nh.mass_fl_e,
             z_theta_v_fl_e=self.z_theta_v_fl_e,
-            horizontal_start=start_edge_lateral_boundary_level_5,
-            horizontal_end=end_edge_halo_level_2,
+            horizontal_start=self._start_edge_lateral_boundary_level_5,
+            horizontal_end=self._end_edge_halo_level_2,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider={},
@@ -1155,8 +1142,8 @@ class SolveNonhydro:
             z_kin_hor_e=z_fields.z_kin_hor_e,
             k_field=self.k_field,
             nflatlev_startindex=self.vertical_params.nflatlev,
-            horizontal_start=start_edge_lateral_boundary_level_5,
-            horizontal_end=end_edge_halo_level_2,
+            horizontal_start=self._start_edge_lateral_boundary_level_5,
+            horizontal_end=self._end_edge_halo_level_2,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -1170,8 +1157,8 @@ class SolveNonhydro:
                 z_vt_ie=z_fields.z_vt_ie,
                 z_kin_hor_e=z_fields.z_kin_hor_e,
                 wgtfacq_e_dsl=self.metric_state_nonhydro.wgtfacq_e,
-                horizontal_start=start_edge_lateral_boundary_level_5,
-                horizontal_end=end_edge_halo_level_2,
+                horizontal_start=self._start_edge_lateral_boundary_level_5,
+                horizontal_end=self._end_edge_halo_level_2,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels + 1,
                 offset_provider=self.grid.offset_providers,
@@ -1186,8 +1173,8 @@ class SolveNonhydro:
             k_field=self.k_field,
             nflatlev_startindex_plus1=gtx.int32(self.vertical_params.nflatlev + 1),
             nlev=self.grid.num_levels,
-            horizontal_start=start_cell_lateral_boundary_level_3,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_3,
+            horizontal_end=self._end_cell_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels + 1,
             offset_provider=self.grid.offset_providers,
@@ -1199,8 +1186,8 @@ class SolveNonhydro:
             z_theta_v_fl_e=self.z_theta_v_fl_e,
             z_flxdiv_mass=self.z_flxdiv_mass,
             z_flxdiv_theta=self.z_flxdiv_theta,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -1230,8 +1217,8 @@ class SolveNonhydro:
             dtime=dtime,
             cpd=constants.CPD,
             nlev=self.grid.num_levels,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=0,
             vertical_end=self.grid.num_levels + 1,
             offset_provider={},
@@ -1241,8 +1228,8 @@ class SolveNonhydro:
             init_two_cell_kdim_fields_with_zero_wp(
                 cell_kdim_field_with_zero_wp_1=prognostic_state[nnew].w,
                 cell_kdim_field_with_zero_wp_2=z_fields.z_contr_w_fl_l,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=0,
                 vertical_end=1,
                 offset_provider={},
@@ -1264,8 +1251,8 @@ class SolveNonhydro:
             k_field=self.k_field,
             dtime=dtime,
             nlev=self.grid.num_levels,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=0,
             vertical_end=self.grid.num_levels + 1,
             offset_provider=self.grid.offset_providers,
@@ -1278,8 +1265,8 @@ class SolveNonhydro:
                 diagnostic_state_nh.rho_incr,
                 diagnostic_state_nh.exner_incr,
                 self.config.iau_wgt_dyn,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -1297,8 +1284,8 @@ class SolveNonhydro:
             w=prognostic_state[nnew].w,
             dtime=dtime,
             cpd=constants.CPD,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=1,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -1307,8 +1294,8 @@ class SolveNonhydro:
         solve_tridiagonal_matrix_for_w_back_substitution(
             z_q=z_fields.z_q,
             w=prognostic_state[nnew].w,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=1,
             vertical_end=self.grid.num_levels,
             offset_provider={},
@@ -1319,8 +1306,8 @@ class SolveNonhydro:
                 z_raylfac=self.z_raylfac,
                 w_1=prognostic_state[nnew].w_1,
                 w=prognostic_state[nnew].w,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=1,
                 vertical_end=gtx.int32(
                     self.vertical_params.end_index_of_damping_layer + 1
@@ -1346,8 +1333,8 @@ class SolveNonhydro:
             theta_v_new=prognostic_state[nnew].theta_v,
             dtime=dtime,
             cvd_o_rd=constants.CVD_O_RD,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=gtx.int32(self.jk_start),
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -1360,8 +1347,8 @@ class SolveNonhydro:
                 w=prognostic_state[nnew].w,
                 w_concorr_c=diagnostic_state_nh.w_concorr_c,
                 z_dwdz_dd=z_fields.z_dwdz_dd,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=self.params.kstart_dd3d,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -1371,8 +1358,8 @@ class SolveNonhydro:
             copy_cell_kdim_field_to_vp(
                 field=prognostic_state[nnow].exner,
                 field_copy=diagnostic_state_nh.exner_dyn_incr,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=self.vertical_params.kstart_moist,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -1392,8 +1379,8 @@ class SolveNonhydro:
                 k_field=self.k_field,
                 dtime=dtime,
                 nlev=self.grid.num_levels,
-                horizontal_start=start_cell_lateral_boundary,
-                horizontal_end=end_cell_lateral_boundary_level_4,
+                horizontal_start=self._start_cell_lateral_boundary,
+                horizontal_end=self._end_cell_lateral_boundary_level_4,
                 vertical_start=0,
                 vertical_end=gtx.int32(self.grid.num_levels + 1),
                 offset_provider={},
@@ -1405,8 +1392,8 @@ class SolveNonhydro:
                 w=prognostic_state[nnew].w,
                 w_concorr_c=diagnostic_state_nh.w_concorr_c,
                 z_dwdz_dd=z_fields.z_dwdz_dd,
-                horizontal_start=start_cell_lateral_boundary,
-                horizontal_end=end_cell_lateral_boundary_level_4,
+                horizontal_start=self._start_cell_lateral_boundary,
+                horizontal_end=self._end_cell_lateral_boundary_level_4,
                 vertical_start=self.params.kstart_dd3d,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -1434,7 +1421,8 @@ class SolveNonhydro:
         at_last_substep: bool,
     ):
         log.info(
-            f"running corrector step: dtime = {dtime}, prep_adv = {lprep_adv},  divdamp_fac_o2 = {divdamp_fac_o2} clean_mfxl= {lclean_mflx}  "
+            f"running corrector step: dtime = {dtime}, prep_adv = {lprep_adv},  "
+            f"divdamp_fac_o2 = {divdamp_fac_o2} clean_mfxl= {lclean_mflx}  "
         )
 
         # TODO (magdalena) is it correct to to use a config parameter here? the actual number of substeps can vary dynmically...
@@ -1457,38 +1445,6 @@ class SolveNonhydro:
             out=(self.scal_divdamp, self._bdy_divdamp),
             offset_provider={},
         )
-
-        cell_domain = h_grid.domain(dims.CellDim)
-        edge_domain = h_grid.domain(dims.EdgeDim)
-        start_cell_lateral_boundary_level_3 = self.grid.start_index(
-            cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_3)
-        )
-
-        start_edge_lateral_boundary_level_7 = self.grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_7)
-        )
-
-        start_edge_nudging_level_2 = self.grid.start_index(edge_domain(h_grid.Zone.NUDGING_LEVEL_2))
-        end_edge_local = self.grid.end_index(edge_domain(h_grid.Zone.LOCAL))
-
-        start_edge_lateral_boundary_level_5 = self.grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5)
-        )
-        end_edge_halo_level_2 = self.grid.end_index(edge_domain(h_grid.Zone.HALO_LEVEL_2))
-
-        start_edge_lateral_boundary = self.grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY)
-        )
-        end_edge_end = self.grid.end_index(edge_domain(h_grid.Zone.END))
-
-        start_cell_lateral_boundary = self.grid.start_index(
-            cell_domain(h_grid.Zone.LATERAL_BOUNDARY)
-        )
-        cell_nudging = cell_domain(h_grid.Zone.NUDGING)
-        end_cell_nudging = self.grid.end_index(cell_nudging)
-
-        start_cell_nudging = self.grid.start_index(cell_nudging)
-        end_cell_local = self.grid.end_index(cell_domain(h_grid.Zone.LOCAL))
 
         lvn_only = False
         log.debug(f"corrector run velocity advection")
@@ -1532,8 +1488,8 @@ class SolveNonhydro:
             dtime=dtime,
             wgt_nnow_rth=self.params.wgt_nnow_rth,
             wgt_nnew_rth=self.params.wgt_nnew_rth,
-            horizontal_start=start_cell_lateral_boundary_level_3,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_lateral_boundary_level_3,
+            horizontal_end=self._end_cell_local,
             vertical_start=1,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -1546,8 +1502,8 @@ class SolveNonhydro:
             inv_dual_edge_length=self.edge_geometry.inverse_dual_edge_lengths,
             z_dwdz_dd=z_fields.z_dwdz_dd,
             z_graddiv_vn=z_fields.z_graddiv_vn,
-            horizontal_start=start_edge_lateral_boundary_level_7,
-            horizontal_end=end_edge_halo_level_2,
+            horizontal_start=self._start_edge_lateral_boundary_level_7,
+            horizontal_end=self._end_edge_halo_level_2,
             vertical_start=self.params.kstart_dd3d,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -1567,8 +1523,8 @@ class SolveNonhydro:
                 wgt_nnow_vel=self.params.wgt_nnow_vel,
                 wgt_nnew_vel=self.params.wgt_nnew_vel,
                 cpd=constants.CPD,
-                horizontal_start=start_edge_nudging_level_2,
-                horizontal_end=end_edge_local,
+                horizontal_start=self._start_edge_nudging_level_2,
+                horizontal_end=self._end_edge_local,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -1584,8 +1540,8 @@ class SolveNonhydro:
                 geofac_grdiv=self.interpolation_state.geofac_grdiv,
                 z_graddiv_vn=z_fields.z_graddiv_vn,
                 z_graddiv2_vn=self.z_graddiv2_vn,
-                horizontal_start=start_edge_nudging_level_2,
-                horizontal_end=end_edge_local,
+                horizontal_start=self._start_edge_nudging_level_2,
+                horizontal_end=self._end_edge_local,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -1600,8 +1556,8 @@ class SolveNonhydro:
                 z_graddiv_vn=z_fields.z_graddiv_vn,
                 vn=prognostic_state[nnew].vn,
                 scal_divdamp_o2=scal_divdamp_o2,
-                horizontal_start=start_edge_nudging_level_2,
-                horizontal_end=end_edge_local,
+                horizontal_start=self._start_edge_nudging_level_2,
+                horizontal_end=self._end_edge_local,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -1620,8 +1576,8 @@ class SolveNonhydro:
                     nudgecoeff_e=self.interpolation_state.nudgecoeff_e,
                     z_graddiv2_vn=self.z_graddiv2_vn,
                     vn=prognostic_state[nnew].vn,
-                    horizontal_start=start_edge_nudging_level_2,
-                    horizontal_end=end_edge_local,
+                    horizontal_start=self._start_edge_nudging_level_2,
+                    horizontal_end=self._end_edge_local,
                     vertical_start=0,
                     vertical_end=self.grid.num_levels,
                     offset_provider={},
@@ -1632,8 +1588,8 @@ class SolveNonhydro:
                     scal_divdamp=self.scal_divdamp,
                     z_graddiv2_vn=self.z_graddiv2_vn,
                     vn=prognostic_state[nnew].vn,
-                    horizontal_start=start_edge_nudging_level_2,
-                    horizontal_end=end_edge_local,
+                    horizontal_start=self._start_edge_nudging_level_2,
+                    horizontal_end=self._end_edge_local,
                     vertical_start=0,
                     vertical_end=self.grid.num_levels,
                     offset_provider={},
@@ -1646,8 +1602,8 @@ class SolveNonhydro:
                 diagnostic_state_nh.vn_incr,
                 prognostic_state[nnew].vn,
                 self.config.iau_wgt_dyn,
-                horizontal_start=start_edge_nudging_level_2,
-                horizontal_end=end_edge_local,
+                horizontal_start=self._start_edge_nudging_level_2,
+                horizontal_end=self._end_edge_local,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -1659,8 +1615,8 @@ class SolveNonhydro:
             e_flx_avg=self.interpolation_state.e_flx_avg,
             vn=prognostic_state[nnew].vn,
             z_vn_avg=self.z_vn_avg,
-            horizontal_start=start_edge_lateral_boundary_level_5,
-            horizontal_end=end_edge_halo_level_2,
+            horizontal_start=self._start_edge_lateral_boundary_level_5,
+            horizontal_end=self._end_edge_halo_level_2,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -1674,8 +1630,8 @@ class SolveNonhydro:
             z_theta_v_e=z_fields.z_theta_v_e,
             mass_fl_e=diagnostic_state_nh.mass_fl_e,
             z_theta_v_fl_e=self.z_theta_v_fl_e,
-            horizontal_start=start_edge_lateral_boundary_level_5,
-            horizontal_end=end_edge_halo_level_2,
+            horizontal_start=self._start_edge_lateral_boundary_level_5,
+            horizontal_end=self._end_edge_halo_level_2,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider={},
@@ -1688,8 +1644,8 @@ class SolveNonhydro:
                 init_two_edge_kdim_fields_with_zero_wp(
                     edge_kdim_field_with_zero_wp_1=prep_adv.vn_traj,
                     edge_kdim_field_with_zero_wp_2=prep_adv.mass_flx_me,
-                    horizontal_start=start_edge_lateral_boundary,
-                    horizontal_end=end_edge_end,
+                    horizontal_start=self._start_edge_lateral_boundary,
+                    horizontal_end=self._end_edge_end,
                     vertical_start=0,
                     vertical_end=self.grid.num_levels,
                     offset_provider={},
@@ -1701,8 +1657,8 @@ class SolveNonhydro:
                 vn_traj=prep_adv.vn_traj,
                 mass_flx_me=prep_adv.mass_flx_me,
                 r_nsubsteps=r_nsubsteps,
-                horizontal_start=start_edge_lateral_boundary_level_5,
-                horizontal_end=end_edge_halo_level_2,
+                horizontal_start=self._start_edge_lateral_boundary_level_5,
+                horizontal_end=self._end_edge_halo_level_2,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -1716,8 +1672,8 @@ class SolveNonhydro:
             z_theta_v_fl_e=self.z_theta_v_fl_e,
             z_flxdiv_mass=self.z_flxdiv_mass,
             z_flxdiv_theta=self.z_flxdiv_theta,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -1752,8 +1708,8 @@ class SolveNonhydro:
                 wgt_nnow_vel=self.params.wgt_nnow_vel,
                 wgt_nnew_vel=self.params.wgt_nnew_vel,
                 nlev=self.grid.num_levels,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels + 1,
                 offset_provider={},
@@ -1784,8 +1740,8 @@ class SolveNonhydro:
                 dtime=dtime,
                 cpd=constants.CPD,
                 nlev=self.grid.num_levels,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels + 1,
                 offset_provider={},
@@ -1794,8 +1750,8 @@ class SolveNonhydro:
             init_two_cell_kdim_fields_with_zero_wp(
                 cell_kdim_field_with_zero_wp_1=prognostic_state[nnew].w,
                 cell_kdim_field_with_zero_wp_2=z_fields.z_contr_w_fl_l,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=0,
                 vertical_end=0,
                 offset_provider={},
@@ -1819,8 +1775,8 @@ class SolveNonhydro:
             k_field=self.k_field,
             dtime=dtime,
             nlev=self.grid.num_levels,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=0,
             vertical_end=self.grid.num_levels + 1,
             offset_provider=self.grid.offset_providers,
@@ -1835,8 +1791,8 @@ class SolveNonhydro:
                 rho_incr=diagnostic_state_nh.rho_incr,
                 exner_incr=diagnostic_state_nh.exner_incr,
                 iau_wgt_dyn=self.config.iau_wgt_dyn,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},
@@ -1854,8 +1810,8 @@ class SolveNonhydro:
             w=prognostic_state[nnew].w,
             dtime=dtime,
             cpd=constants.CPD,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=1,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -1864,8 +1820,8 @@ class SolveNonhydro:
         solve_tridiagonal_matrix_for_w_back_substitution(
             z_q=z_fields.z_q,
             w=prognostic_state[nnew].w,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=1,
             vertical_end=self.grid.num_levels,
             offset_provider={},
@@ -1877,8 +1833,8 @@ class SolveNonhydro:
                 z_raylfac=self.z_raylfac,
                 w_1=prognostic_state[nnew].w_1,
                 w=prognostic_state[nnew].w,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=1,
                 vertical_end=gtx.int32(
                     self.vertical_params.end_index_of_damping_layer + 1
@@ -1904,8 +1860,8 @@ class SolveNonhydro:
             theta_v_new=prognostic_state[nnew].theta_v,
             dtime=dtime,
             cvd_o_rd=constants.CVD_O_RD,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=gtx.int32(self.jk_start),
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -1917,8 +1873,8 @@ class SolveNonhydro:
                 init_two_cell_kdim_fields_with_zero_wp(
                     prep_adv.mass_flx_ic,
                     prep_adv.vol_flx_ic,
-                    horizontal_start=start_cell_nudging,
-                    horizontal_end=end_cell_local,
+                    horizontal_start=self._start_cell_nudging,
+                    horizontal_end=self._end_cell_local,
                     vertical_start=0,
                     vertical_end=self.grid.num_levels,
                     offset_provider={},
@@ -1932,8 +1888,8 @@ class SolveNonhydro:
             mass_flx_ic=prep_adv.mass_flx_ic,
             vol_flx_ic=prep_adv.vol_flx_ic,
             r_nsubsteps=r_nsubsteps,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=1,
             vertical_end=self.grid.num_levels,
             offset_provider={},
@@ -1945,8 +1901,8 @@ class SolveNonhydro:
                 exner_dyn_incr=diagnostic_state_nh.exner_dyn_incr,
                 ndyn_substeps_var=float(self.config.ndyn_substeps_var),
                 dtime=dtime,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=self.vertical_params.kstart_moist,
                 vertical_end=gtx.int32(self.grid.num_levels),
                 offset_provider={},
@@ -1957,8 +1913,8 @@ class SolveNonhydro:
                 log.debug(f"corrector set prep_adv.mass_flx_ic to zero")
                 init_cell_kdim_field_with_zero_wp(
                     field_with_zero_wp=prep_adv.mass_flx_ic,
-                    horizontal_start=start_cell_lateral_boundary,
-                    horizontal_end=end_cell_nudging,
+                    horizontal_start=self._start_cell_lateral_boundary,
+                    horizontal_end=self._end_cell_nudging,
                     vertical_start=0,
                     vertical_end=self.grid.num_levels + 1,
                     offset_provider={},
@@ -1973,8 +1929,8 @@ class SolveNonhydro:
                 w_concorr_c=diagnostic_state_nh.w_concorr_c,
                 mass_flx_ic=prep_adv.mass_flx_ic,
                 r_nsubsteps=r_nsubsteps,
-                horizontal_start=start_cell_lateral_boundary,
-                horizontal_end=end_cell_nudging,
+                horizontal_start=self._start_cell_lateral_boundary,
+                horizontal_end=self._end_cell_nudging,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider={},

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity/velocity_advection.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity/velocity_advection.py
@@ -70,6 +70,7 @@ class VelocityAdvection:
         self.cfl_w_limit: float = 0.65
         self.scalfac_exdiff: float = 0.05
         self._allocate_local_fields()
+        self._determine_local_domains()
 
         self._initialized = True
 
@@ -100,6 +101,39 @@ class VelocityAdvection:
         self.vcfl_dsl = field_alloc.allocate_zero_field(dims.CellDim, dims.KDim, grid=self.grid)
         self.k_field = field_alloc.allocate_indices(dims.KDim, grid=self.grid, is_halfdim=True)
 
+    def _determine_local_domains(self):
+        vertex_domain = h_grid.domain(dims.VertexDim)
+        edge_domain = h_grid.domain(dims.EdgeDim)
+        cell_domain = h_grid.domain(dims.CellDim)
+        self._start_vertex_lateral_boundary_level_2 = self.grid.start_index(
+            vertex_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2)
+        )
+        self._end_vertex_halo = self.grid.end_index(vertex_domain(h_grid.Zone.HALO))
+
+        self._start_edge_lateral_boundary_level_5 = self.grid.start_index(
+            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5)
+        )
+        self._start_edge_lateral_boundary_level_7 = self.grid.start_index(
+            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_7)
+        )
+        self._start_edge_nudging_level_2 = self.grid.start_index(
+            edge_domain(h_grid.Zone.NUDGING_LEVEL_2)
+        )
+
+        self._end_edge_local = self.grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+        self._end_edge_halo = self.grid.end_index(edge_domain(h_grid.Zone.HALO))
+        self._end_edge_halo_level_2 = self.grid.end_index(edge_domain(h_grid.Zone.HALO_LEVEL_2))
+
+        self._start_cell_lateral_boundary_level_3 = self.grid.start_index(
+            cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_3)
+        )
+        self._start_cell_lateral_boundary_level_4 = self.grid.start_index(
+            cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_4)
+        )
+        self._start_cell_nudging = self.grid.start_index(cell_domain(h_grid.Zone.NUDGING))
+        self._end_cell_local = self.grid.end_index(cell_domain(h_grid.Zone.LOCAL))
+        self._end_cell_halo = self.grid.end_index(cell_domain(h_grid.Zone.HALO))
+
     def run_predictor_step(
         self,
         vn_only: bool,
@@ -113,40 +147,14 @@ class VelocityAdvection:
         cell_areas: fa.CellField[float],
     ):
         cfl_w_limit, scalfac_exdiff = self._scale_factors_by_dtime(dtime)
-        vertex_domain = h_grid.domain(dims.VertexDim)
-        edge_domain = h_grid.domain(dims.EdgeDim)
-        cell_domain = h_grid.domain(dims.CellDim)
-        start_vertex_lateral_boundary_level_2 = self.grid.start_index(
-            vertex_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2)
-        )
-        end_vertex_halo = self.grid.end_index(vertex_domain(h_grid.Zone.HALO))
-
-        start_edge_lateral_boundary_level_5 = self.grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5)
-        )
-        start_edge_lateral_boundary_level_7 = self.grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_7)
-        )
-        start_edge_nudging_level_2 = self.grid.start_index(edge_domain(h_grid.Zone.NUDGING_LEVEL_2))
-        end_edge_local = self.grid.end_index(edge_domain(h_grid.Zone.LOCAL))
-
-        end_edge_halo = self.grid.end_index(edge_domain(h_grid.Zone.HALO))
-        end_edge_halo_level_2 = self.grid.end_index(edge_domain(h_grid.Zone.HALO_LEVEL_2))
-
-        start_cell_lateral_boundary_level_4 = self.grid.start_index(
-            cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_4)
-        )
-        start_cell_nudging = self.grid.start_index(cell_domain(h_grid.Zone.NUDGING))
-        end_cell_local = self.grid.end_index(cell_domain(h_grid.Zone.LOCAL))
-        end_cell_halo = self.grid.end_index(cell_domain(h_grid.Zone.HALO))
 
         if not vn_only:
             mo_icon_interpolation_scalar_cells2verts_scalar_ri_dsl(
                 p_cell_in=prognostic_state.w,
                 c_intp=self.interpolation_state.c_intp,
                 p_vert_out=self.z_w_v,
-                horizontal_start=start_vertex_lateral_boundary_level_2,
-                horizontal_end=end_vertex_halo,
+                horizontal_start=self._start_vertex_lateral_boundary_level_2,
+                horizontal_end=self._end_vertex_halo,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -156,8 +164,8 @@ class VelocityAdvection:
             vec_e=prognostic_state.vn,
             geofac_rot=self.interpolation_state.geofac_rot,
             rot_vec=self.zeta,
-            horizontal_start=start_vertex_lateral_boundary_level_2,
-            horizontal_end=end_vertex_halo,
+            horizontal_start=self._start_vertex_lateral_boundary_level_2,
+            horizontal_end=self._end_vertex_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -167,8 +175,8 @@ class VelocityAdvection:
             vn=prognostic_state.vn,
             rbf_vec_coeff_e=self.interpolation_state.rbf_vec_coeff_e,
             vt=diagnostic_state.vt,
-            horizontal_start=start_edge_lateral_boundary_level_5,
-            horizontal_end=end_edge_halo_level_2,
+            horizontal_start=self._start_edge_lateral_boundary_level_5,
+            horizontal_end=self._end_edge_halo_level_2,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -180,8 +188,8 @@ class VelocityAdvection:
             vt=diagnostic_state.vt,
             vn_ie=diagnostic_state.vn_ie,
             z_kin_hor_e=z_kin_hor_e,
-            horizontal_start=start_edge_lateral_boundary_level_5,
-            horizontal_end=end_edge_halo_level_2,
+            horizontal_start=self._start_edge_lateral_boundary_level_5,
+            horizontal_end=self._end_edge_halo_level_2,
             vertical_start=1,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -192,8 +200,8 @@ class VelocityAdvection:
                 wgtfac_e=self.metric_state.wgtfac_e,
                 vt=diagnostic_state.vt,
                 z_vt_ie=z_vt_ie,
-                horizontal_start=start_edge_lateral_boundary_level_5,
-                horizontal_end=end_edge_halo_level_2,
+                horizontal_start=self._start_edge_lateral_boundary_level_5,
+                horizontal_end=self._end_edge_halo_level_2,
                 vertical_start=1,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -211,8 +219,8 @@ class VelocityAdvection:
             k_field=self.k_field,
             nflatlev_startindex=self.vertical_params.nflatlev,
             nlev=self.grid.num_levels,
-            horizontal_start=start_edge_lateral_boundary_level_5,
-            horizontal_end=end_edge_halo_level_2,
+            horizontal_start=self._start_edge_lateral_boundary_level_5,
+            horizontal_end=self._end_edge_halo_level_2,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider={},
@@ -221,8 +229,8 @@ class VelocityAdvection:
             wgtfacq_e=self.metric_state.wgtfacq_e,
             vn=prognostic_state.vn,
             vn_ie=diagnostic_state.vn_ie,
-            horizontal_start=start_edge_lateral_boundary_level_5,
-            horizontal_end=end_edge_halo_level_2,
+            horizontal_start=self._start_edge_lateral_boundary_level_5,
+            horizontal_end=self._end_edge_halo_level_2,
             vertical_start=self.grid.num_levels,
             vertical_end=self.grid.num_levels + 1,
             offset_provider=self.grid.offset_providers,
@@ -238,8 +246,8 @@ class VelocityAdvection:
                 tangent_orientation=self.edge_params.tangent_orientation,
                 z_w_v=self.z_w_v,
                 z_v_grad_w=self.z_v_grad_w,
-                horizontal_start=start_edge_lateral_boundary_level_7,
-                horizontal_end=end_edge_halo,
+                horizontal_start=self._start_edge_lateral_boundary_level_7,
+                horizontal_end=self._end_edge_halo,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -249,8 +257,8 @@ class VelocityAdvection:
             interpolant=z_kin_hor_e,
             e_bln_c_s=self.interpolation_state.e_bln_c_s,
             interpolation=self.z_ekinh,
-            horizontal_start=start_cell_lateral_boundary_level_4,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_4,
+            horizontal_end=self._end_cell_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -265,8 +273,8 @@ class VelocityAdvection:
             k_field=self.k_field,
             nflatlev_startindex=self.vertical_params.nflatlev,
             nlev=self.grid.num_levels,
-            horizontal_start=start_cell_lateral_boundary_level_4,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_4,
+            horizontal_end=self._end_cell_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -279,8 +287,8 @@ class VelocityAdvection:
             k_field=self.k_field,
             nflatlev_startindex=self.vertical_params.nflatlev,
             nlev=self.grid.num_levels,
-            horizontal_start=start_cell_lateral_boundary_level_4,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_4,
+            horizontal_end=self._end_cell_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels + 1,
             offset_provider={},
@@ -293,8 +301,8 @@ class VelocityAdvection:
             local_vcfl=self.vcfl_dsl,
             cfl_w_limit=cfl_w_limit,
             dtime=dtime,
-            horizontal_start=start_cell_lateral_boundary_level_4,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_4,
+            horizontal_end=self._end_cell_halo,
             vertical_start=gtx.int32(
                 max(3, self.vertical_params.end_index_of_damping_layer - 2) - 1
             ),
@@ -307,8 +315,8 @@ class VelocityAdvection:
         interpolate_contravariant_vertical_velocity_to_full_levels(
             z_w_con_c=self.z_w_con_c,
             z_w_con_c_full=self.z_w_con_c_full,
-            horizontal_start=start_cell_lateral_boundary_level_4,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_4,
+            horizontal_end=self._end_cell_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -323,8 +331,8 @@ class VelocityAdvection:
                 coeff1_dwdz=self.metric_state.coeff1_dwdz,
                 coeff2_dwdz=self.metric_state.coeff2_dwdz,
                 ddt_w_adv=diagnostic_state.ddt_w_adv_pc[ntnd],
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=1,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -343,8 +351,8 @@ class VelocityAdvection:
                 scalfac_exdiff=scalfac_exdiff,
                 cfl_w_limit=cfl_w_limit,
                 dtime=dtime,
-                horizontal_start=start_cell_nudging,
-                horizontal_end=end_cell_local,
+                horizontal_start=self._start_cell_nudging,
+                horizontal_end=self._end_cell_local,
                 vertical_start=gtx.int32(
                     max(3, self.vertical_params.end_index_of_damping_layer - 2) - 1
                 ),
@@ -366,8 +374,8 @@ class VelocityAdvection:
             vn_ie=diagnostic_state.vn_ie,
             ddqz_z_full_e=self.metric_state.ddqz_z_full_e,
             ddt_vn_apc=diagnostic_state.ddt_vn_apc_pc[ntnd],
-            horizontal_start=start_edge_nudging_level_2,
-            horizontal_end=end_edge_local,
+            horizontal_start=self._start_edge_nudging_level_2,
+            horizontal_end=self._end_edge_local,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -388,8 +396,8 @@ class VelocityAdvection:
             cfl_w_limit=cfl_w_limit,
             scalfac_exdiff=scalfac_exdiff,
             dtime=dtime,
-            horizontal_start=start_edge_nudging_level_2,
-            horizontal_end=end_edge_local,
+            horizontal_start=self._start_edge_nudging_level_2,
+            horizontal_end=self._end_edge_local,
             vertical_start=gtx.int32(
                 max(3, self.vertical_params.end_index_of_damping_layer - 2) - 1
             ),
@@ -420,35 +428,13 @@ class VelocityAdvection:
     ):
         cfl_w_limit, scalfac_exdiff = self._scale_factors_by_dtime(dtime)
 
-        vertex_domain = h_grid.domain(dims.VertexDim)
-        edge_domain = h_grid.domain(dims.EdgeDim)
-        cell_domain = h_grid.domain(dims.CellDim)
-        start_vertex_lateral_boundary_level_2 = self.grid.start_index(
-            vertex_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2)
-        )
-        end_vertex_halo = self.grid.end_index(vertex_domain(h_grid.Zone.HALO))
-        start_edge_lateral_boundary_level_7 = self.grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_7)
-        )
-        start_edge_nudging_level_2 = self.grid.start_index(edge_domain(h_grid.Zone.NUDGING_LEVEL_2))
-        end_edge_local = self.grid.end_index(edge_domain(h_grid.Zone.LOCAL))
-        end_edge_halo = self.grid.end_index(edge_domain(h_grid.Zone.HALO))
-
-        start_cell_lateral_boundary_level_3 = self.grid.start_index(
-            cell_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_4)
-        )
-
-        start_cell_nudging = self.grid.start_index(cell_domain(h_grid.Zone.NUDGING))
-        end_cell_local = self.grid.end_index(cell_domain(h_grid.Zone.LOCAL))
-        end_cell_halo = self.grid.end_index(cell_domain(h_grid.Zone.HALO))
-
         if not vn_only:
             mo_icon_interpolation_scalar_cells2verts_scalar_ri_dsl(
                 p_cell_in=prognostic_state.w,
                 c_intp=self.interpolation_state.c_intp,
                 p_vert_out=self.z_w_v,
-                horizontal_start=start_vertex_lateral_boundary_level_2,
-                horizontal_end=end_vertex_halo,
+                horizontal_start=self._start_vertex_lateral_boundary_level_2,
+                horizontal_end=self._end_vertex_halo,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -458,8 +444,8 @@ class VelocityAdvection:
             vec_e=prognostic_state.vn,
             geofac_rot=self.interpolation_state.geofac_rot,
             rot_vec=self.zeta,
-            horizontal_start=start_vertex_lateral_boundary_level_2,
-            horizontal_end=end_vertex_halo,
+            horizontal_start=self._start_vertex_lateral_boundary_level_2,
+            horizontal_end=self._end_vertex_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -475,8 +461,8 @@ class VelocityAdvection:
                 tangent_orientation=self.edge_params.tangent_orientation,
                 z_w_v=self.z_w_v,
                 z_v_grad_w=self.z_v_grad_w,
-                horizontal_start=start_edge_lateral_boundary_level_7,
-                horizontal_end=end_edge_halo,
+                horizontal_start=self._start_edge_lateral_boundary_level_7,
+                horizontal_end=self._end_edge_halo,
                 vertical_start=0,
                 vertical_end=self.grid.num_levels,
                 offset_provider=self.grid.offset_providers,
@@ -486,8 +472,8 @@ class VelocityAdvection:
             interpolant=z_kin_hor_e,
             e_bln_c_s=self.interpolation_state.e_bln_c_s,
             interpolation=self.z_ekinh,
-            horizontal_start=start_cell_lateral_boundary_level_3,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_3,
+            horizontal_end=self._end_cell_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -500,8 +486,8 @@ class VelocityAdvection:
             k_field=self.k_field,
             nflatlev_startindex=self.vertical_params.nflatlev,
             nlev=self.grid.num_levels,
-            horizontal_start=start_cell_lateral_boundary_level_3,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_3,
+            horizontal_end=self._end_cell_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider={},
@@ -514,8 +500,8 @@ class VelocityAdvection:
             local_vcfl=self.vcfl_dsl,
             cfl_w_limit=cfl_w_limit,
             dtime=dtime,
-            horizontal_start=start_cell_lateral_boundary_level_3,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_3,
+            horizontal_end=self._end_cell_halo,
             vertical_start=gtx.int32(max(3, self.vertical_params.end_index_of_damping_layer - 2)),
             vertical_end=gtx.int32(self.grid.num_levels - 3),
             offset_provider={},
@@ -526,8 +512,8 @@ class VelocityAdvection:
         interpolate_contravariant_vertical_velocity_to_full_levels(
             z_w_con_c=self.z_w_con_c,
             z_w_con_c_full=self.z_w_con_c_full,
-            horizontal_start=start_cell_lateral_boundary_level_3,
-            horizontal_end=end_cell_halo,
+            horizontal_start=self._start_cell_lateral_boundary_level_3,
+            horizontal_end=self._end_cell_halo,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -541,8 +527,8 @@ class VelocityAdvection:
             coeff1_dwdz=self.metric_state.coeff1_dwdz,
             coeff2_dwdz=self.metric_state.coeff2_dwdz,
             ddt_w_adv=diagnostic_state.ddt_w_adv_pc[ntnd],
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=1,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -561,8 +547,8 @@ class VelocityAdvection:
             scalfac_exdiff=scalfac_exdiff,
             cfl_w_limit=cfl_w_limit,
             dtime=dtime,
-            horizontal_start=start_cell_nudging,
-            horizontal_end=end_cell_local,
+            horizontal_start=self._start_cell_nudging,
+            horizontal_end=self._end_cell_local,
             vertical_start=gtx.int32(max(3, self.vertical_params.end_index_of_damping_layer - 2)),
             vertical_end=gtx.int32(self.grid.num_levels - 4),
             offset_provider=self.grid.offset_providers,
@@ -583,8 +569,8 @@ class VelocityAdvection:
             vn_ie=diagnostic_state.vn_ie,
             ddqz_z_full_e=self.metric_state.ddqz_z_full_e,
             ddt_vn_apc=diagnostic_state.ddt_vn_apc_pc[ntnd],
-            horizontal_start=start_edge_nudging_level_2,
-            horizontal_end=end_edge_local,
+            horizontal_start=self._start_edge_nudging_level_2,
+            horizontal_end=self._end_edge_local,
             vertical_start=0,
             vertical_end=self.grid.num_levels,
             offset_provider=self.grid.offset_providers,
@@ -605,8 +591,8 @@ class VelocityAdvection:
             cfl_w_limit=cfl_w_limit,
             scalfac_exdiff=scalfac_exdiff,
             dtime=dtime,
-            horizontal_start=start_edge_nudging_level_2,
-            horizontal_end=end_edge_local,
+            horizontal_start=self._start_edge_nudging_level_2,
+            horizontal_end=self._end_edge_local,
             vertical_start=gtx.int32(max(3, self.vertical_params.end_index_of_damping_layer - 2)),
             vertical_end=gtx.int32(self.grid.num_levels - 4),
             offset_provider=self.grid.offset_providers,

--- a/model/atmosphere/dycore/tests/dycore_tests/test_solve_nonhydro.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/test_solve_nonhydro.py
@@ -953,7 +953,7 @@ def test_run_solve_nonhydro_multi_step(
         h_grid.domain(dims.CellDim)(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_3)
     )
     edge_start_lb_plus4 = icon_grid.start_index(
-        h_grid.comain(dims.EdgeDim)(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5)
+        h_grid.domain(dims.EdgeDim)(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5)
     )
 
     assert helpers.dallclose(


### PR DESCRIPTION
Spill over from this [PR](https://github.com/C2SM/icon4py/pull/531): pushed all grid start and end index resolution to `init` in `SolveNonHydro` and `Diffusion`.