### PR TITLE
Offset vertical domain

### DIFF
--- a/model/common/src/icon4py/model/common/exceptions.py
+++ b/model/common/src/icon4py/model/common/exceptions.py
@@ -14,3 +14,7 @@ class InvalidConfigError(Exception):
 class IncompleteStateError(Exception):
     def __init__(self, field_name):
         super().__init__(f"Field '{field_name}' is missing in state.")
+
+
+class IconGridError(RuntimeError):
+    pass

--- a/model/common/src/icon4py/model/common/grid/grid_manager.py
+++ b/model/common/src/icon4py/model/common/grid/grid_manager.py
@@ -26,7 +26,7 @@ except ImportError:
             raise ModuleNotFoundError("NetCDF4 is not installed.")
 
 
-from icon4py.model.common import dimension as dims
+from icon4py.model.common import dimension as dims, exceptions
 from icon4py.model.common.grid import (
     base as grid_def,
     icon as icon_grid,
@@ -46,7 +46,7 @@ class GridFileField:
 
 def _validate_shape(data: np.array, field_definition: GridFileField):
     if data.shape != field_definition.shape:
-        raise IconGridError(
+        raise exceptions.IconGridError(
             f"invalid grid file field {field_definition.name} does not have dimension {field_definition.shape}"
         )
 
@@ -174,11 +174,7 @@ class GridFile:
         except KeyError as err:
             msg = f"{name} does not exist in dataset"
             self._log.warning(msg)
-            raise IconGridError(msg) from err
-
-
-class IconGridError(RuntimeError):
-    pass
+            raise exceptions.IconGridError(msg) from err
 
 
 class IndexTransformation:
@@ -292,13 +288,13 @@ class GridManager:
         if dim.kind != gtx.DimensionKind.HORIZONTAL:
             msg = f"getting start index in horizontal domain with non - horizontal dimension {dim}"
             self._log.warning(msg)
-            raise IconGridError(msg)
+            raise exceptions.IconGridError(msg)
         try:
             return index_dict[dim][start_marker]
         except KeyError as err:
             msg = f"start, end indices for dimension {dim} not present"
             self._log.error(msg)
-            raise IconGridError(msg) from err
+            raise exceptions.IconGridError(msg) from err
 
     def _construct_grid(
         self, dataset: Dataset, on_gpu: bool, limited_area: bool
@@ -314,7 +310,7 @@ class GridManager:
             return self._grid.config.num_edges
         else:
             self._log.warning(f"cannot determine size of unknown dimension {dim}")
-            raise IconGridError(f"Unknown dimension {dim}")
+            raise exceptions.IconGridError(f"Unknown dimension {dim}")
 
     def _get_index_field(
         self,

--- a/model/common/src/icon4py/model/common/grid/vertical.py
+++ b/model/common/src/icon4py/model/common/grid/vertical.py
@@ -142,7 +142,7 @@ class VerticalGrid:
         log.info(f"computation of moist physics start on layer: {self.kstart_moist}")
         log.info(f"end index of Rayleigh damping layer for w: {self.nrdmax} ")
 
-    def __str__(self):
+    def __str__(self) -> str:
         vertical_params_properties = ["Model interface height properties:"]
         for key, value in self.metadata_interface_physical_height.items():
             vertical_params_properties.append(f"    {key}: {value}")
@@ -159,7 +159,7 @@ class VerticalGrid:
         return "\n".join(vertical_params_properties)
 
     @property
-    def metadata_interface_physical_height(self):
+    def metadata_interface_physical_height(self) -> dict:
         return dict(
             standard_name="model_interface_height",
             long_name="height value of half levels without topography",
@@ -189,35 +189,35 @@ class VerticalGrid:
         ), f"vertical index {index} outside of grid levels for {domain.dim}"
         return index
 
-    def _bottom_level(self, domain: Domain):
-        return self.size(domain.dim)
+    def _bottom_level(self, domain: Domain) -> gtx.int32:
+        return gtx.int32(self.size(domain.dim))
 
     @property
     def interface_physical_height(self) -> fa.KField[float]:
         return self._vct_a
 
     @functools.cached_property
-    def kstart_moist(self):
+    def kstart_moist(self) -> gtx.int32:
         """Vertical index for start level of moist physics."""
         return self.index(Domain(dims.KDim, Zone.MOIST))
 
     @functools.cached_property
-    def nflatlev(self):
+    def nflatlev(self) -> gtx.int32:
         """Vertical index for bottom most level at which coordinate surfaces are flat."""
         return self.index(Domain(dims.KDim, Zone.FLAT))
 
     @functools.cached_property
-    def nrdmax(self):
+    def nrdmax(self) -> gtx.int32:
         """Vertical index where damping starts."""
         return self.end_index_of_damping_layer
 
     @functools.cached_property
-    def end_index_of_damping_layer(self):
+    def end_index_of_damping_layer(self) -> gtx.int32:
         """Vertical index where damping starts."""
         return self.index(Domain(dims.KDim, Zone.DAMPING))
 
     @property
-    def nflat_gradp(self):
+    def nflat_gradp(self) -> gtx.int32:
         return self._min_index_flat_horizontal_grad_pressure
 
     def size(self, dim: dims.VerticalDim) -> int:
@@ -239,7 +239,7 @@ class VerticalGrid:
         return gtx.int32(xp.min(xp.where(interface_height < top_moist_threshold)[0]).item())
 
     @classmethod
-    def _determine_damping_height_index(cls, vct_a: xp.ndarray, damping_height: float):
+    def _determine_damping_height_index(cls, vct_a: xp.ndarray, damping_height: float) -> gtx.int32:
         assert damping_height >= 0.0, "Damping height must be positive."
         return (
             0
@@ -259,7 +259,9 @@ class VerticalGrid:
         )
 
 
-def _read_vct_a_and_vct_b_from_file(file_path: pathlib.Path, num_levels: int):
+def _read_vct_a_and_vct_b_from_file(
+    file_path: pathlib.Path, num_levels: int
+) -> tuple[fa.KField, fa.KField]:
     """
     Read vct_a and vct_b from a file.
     The file format should be as follows (the same format used for icon):
@@ -300,7 +302,7 @@ def _read_vct_a_and_vct_b_from_file(file_path: pathlib.Path, num_levels: int):
     return gtx.as_field((dims.KDim,), vct_a), gtx.as_field((dims.KDim,), vct_b)
 
 
-def _compute_vct_a_and_vct_b(vertical_config: VerticalGridConfig):
+def _compute_vct_a_and_vct_b(vertical_config: VerticalGridConfig) -> tuple[fa.KField, fa.KField]:
     """
     Compute vct_a and vct_b.
 
@@ -481,7 +483,7 @@ def _compute_vct_a_and_vct_b(vertical_config: VerticalGridConfig):
     return gtx.as_field((dims.KDim,), vct_a), gtx.as_field((dims.KDim,), vct_b)
 
 
-def get_vct_a_and_vct_b(vertical_config: VerticalGridConfig):
+def get_vct_a_and_vct_b(vertical_config: VerticalGridConfig) -> tuple[fa.KField, fa.KField]:
     """
     get vct_a and vct_b.
     vct_a is an array that contains the height of grid interfaces (or half levels) from model surface to model top, before terrain-following coordinates are applied.

--- a/model/common/tests/grid_tests/test_vertical.py
+++ b/model/common/tests/grid_tests/test_vertical.py
@@ -5,7 +5,6 @@
 #
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
-
 import math
 
 import gt4py.next as gtx
@@ -14,11 +13,7 @@ import pytest
 
 from icon4py.model.common import dimension as dims
 from icon4py.model.common.grid import vertical as v_grid
-from icon4py.model.common.test_utils.datatest_utils import (
-    GLOBAL_EXPERIMENT,
-    REGIONAL_EXPERIMENT,
-)
-from icon4py.model.common.test_utils.helpers import dallclose
+from icon4py.model.common.test_utils import datatest_utils as dt_utils, helpers
 
 
 NUM_LEVELS = 65
@@ -32,7 +27,7 @@ def test_damping_layer_calculation(max_h, damping_height, delta, flat_height):
     vct_a = np.arange(0, max_h, delta)
     vct_a_field = gtx.as_field((dims.KDim,), data=vct_a[::-1])
     vertical_config = v_grid.VerticalGridConfig(
-        num_levels=NUM_LEVELS,
+        num_levels=1000,
         flat_height=flat_height,
         rayleigh_damping_height=damping_height,
     )
@@ -49,7 +44,7 @@ def test_damping_layer_calculation(max_h, damping_height, delta, flat_height):
 
 
 @pytest.mark.datatest
-@pytest.mark.parametrize("experiment", [REGIONAL_EXPERIMENT, GLOBAL_EXPERIMENT])
+@pytest.mark.parametrize("experiment", [dt_utils.REGIONAL_EXPERIMENT, dt_utils.GLOBAL_EXPERIMENT])
 def test_damping_layer_calculation_from_icon_input(
     grid_savepoint, experiment, damping_height, flat_height
 ):
@@ -122,7 +117,7 @@ def configure_vertical_grid(grid_savepoint, top_moist_threshold=22500.0):
 
 @pytest.mark.datatest
 @pytest.mark.parametrize(
-    "experiment, expected_moist_level", [(REGIONAL_EXPERIMENT, 0), (GLOBAL_EXPERIMENT, 25)]
+    "experiment, expected_moist_level", [(dt_utils.REGIONAL_EXPERIMENT, 0), (dt_utils.GLOBAL_EXPERIMENT, 25)]
 )
 def test_moist_level_calculation(grid_savepoint, experiment, expected_moist_level):
     threshold = 22500.0
@@ -134,13 +129,13 @@ def test_moist_level_calculation(grid_savepoint, experiment, expected_moist_leve
 @pytest.mark.datatest
 def test_interface_physical_height(grid_savepoint):
     vertical_grid = configure_vertical_grid(grid_savepoint)
-    assert dallclose(
+    assert helpers.dallclose(
         grid_savepoint.vct_a().asnumpy(), vertical_grid.interface_physical_height.asnumpy()
     )
 
 
 @pytest.mark.datatest
-@pytest.mark.parametrize("experiment", [REGIONAL_EXPERIMENT, GLOBAL_EXPERIMENT])
+@pytest.mark.parametrize("experiment", [dt_utils.REGIONAL_EXPERIMENT, dt_utils.GLOBAL_EXPERIMENT])
 def test_flat_level_calculation(grid_savepoint, experiment, flat_height):
     vertical_grid = configure_vertical_grid(grid_savepoint)
 
@@ -150,24 +145,116 @@ def test_flat_level_calculation(grid_savepoint, experiment, flat_height):
     )
 
 
-@pytest.mark.parametrize("experiment, levels", [(REGIONAL_EXPERIMENT, 65), (GLOBAL_EXPERIMENT, 60)])
-def test_grid_index_top(grid_savepoint, experiment, levels):
-    vertical_grid = configure_vertical_grid(grid_savepoint)
-    assert 0 == vertical_grid.index(v_grid.Domain(dims.KDim, v_grid.Zone.TOP))
-    assert levels == vertical_grid.index(v_grid.Domain(dims.KDim, v_grid.Zone.BOTTOM))
-    assert levels + 1 == vertical_grid.index(v_grid.Domain(dims.KHalfDim, v_grid.Zone.BOTTOM))
-    assert 0 == vertical_grid.index(v_grid.Domain(dims.KHalfDim, v_grid.Zone.TOP))
+def offsets():
+    for i in range(5):
+        yield i
+        
+def vertical_zones():
+    for z in v_grid.Zone.__members__.values():
+        yield z
 
 
-@pytest.mark.parametrize("experiment, levels", [(REGIONAL_EXPERIMENT, 65), (GLOBAL_EXPERIMENT, 60)])
-def test_grid_index_bottom(grid_savepoint, experiment, levels):
+
+@pytest.mark.parametrize("zone", vertical_zones())
+@pytest.mark.parametrize("kind", (gtx.DimensionKind.LOCAL, gtx.DimensionKind.HORIZONTAL))
+def test_domain_raises_for_vertical_dim(zone, kind):
+    dim = gtx.Dimension("I", kind=kind)
+    with pytest.raises(AssertionError):
+        v_grid.Domain(dim, zone)
+    
+@pytest.mark.datatest
+@pytest.mark.parametrize("dim", [dims.KDim, dims.KHalfDim])
+@pytest.mark.parametrize("offset", offsets())
+def test_grid_index_top(grid_savepoint, dim, offset):
     vertical_grid = configure_vertical_grid(grid_savepoint)
-    assert levels == vertical_grid.index(v_grid.Domain(dims.KDim, v_grid.Zone.BOTTOM))
-    assert levels + 1 == vertical_grid.index(v_grid.Domain(dims.KHalfDim, v_grid.Zone.BOTTOM))
+    assert offset == vertical_grid.index(v_grid.Domain(dim, v_grid.Zone.TOP, offset))
+
+@pytest.mark.datatest
+@pytest.mark.parametrize("experiment, levels", [(dt_utils.GLOBAL_EXPERIMENT, 60)])
+@pytest.mark.parametrize("dim", [dims.KDim, dims.KHalfDim])
+@pytest.mark.parametrize("offset",offsets())
+def test_grid_index_damping(grid_savepoint,  experiment, levels,dim,offset):
+    vertical_grid = configure_vertical_grid(grid_savepoint)
+    upwards = -offset
+    downwards = offset
+    zone = v_grid.Zone.DAMPING
+    domain = v_grid.Domain(dim, zone, upwards)
+    assert vertical_grid.end_index_of_damping_layer + upwards == vertical_grid.index(domain)
+    domain = v_grid.Domain(dim, zone, downwards)
+    assert vertical_grid.end_index_of_damping_layer + downwards == vertical_grid.index(domain)
+
+@pytest.mark.datatest
+@pytest.mark.parametrize("experiment, levels", [(dt_utils.GLOBAL_EXPERIMENT, 60)])
+@pytest.mark.parametrize("dim", [dims.KDim, dims.KHalfDim])
+@pytest.mark.parametrize("offset",offsets())
+def test_grid_index_moist(grid_savepoint,  experiment, levels,dim,offset):
+    vertical_grid = configure_vertical_grid(grid_savepoint)
+    upwards = -offset
+    downwards = offset
+    zone = v_grid.Zone.MOIST
+    domain = v_grid.Domain(dim, zone, upwards)
+    assert vertical_grid.kstart_moist + upwards == vertical_grid.index(domain)
+    domain = v_grid.Domain(dim, zone, downwards)
+    assert vertical_grid.kstart_moist + downwards == vertical_grid.index(domain)
 
 
 @pytest.mark.datatest
-@pytest.mark.parametrize("experiment", [REGIONAL_EXPERIMENT, GLOBAL_EXPERIMENT])
+@pytest.mark.parametrize("experiment, levels", [(dt_utils.GLOBAL_EXPERIMENT, 60)])
+@pytest.mark.parametrize("dim", [dims.KDim, dims.KHalfDim])
+@pytest.mark.parametrize("offset",offsets())
+def test_grid_index_flat(grid_savepoint,  experiment, levels,dim,offset):
+    vertical_grid = configure_vertical_grid(grid_savepoint)
+    upwards = -offset
+    downwards = offset
+    zone = v_grid.Zone.FLAT
+    domain = v_grid.Domain(dim, zone, upwards)
+    assert vertical_grid.nflatlev + upwards == vertical_grid.index(domain)
+    domain = v_grid.Domain(dim, zone, downwards)
+    assert vertical_grid.nflatlev + downwards == vertical_grid.index(domain)
+
+
+@pytest.mark.datatest
+@pytest.mark.parametrize("experiment, levels", [(dt_utils.REGIONAL_EXPERIMENT, NUM_LEVELS), (dt_utils.GLOBAL_EXPERIMENT, 60)])
+@pytest.mark.parametrize("dim", [dims.KDim, dims.KHalfDim])
+@pytest.mark.parametrize("offset", offsets())
+def test_grid_index_bottom(grid_savepoint,  experiment, levels,dim, offset):
+    valid_offset = - offset
+    vertical_grid = configure_vertical_grid(grid_savepoint)
+    num_levels = levels if dim == dims.KDim else levels + 1
+    domain = v_grid.Domain(dim, v_grid.Zone.BOTTOM, valid_offset)
+    assert num_levels + valid_offset == vertical_grid.index(domain)
+   
+
+@pytest.mark.datatest
+@pytest.mark.parametrize("experiment, levels", [(dt_utils.GLOBAL_EXPERIMENT, 60)])
+@pytest.mark.parametrize("zone", vertical_zones())
+@pytest.mark.parametrize("dim", [dims.KDim, dims.KHalfDim])
+@pytest.mark.parametrize("offset", offsets())
+def test_grid_index_bottom_raises_if_index_above_num_levels(grid_savepoint,  experiment, levels, zone, dim, offset):
+    invalid_offset = offset + levels + 2
+    vertical_grid = configure_vertical_grid(grid_savepoint)
+    domain = v_grid.Domain(dim, zone, invalid_offset)
+    with pytest.raises(expected_exception=AssertionError):
+        vertical_grid.index(domain)
+
+@pytest.mark.datatest
+@pytest.mark.parametrize("experiment, levels", [(dt_utils.GLOBAL_EXPERIMENT, 60)])
+@pytest.mark.parametrize("zone", vertical_zones())
+@pytest.mark.parametrize("dim", [dims.KDim, dims.KHalfDim])
+@pytest.mark.parametrize("offset", offsets())
+def test_grid_index_bottom_raises_if_index_below_zero(grid_savepoint,  experiment, levels, zone, dim, offset):
+    invalid_offset = - (offset + 2 + levels)
+    vertical_grid = configure_vertical_grid(grid_savepoint)
+    with pytest.raises(expected_exception=AssertionError):
+        domain = v_grid.Domain(dim, zone, invalid_offset)
+        vertical_grid.index(domain)
+
+
+
+
+
+@pytest.mark.datatest
+@pytest.mark.parametrize("experiment", (dt_utils.REGIONAL_EXPERIMENT, dt_utils.GLOBAL_EXPERIMENT))
 def test_vct_a_vct_b_calculation_from_icon_input(
     grid_savepoint,
     experiment,
@@ -193,5 +280,5 @@ def test_vct_a_vct_b_calculation_from_icon_input(
     )
     vct_a, vct_b = v_grid.get_vct_a_and_vct_b(vertical_config)
 
-    assert dallclose(vct_a.asnumpy(), grid_savepoint.vct_a().asnumpy())
-    assert dallclose(vct_b.asnumpy(), grid_savepoint.vct_b().asnumpy())
+    assert helpers.dallclose(vct_a.asnumpy(), grid_savepoint.vct_a().asnumpy())
+    assert helpers.dallclose(vct_b.asnumpy(), grid_savepoint.vct_b().asnumpy())


### PR DESCRIPTION
Introduces more flexibility for the vertical domain by allowing for a integer offset, such that essentially any vertical level can be defined: 
For example:
```python
vertical_grid.index(domain(dims.KDim, Zone.TOP, 1) = 1
```
The `VerticalGrid.index` function checks for out of bounds, i.e. index values below 0 or larger than `num_levels` or `num_levels + 1` depending on the dimension. 

### Additional changes
- moved the `IconGridError` exception class to `exceptions.py`
- fixed imports in `test_vertical.py`
- add return types in `vertical.py`