### PR TITLE
Fix base image for docker build

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -26,22 +26,16 @@ variables:
     DOCKERFILE: ci/docker/base.Dockerfile
     # change to 'always' if you want to rebuild, even if target tag exists already (if-not-exists is the default, i.e. we could also skip the variable)
     CSCS_REBUILD_POLICY: if-not-exists
-    DOCKER_BUILD_ARGS: '["ARCH=$ARCH", "BASE_IMAGE=$BASE_IMAGE", "HPC_SDK_VERSION=$HPC_SDK_VERSION", "HPC_SDK_NAME=$HPC_SDK_NAME", "CUPY_PACKAGE=$CUPY_PACKAGE", "PYVERSION=$PYVERSION", "CI_PROJECT_DIR=$CI_PROJECT_DIR"]'
+    DOCKER_BUILD_ARGS: '["ARCH=$ARCH", "HPC_SDK_VERSION=$HPC_SDK_VERSION", "HPC_SDK_NAME=$HPC_SDK_NAME", "CUPY_PACKAGE=$CUPY_PACKAGE", "PYVERSION=$PYVERSION", "CI_PROJECT_DIR=$CI_PROJECT_DIR"]'
 build_baseimage_x86_64:
   extends: [.container-builder-cscs-zen2, .build_baseimage]
   variables:
-    # x86_64 test target is Daint-gpu through Sarus:
-    # the base image does not need to provide the cuda runtime
-    BASE_IMAGE: "ubuntu:20.04"
     HPC_SDK_VERSION: 22.11
     HPC_SDK_NAME: "nvhpc_2022_2211_Linux_${ARCH}_cuda_11.8"
     CUPY_PACKAGE: cupy-cuda11x
 build_baseimage_aarch64:
   extends: [.container-builder-cscs-gh200, .build_baseimage]
   variables:
-    # aarm64 test target is Todi through Container Engine:
-    # the base image should provide the cuda runtime, therefore we use the cuda base image
-    BASE_IMAGE: "docker.io/nvidia/cuda:12.4.1-base-ubuntu20.04"
     HPC_SDK_VERSION: 24.5
     HPC_SDK_NAME: "nvhpc_2024_245_Linux_${ARCH}_cuda_12.4"
     CUPY_PACKAGE: cupy-cuda12x

--- a/ci/docker/base.Dockerfile
+++ b/ci/docker/base.Dockerfile
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE=ubuntu:20.04
-FROM ${BASE_IMAGE}
+FROM ubuntu:20.04
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
@@ -49,7 +48,9 @@ RUN cd /opt/nvidia/${HPC_SDK_NAME} && ./install
 ARG ARCH=x86_64
 ENV HPC_SDK_PATH=/opt/nvidia/hpc_sdk/Linux_${ARCH}/${HPC_SDK_VERSION}
 # The variable CUDA_PATH is used by cupy to find the cuda toolchain
-ENV CUDA_PATH=${HPC_SDK_PATH}/cuda
+ENV CUDA_PATH=${HPC_SDK_PATH}/cuda \
+    NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
 ENV PATH=${HPC_SDK_PATH}/compilers/bin:${HPC_SDK_PATH}/comm_libs/mpi/bin:${PATH} \
     MANPATH=${HPC_SDK_PATH}/compilers/man:${MANPATH} \


### PR DESCRIPTION
There is no reason for using 2 different base images between DaintXC and Todi image build. The issue that prevented gpu-tests on Todi to run with a plain ubuntu image (runtime error `cudaErrorInsufficientDriver`) was that Alps uses the Container Engine as container runtime, which requires some `NVIDIA_` environment variables to be set in the docker image. This was done by default in the cuda images provided by Nvidia docker hub. For plain ubuntu images, we have to explicitly set them, until the vCluster service manager configures the Container Engine on Todi to enable them transparently on all images.