### PR TITLE
Refactor Component interface and fix typos in component ADR

### DIFF
--- a/model/common/src/icon4py/model/common/components/components.py
+++ b/model/common/src/icon4py/model/common/components/components.py
@@ -37,6 +37,13 @@ class Component(Protocol[Ins, Outs]):
         >>> RequiredInputs: TypeAlias = Literal["foo", "bar"]
         >>> ProducedOutputs: TypeAlias = Literal["baz"]
         >>> class AlphaComponent(Component[RequiredInputs, ProducedOutputs]):
+        ...     inputs_properties = {
+        ...         "foo": {"standard_name": "Foo", "units": "m"},
+        ...         "bar": {"standard_name": "BarBar", "units": "s"},
+        ...     }
+        ...
+        ...     outputs_properties = {"baz": {"standard_name": "BAZ", "units": "s"}}
+        ...
         ...     def __call__(
         ...         self, state: dict[RequiredInputs, model.DataField], time_step: datetime.datetime
         ...     ) -> dict[ProducedOutputs, model.DataField]:
@@ -51,7 +58,7 @@ class Component(Protocol[Ins, Outs]):
 
     @property
     @abc.abstractmethod
-    def input_properties(self) -> dict[Ins, model.FieldMetaData]:
+    def inputs_properties(self) -> dict[Ins, model.FieldMetaData]:
         """Return a dictionary with the properties of the inputs expected by the component.
 
         Each input key contains metadata with the CF name, units and dimension of the associated data field.
@@ -60,7 +67,7 @@ class Component(Protocol[Ins, Outs]):
 
     @property
     @abc.abstractmethod
-    def output_properties(self) -> dict[Outs, model.FieldMetaData]:
+    def outputs_properties(self) -> dict[Outs, model.FieldMetaData]:
         """Return a dictionary with the properties of the outputs expected by the component.
 
         Each input key contains metadata with the CF name, units and dimension of the associated data field.

--- a/model/common/src/icon4py/model/common/components/components.py
+++ b/model/common/src/icon4py/model/common/components/components.py
@@ -61,7 +61,7 @@ class Component(Protocol[Ins, Outs]):
     def inputs_properties(self) -> dict[Ins, model.FieldMetaData]:
         """Return a dictionary with the properties of the inputs expected by the component.
 
-        Each input key contains metadata with the CF name, units and dimension of the associated data field.
+        Each input key contains metadata with the standard CF name, units and dimension of the associated data field.
         """
         ...
 
@@ -70,7 +70,7 @@ class Component(Protocol[Ins, Outs]):
     def outputs_properties(self) -> dict[Outs, model.FieldMetaData]:
         """Return a dictionary with the properties of the outputs expected by the component.
 
-        Each input key contains metadata with the CF name, units and dimension of the associated data field.
+        Each input key contains metadata with the standard CF name, units and dimension of the associated data field.
 
         TODO (@halungge): is this too generic and we should split into separate properties for the different types of outputs: like
             tendencies, diagnostics, prognostics, etc?

--- a/model/common/src/icon4py/model/common/components/components.py
+++ b/model/common/src/icon4py/model/common/components/components.py
@@ -9,25 +9,39 @@
 
 import abc
 import datetime
-from typing import Protocol
+from typing import Protocol, TypeVar
 
-from icon4py.model.common import exceptions
 from icon4py.model.common.states import model
 
 
-class Component(Protocol):
+Ins = TypeVar("Ins", bound=str)
+Outs = TypeVar("Outs", bound=str)
+
+
+class Component(Protocol[Ins, Outs]):
     """
-    Protocol for components of the model.
+    Protocol for model components.
 
     Components are the building blocks of the model.
-    The operate on model state variables and transform it or produce new state variables.
+    They operate on model state variables and transform them or produce new state variables.
 
     Each component should declare its inputs and outputs in terms of name, expected units and dimensions.
 
-    Components are Callables upon __call__ the get passed a reference for the model state and
+    Components are Callables upon __call__ that get passed a reference for the model state and
     select their needed inputs from there.
 
-    In order to define a component, subclass from this one and implement the `run` method.
+    Actual component definitions only need to implement this interface.
+
+    Examples:
+
+        >>> RequiredInputs: TypeAlias = Literal["foo", "bar"]
+        >>> ProducedOutputs: TypeAlias = Literal["baz"]
+        >>> class AlphaComponent(Component[RequiredInputs, ProducedOutputs]):
+        ...     def __call__(
+        ...         self, state: dict[RequiredInputs, model.DataField], time_step: datetime.datetime
+        ...     ) -> dict[ProducedOutputs, model.DataField]:
+        ...         ...
+
 
     TODO (@halungge): add more consistency checks.
      - check for mathching units and provide a hook for unit conversion for the components implementations
@@ -35,23 +49,21 @@ class Component(Protocol):
 
     """
 
-    @abc.abstractmethod
     @property
-    def input_properties(self) -> dict[str, model.FieldMetaData]:
-        """Return a dictionary of input properties for the component:contains name, units and dimension of
-        the output_properties.
+    @abc.abstractmethod
+    def input_properties(self) -> dict[Ins, model.FieldMetaData]:
+        """Return a dictionary with the properties of the inputs expected by the component.
 
-        We make this abstract in order to for the implementing class to define the input_properties.
+        Each input key contains metadata with the CF name, units and dimension of the associated data field.
         """
-        raise NotImplementedError
+        ...
 
-    @abc.abstractmethod
     @property
-    def output_properties(self) -> dict[str, model.FieldMetaData]:
-        """Returns a dictionary of the output of the component: contains name, units and dimension of
-        the output_properties.
+    @abc.abstractmethod
+    def output_properties(self) -> dict[Outs, model.FieldMetaData]:
+        """Return a dictionary with the properties of the outputs expected by the component.
 
-        We make this abstract in order for the implementing class to define the output_properties.
+        Each input key contains metadata with the CF name, units and dimension of the associated data field.
 
         TODO (@halungge): is this too generic and we should split into separate properties for the different types of outputs: like
             tendencies, diagnostics, prognostics, etc?
@@ -59,56 +71,30 @@ class Component(Protocol):
             and how they are applied to the model state? Should this be made explicit in the interface?
             Along the same lines how should we track the time the produced values are valid for?
         """
-        raise NotImplementedError
+        ...
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"instance of {self.__class__}(Component) uses inputs: "
             f"{self.input_properties.keys()} \n "
             f"produces : {self.output_properties.keys()}"
         )
 
-    def __call__(self, state: dict[str, model.DataField], time_step: datetime.datetime):
+    def __call__(
+        self, state: dict[Ins, model.DataField], time_step: datetime.datetime
+    ) -> dict[Outs, model.DataField]:
         """
-        Gets the input_properties from the model state and applies the `run` to them and
-        returns the output_properties.
-        This function should implement some joint functionality like consistency checks,
-        field unit conversion etc. it calls
-        `run` as a hook to do the actual computation.
+        Runs the component on the input fields and returns the output fields.
 
-        Args:
-            state: dict  model state dictionary
-            time_step: datetime.datetime  current simulation time
-        Returns:
-            output_properties a dictionary of output quantities
-        Raises:
-              IncompleteStateError if the input_properties are not in the state
-
-        """
-        for key in self.input_properties.keys():
-            if key not in state:
-                raise exceptions.IncompleteStateError(f"input_properties {key} not found in state")
-            # TODO (@halungge) (check that units, dimensions match state[key] and input_properties[key]) if they do not match
-
-        return self.run(state, time_step)
-
-    @abc.abstractmethod
-    def run(
-        self, state: dict[str, model.DataField], time_step: datetime.datetime
-    ) -> dict[str, model.DataField]:
-        """
-        Runs the component on the input_properties and returns the output_properties.
-
-        This is an abstract hook for the actual component implementation to add its logic.
-        This function *must* to be implemented in each implementing class and contain the
-        real logic of the component.
+        This function *must* be implemented with the real logic of the component.
 
         TODO (@halungge): is it possible to improve this interface not haveing to pass on the entire state for example?
 
         Args:
-            state: dict  input properties dictionary
-            time_step: datetime.datetime  current simulation time
+            state: Model state dictionary.
+            time_step: Current simulation time.
         Returns:
-            dict  output properties dictionary
+            A dictionary of output quantities.
+        Raises:
+              IncompleteStateError if the input_properties are not in the state.
         """
-        raise NotImplementedError

--- a/model/docs/development/ADRs/0001_model_physics_components_interface.md
+++ b/model/docs/development/ADRs/0001_model_physics_components_interface.md
@@ -4,10 +4,10 @@ tags: [physics components, tendencies, model state]
 
 # Physics components interface: return values
 
-- **Status**: valid ~~| superseded | deprecated~~
+- **Status**: valid
 - **Authors**: Magdalena Luz (@halungge), Ong Chia Rui (@ongchia)
 - **Created**: 2024-07-23
-- **Updated**: YYYY-MM-DD
+- **Updated**: 2024-09-11
 
 In the context of a modular python driven model, facing the question of standardizing components interfaces
 we decided for physics modules always returning *tendencies* and 
@@ -17,16 +17,16 @@ with the coupling of components.
 ## Context
 We aim at making `icon4py` a flexible model code which endorses modularity and extensibility, and makes it
 easy for future users and developers to add new components and replace existing ones. This includes the 
-possibility of experimenting with the coupling of different physics components, revising 
-the order in which they are run and whether or not there result should be applied to the model state.
+possibility of experimenting with the coupling of different physics components, revisiting 
+the order in which they are run and whether or not their result should be applied to the model state.
 
-In the original [ICON code](https://gitlab.dkrz.de/icon/icon-model) physics components may do both: compute tendencies and as well as
-update the model state (update diagnostic and prognostic variables directly). More precisely, there are physcis
+In the original [ICON code](https://gitlab.dkrz.de/icon/icon-model) physics components may do both: compute tendencies as well as
+update the model state (update diagnostic and prognostic variables directly). More precisely, physics
 processes are split in fast physics (runs every timestep) and slow physics (runs every n-th timestep, n > 1). Fast physics update model state directly
 while slow physics return tendendencies. The distinction is somewhat arbitrary and probably largely dictated by
 computational efficiency of a component. 
 
-We believe that this distinction is intransparent, makes the code inflexible and the individual components and their application order tightly coupled.
+We believe that this distinction is not really transparent, makes the code inflexible and the individual components and their application order tightly coupled.
 
 We want to provide a cleaner and more transparent structure that treats all physics components in the same way and allows
 the user to decide which update should be applied to the model state prior to the next dynamics step.


### PR DESCRIPTION
Refactor the `Component` protocol definition as discussed offline with @halungge and fix some typos in the Component ADR. 