### PR TITLE
nabla2_...damping refactoring and some stencil tests' xfails cleanup

### DIFF
--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -435,7 +435,7 @@ class Diffusion:
         diffusion_utils.init_nabla2_factor_in_upper_damping_zone(
             physical_heights=self.vertical_grid.interface_physical_height,
             k_field=field_alloc.allocate_indices(dims.KDim, grid=self.grid),
-            diff_multfac_n2w=diff_multfac_n2w,
+            diff_multfac_n2w=self.diff_multfac_n2w,
             nrdmax=self.vertical_grid.end_index_of_damping_layer,
             nshift=0,
             heights_nrd_shift=self.vertical_grid.interface_physical_height.asnumpy()[

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -444,6 +444,7 @@ class Diffusion:
             heights_1=self.vertical_grid.interface_physical_height.asnumpy()[1],
             vertical_start=1,
             vertical_end=self.vertical_grid.end_index_of_damping_layer + 1,
+            offset_provider={}
         )
         self._determine_horizontal_domains()
 

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -432,7 +432,7 @@ class Diffusion:
         )
 
         diff_multfac_n2w = field_alloc.allocate_zero_field(dims.KDim, grid=self.grid)
-        self.diff_multfac_n2w = diffusion_utils.init_nabla2_factor_in_upper_damping_zone(
+        diffusion_utils.init_nabla2_factor_in_upper_damping_zone(
             physical_heights=self.vertical_grid.interface_physical_height,
             k_field=field_alloc.allocate_indices(dims.KDim, grid=self.grid),
             diff_multfac_n2w=diff_multfac_n2w,
@@ -446,6 +446,8 @@ class Diffusion:
             vertical_end=self.vertical_grid.end_index_of_damping_layer + 1,
             offset_provider={},
         )
+        self.diff_multfac_n2w = diff_multfac_n2w
+
         self._determine_horizontal_domains()
 
         self._initialized = True

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -431,12 +431,19 @@ class Diffusion:
             offset_provider={"Koff": dims.KDim},
         )
 
-        # TODO (magdalena) port to gt4py?
+        diff_multfac_n2w = field_alloc.allocate_zero_field(dims.KDim, grid=self.grid)
         self.diff_multfac_n2w = diffusion_utils.init_nabla2_factor_in_upper_damping_zone(
-            k_size=self.grid.num_levels,
-            nshift=0,
             physical_heights=self.vertical_grid.interface_physical_height,
+            k_field=field_alloc.allocate_indices(dims.KDim, grid=self.grid),
+            diff_multfac_n2w=diff_multfac_n2w,
             nrdmax=self.vertical_grid.end_index_of_damping_layer,
+            nshift=0,
+            heights_nrd_shift=self.vertical_grid.interface_physical_height.asnumpy()[
+                self.vertical_grid.end_index_of_damping_layer + 1
+            ],
+            heights_1=self.vertical_grid.interface_physical_height.asnumpy()[1],
+            vertical_start=1,
+            vertical_end=self.vertical_grid.end_index_of_damping_layer + 1,
         )
         self._determine_horizontal_domains()
 

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -444,7 +444,7 @@ class Diffusion:
             heights_1=self.vertical_grid.interface_physical_height.asnumpy()[1],
             vertical_start=1,
             vertical_end=self.vertical_grid.end_index_of_damping_layer + 1,
-            offset_provider={}
+            offset_provider={},
         )
         self._determine_horizontal_domains()
 

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -446,7 +446,6 @@ class Diffusion:
             vertical_end=self.vertical_grid.end_index_of_damping_layer + 1,
             offset_provider={},
         )
-        self.diff_multfac_n2w = diff_multfac_n2w
 
         self._determine_horizontal_domains()
 

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -438,7 +438,7 @@ class Diffusion:
             diff_multfac_n2w=self.diff_multfac_n2w,
             nrdmax=self.vertical_grid.end_index_of_damping_layer,
             nshift=0,
-            heights_nrd_shift=self.vertical_grid.interface_physical_height.asnumpy()[
+            heights_nrd_shift=self.vertical_grid.interface_physical_height.ndarray[self.vertical_grid.end_index_of_damping_layer + 1].item()
                 self.vertical_grid.end_index_of_damping_layer + 1
             ],
             heights_1=self.vertical_grid.interface_physical_height.asnumpy()[1],

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -431,19 +431,17 @@ class Diffusion:
             offset_provider={"Koff": dims.KDim},
         )
 
-        diff_multfac_n2w = field_alloc.allocate_zero_field(dims.KDim, grid=self.grid)
-        diffusion_utils.init_nabla2_factor_in_upper_damping_zone(
+        diffusion_utils._init_nabla2_factor_in_upper_damping_zone(
             physical_heights=self.vertical_grid.interface_physical_height,
-            k_field=field_alloc.allocate_indices(dims.KDim, grid=self.grid),
-            diff_multfac_n2w=self.diff_multfac_n2w,
+            k_field=self.vertical_index,
             nrdmax=self.vertical_grid.end_index_of_damping_layer,
             nshift=0,
-            heights_nrd_shift=self.vertical_grid.interface_physical_height.ndarray[self.vertical_grid.end_index_of_damping_layer + 1].item()
+            heights_nrd_shift=self.vertical_grid.interface_physical_height.ndarray[
                 self.vertical_grid.end_index_of_damping_layer + 1
-            ],
-            heights_1=self.vertical_grid.interface_physical_height.asnumpy()[1],
-            vertical_start=1,
-            vertical_end=self.vertical_grid.end_index_of_damping_layer + 1,
+            ].item(),
+            heights_1=self.vertical_grid.interface_physical_height.ndarray[1].item(),
+            domain={dims.KDim: (1, self.vertical_grid.end_index_of_damping_layer + 1)},
+            out=self.diff_multfac_n2w,
             offset_provider={},
         )
 
@@ -457,7 +455,7 @@ class Diffusion:
 
     def _allocate_temporary_fields(self):
         self.diff_multfac_vn = field_alloc.allocate_zero_field(dims.KDim, grid=self.grid)
-
+        self.diff_multfac_n2w = field_alloc.allocate_zero_field(dims.KDim, grid=self.grid)
         self.smag_limit = field_alloc.allocate_zero_field(dims.KDim, grid=self.grid)
         self.enh_smag_fac = field_alloc.allocate_zero_field(dims.KDim, grid=self.grid)
         self.u_vert = field_alloc.allocate_zero_field(dims.VertexDim, dims.KDim, grid=self.grid)

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion_utils.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion_utils.py
@@ -169,7 +169,7 @@ def _init_nabla2_factor_in_upper_damping_zone(
     heights_1: float,
 ) -> fa.KField[float]:
     height_sliced = where(
-        k_field >= (1 + nshift) & k_field < (nshift + nrdmax + 1), physical_heights, 0.0
+        (k_field >= (1 + nshift)) & (k_field < (nshift + nrdmax + 1)), physical_heights, 0.0
     )
     diff_multfac_n2w = (
         1.0 / 12.0 * ((height_sliced - heights_nrd_shift) / (heights_1 - heights_nrd_shift)) ** 4

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion_utils.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion_utils.py
@@ -9,15 +9,12 @@
 from typing import Tuple
 
 import gt4py.next as gtx
-from gt4py.next.ffront.fbuiltins import (
-    broadcast,
-    minimum,
-)
+from gt4py.next.ffront.fbuiltins import broadcast, minimum, where
 
 from icon4py.model.common import dimension as dims, field_type_aliases as fa
 from icon4py.model.common.dimension import KDim, VertexDim
 from icon4py.model.common.math.smagorinsky import _en_smag_fac_for_zero_nshift
-from icon4py.model.common.settings import backend, xp
+from icon4py.model.common.settings import backend
 
 
 @gtx.field_operator
@@ -162,30 +159,58 @@ def init_diffusion_local_fields_for_regular_timestep(
     )
 
 
-def init_nabla2_factor_in_upper_damping_zone(
-    k_size: int, nrdmax: gtx.int32, nshift: int, physical_heights: fa.KField[float]
+@gtx.field_operator
+def _init_nabla2_factor_in_upper_damping_zone(
+    physical_heights: fa.KField[float],
+    k_field: fa.KField[gtx.int32],
+    nrdmax: gtx.int32,
+    nshift: gtx.int32,
+    heights_nrd_shift: float,
+    heights_1: float,
 ) -> fa.KField[float]:
+    height_sliced = where(
+        k_field >= (1 + nshift) & k_field < (nshift + nrdmax + 1), physical_heights, 0.0
+    )
+    diff_multfac_n2w = (
+        1.0 / 12.0 * ((height_sliced - heights_nrd_shift) / (heights_1 - heights_nrd_shift)) ** 4
+    )
+    return diff_multfac_n2w
+
+
+@gtx.program
+def init_nabla2_factor_in_upper_damping_zone(
+    physical_heights: fa.KField[float],
+    k_field: fa.KField[gtx.int32],
+    diff_multfac_n2w: fa.KField[gtx.int32],
+    nrdmax: gtx.int32,
+    nshift: gtx.int32,
+    heights_nrd_shift: float,
+    heights_1: float,
+    vertical_start: gtx.int32,
+    vertical_end: gtx.int32,
+):
     """
     Calculate diff_multfac_n2w.
 
     numpy version, since gt4py does not allow non-constant indexing into fields
 
     Args
-        k_size: number of vertical levels
-        nrdmax: index of the level where rayleigh dampint starts
-        nshift:
         physcial_heights: vector of physical heights [m] of the height levels
+        k_field: field of k levels
+        nrdmax: index of the level where rayleigh dampint starts
+        nshift: 0
+        heights_nrd_shift: physcial_heights at nrdmax + nshift + 1,
+        heights_1: physcial_heights at 1st level,
+        vertical_start: vertical lower bound,
+        vertical_end: vertical upper bound,
     """
-    # TODO(Magdalena): fix with as_offset in gt4py
-    heights = physical_heights.ndarray
-    buffer = xp.zeros(k_size)
-    buffer[1 : nrdmax + 1] = (
-        1.0
-        / 12.0
-        * (
-            (heights[1 + nshift : nrdmax + 1 + nshift] - heights[nshift + nrdmax + 1])
-            / (heights[1] - heights[nshift + nrdmax + 1])
-        )
-        ** 4
+    _init_nabla2_factor_in_upper_damping_zone(
+        physical_heights=physical_heights,
+        k_field=k_field,
+        nrdmax=nrdmax,
+        nshift=nshift,
+        heights_nrd_shift=heights_nrd_shift,
+        heights_1=heights_1,
+        out=diff_multfac_n2w,
+        domain={dims.KDim: (vertical_start, vertical_end)},
     )
-    return gtx.as_field((dims.KDim,), buffer)

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion_utils.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion_utils.py
@@ -181,7 +181,7 @@ def _init_nabla2_factor_in_upper_damping_zone(
 def init_nabla2_factor_in_upper_damping_zone(
     physical_heights: fa.KField[float],
     k_field: fa.KField[gtx.int32],
-    diff_multfac_n2w: fa.KField[gtx.int32],
+    diff_multfac_n2w: fa.KField[float],
     nrdmax: gtx.int32,
     nshift: gtx.int32,
     heights_nrd_shift: float,

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion_utils.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion_utils.py
@@ -197,7 +197,7 @@ def init_nabla2_factor_in_upper_damping_zone(
     Args
         physcial_heights: vector of physical heights [m] of the height levels
         k_field: field of k levels
-        nrdmax: index of the level where rayleigh dampint starts
+        nrdmax: index of the level where rayleigh damping starts
         nshift: 0
         heights_nrd_shift: physcial_heights at nrdmax + nshift + 1,
         heights_1: physcial_heights at 1st level,

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/stencils/apply_diffusion_to_theta_and_exner.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/stencils/apply_diffusion_to_theta_and_exner.py
@@ -75,6 +75,10 @@ def apply_diffusion_to_theta_and_exner(
     theta_v: fa.CellKField[wpfloat],
     exner: fa.CellKField[wpfloat],
     rd_o_cvd: vpfloat,
+    horizontal_start: int32,
+    horizontal_end: int32,
+    vertical_start: int32,
+    vertical_end: int32,
 ):
     _apply_diffusion_to_theta_and_exner(
         kh_smag_e,
@@ -91,4 +95,8 @@ def apply_diffusion_to_theta_and_exner(
         exner,
         rd_o_cvd,
         out=(theta_v, exner),
+        domain={
+            dims.CellDim: (horizontal_start, horizontal_end),
+            dims.KDim: (vertical_start, vertical_end),
+        },
     )

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_theta_and_exner.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_theta_and_exner.py
@@ -58,10 +58,16 @@ class TestApplyDiffusionToThetaAndExner(StencilTest):
         kwargs_2 = {k: kwargs[k] for k in kwargs.keys() - {"theta_v"}}  # remove unused kwargs
         # adjust boundary for numpy stencil over edges below
         edge_domain = h_grid.domain(dims.EdgeDim)
-        kwargs_2["horizontal_start"] = grid.start_index(
-            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2)
+        kwargs_2["horizontal_start"] = (
+            0
+            if "SimpleGrid" in str(grid)
+            else grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2))
         )
-        kwargs_2["horizontal_end"] = grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+        kwargs_2["horizontal_end"] = (
+            grid.num_edges
+            if "SimpleGrid" in str(grid)
+            else grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+        )
         z_nabla2_e = calculate_nabla2_for_z_numpy(
             grid, kh_smag_e, inv_dual_edge_length, theta_v_in, z_nabla2_e, **kwargs_2
         )

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_theta_and_exner.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_theta_and_exner.py
@@ -59,14 +59,14 @@ class TestApplyDiffusionToThetaAndExner(StencilTest):
         # adjust boundary for numpy stencil over edges below
         edge_domain = h_grid.domain(dims.EdgeDim)
         kwargs_2["horizontal_start"] = (
-            0
-            if "SimpleGrid" in str(grid)
-            else grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2))
+            grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2))
+            if hasattr(grid, "start_index")
+            else 0
         )
         kwargs_2["horizontal_end"] = (
-            grid.num_edges
-            if "SimpleGrid" in str(grid)
-            else grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+            grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+            if hasattr(grid, "end_index")
+            else grid.num_edges
         )
         z_nabla2_e = calculate_nabla2_for_z_numpy(
             grid, kh_smag_e, inv_dual_edge_length, theta_v_in, z_nabla2_e, **kwargs_2

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_theta_and_exner.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_theta_and_exner.py
@@ -14,7 +14,6 @@ from icon4py.model.atmosphere.diffusion.stencils.apply_diffusion_to_theta_and_ex
     apply_diffusion_to_theta_and_exner,
 )
 from icon4py.model.common import dimension as dims
-from icon4py.model.common.grid.icon import IconGrid
 from icon4py.model.common.test_utils.helpers import (
     StencilTest,
     flatten_first_two_dims,
@@ -78,11 +77,6 @@ class TestApplyDiffusionToThetaAndExner(StencilTest):
 
     @pytest.fixture
     def input_data(self, grid):
-        if isinstance(grid, IconGrid) and grid.limited_area:
-            pytest.xfail(
-                "Execution domain needs to be restricted or boundary taken into account in stencil."
-            )
-
         kh_smag_e = random_field(grid, dims.EdgeDim, dims.KDim)
         inv_dual_edge_length = random_field(grid, dims.EdgeDim)
         theta_v_in = random_field(grid, dims.CellDim, dims.KDim)

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_theta_and_exner.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_theta_and_exner.py
@@ -14,6 +14,7 @@ from icon4py.model.atmosphere.diffusion.stencils.apply_diffusion_to_theta_and_ex
     apply_diffusion_to_theta_and_exner,
 )
 from icon4py.model.common import dimension as dims
+from icon4py.model.common.grid import horizontal as h_grid
 from icon4py.model.common.test_utils.helpers import (
     StencilTest,
     flatten_first_two_dims,
@@ -53,7 +54,17 @@ class TestApplyDiffusionToThetaAndExner(StencilTest):
         rd_o_cvd,
         **kwargs,
     ):
-        z_nabla2_e = calculate_nabla2_for_z_numpy(grid, kh_smag_e, inv_dual_edge_length, theta_v_in)
+        z_nabla2_e = np.zeros_like(kh_smag_e)
+        kwargs_2 = {k: kwargs[k] for k in kwargs.keys() - {"theta_v"}}  # remove unused kwargs
+        # adjust boundary for numpy stencil over edges below
+        edge_domain = h_grid.domain(dims.EdgeDim)
+        kwargs_2["horizontal_start"] = grid.start_index(
+            edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2)
+        )
+        kwargs_2["horizontal_end"] = grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+        z_nabla2_e = calculate_nabla2_for_z_numpy(
+            grid, kh_smag_e, inv_dual_edge_length, theta_v_in, z_nabla2_e, **kwargs_2
+        )
         z_temp = calculate_nabla2_of_theta_numpy(grid, z_nabla2_e, geofac_div)
 
         geofac_n2s_nbh = unflatten_first_two_dims(geofac_n2s_nbh)
@@ -77,6 +88,10 @@ class TestApplyDiffusionToThetaAndExner(StencilTest):
 
     @pytest.fixture
     def input_data(self, grid):
+        # error message contained in truly_horizontal_diffusion_nabla_of_theta_over_steep_points_numpy
+        if np.any(grid.connectivities[dims.C2E2CDim] == -1):
+            pytest.xfail("Stencil does not support missing neighbors.")
+
         kh_smag_e = random_field(grid, dims.EdgeDim, dims.KDim)
         inv_dual_edge_length = random_field(grid, dims.EdgeDim)
         theta_v_in = random_field(grid, dims.CellDim, dims.KDim)
@@ -119,4 +134,8 @@ class TestApplyDiffusionToThetaAndExner(StencilTest):
             theta_v=theta_v,
             exner=exner,
             rd_o_cvd=rd_o_cvd,
+            horizontal_start=0,
+            horizontal_end=int32(grid.num_cells),
+            vertical_start=0,
+            vertical_end=int32(grid.num_levels),
         )

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_theta_and_exner.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_theta_and_exner.py
@@ -94,6 +94,7 @@ class TestApplyDiffusionToThetaAndExner(StencilTest):
 
     @pytest.fixture
     def input_data(self, grid):
+        # TODO: understand why values do not verify intermittently
         # error message contained in truly_horizontal_diffusion_nabla_of_theta_over_steep_points_numpy
         if np.any(grid.connectivities[dims.C2E2CDim] == -1):
             pytest.xfail("Stencil does not support missing neighbors.")

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_vn.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_vn.py
@@ -119,15 +119,23 @@ class TestApplyDiffusionToVn(StencilTest):
         vn = random_field(grid, dims.EdgeDim, dims.KDim)
         nudgecoeff_e = random_field(grid, dims.EdgeDim)
 
-        limited_area = grid.limited_area
+        limited_area = True if "SimpleGrid" in str(grid) else grid.limited_area
         fac_bdydiff_v = 5.0
         nudgezone_diff = 9.0
 
         start_2nd_nudge_line_idx_e = 6
 
         edge_domain = h_grid.domain(dims.EdgeDim)
-        horizontal_start = grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5))
-        horizontal_end = grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+        horizontal_start = (
+            0
+            if "SimpleGrid" in str(grid)
+            else grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5))
+        )
+        horizontal_end = (
+            grid.num_edges
+            if "SimpleGrid" in str(grid)
+            else grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+        )
 
         return dict(
             u_vert=u_vert,

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_vn.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_vn.py
@@ -119,7 +119,7 @@ class TestApplyDiffusionToVn(StencilTest):
         vn = random_field(grid, dims.EdgeDim, dims.KDim)
         nudgecoeff_e = random_field(grid, dims.EdgeDim)
 
-        limited_area = True if "SimpleGrid" in str(grid) else grid.limited_area
+        limited_area = grid.limited_area if hasattr(grid, "limited_area") else True
         fac_bdydiff_v = 5.0
         nudgezone_diff = 9.0
 
@@ -127,14 +127,14 @@ class TestApplyDiffusionToVn(StencilTest):
 
         edge_domain = h_grid.domain(dims.EdgeDim)
         horizontal_start = (
-            0
-            if "SimpleGrid" in str(grid)
-            else grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5))
+            grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5))
+            if hasattr(grid, "start_index")
+            else 0
         )
         horizontal_end = (
-            grid.num_edges
-            if "SimpleGrid" in str(grid)
-            else grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+            grid.end_index(edge_domain(h_grid.Zone.LOCAL))
+            if hasattr(grid, "end_index")
+            else grid.num_edges
         )
 
         return dict(

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_vn.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_apply_diffusion_to_vn.py
@@ -11,7 +11,7 @@ import pytest
 
 from icon4py.model.atmosphere.diffusion.stencils.apply_diffusion_to_vn import apply_diffusion_to_vn
 from icon4py.model.common import dimension as dims
-from icon4py.model.common.grid.icon import IconGrid
+from icon4py.model.common.grid import horizontal as h_grid
 from icon4py.model.common.test_utils.helpers import StencilTest, as_1D_sparse_field, random_field
 from icon4py.model.common.utils import gt4py_field_allocation as field_alloc
 
@@ -49,6 +49,7 @@ class TestApplyDiffusionToVn(StencilTest):
         limited_area,
         **kwargs,
     ):
+        vn_cp = vn.copy()
         z_nabla4_e2 = calculate_nabla4_numpy(
             grid,
             u_vert,
@@ -89,15 +90,14 @@ class TestApplyDiffusionToVn(StencilTest):
                 vn,
             )
 
+        # restriction of execution domain
+        vn[0 : kwargs["horizontal_start"], :] = vn_cp[0 : kwargs["horizontal_start"], :]
+        vn[kwargs["horizontal_end"] :, :] = vn_cp[kwargs["horizontal_end"] :, :]
+
         return dict(vn=vn)
 
     @pytest.fixture
     def input_data(self, grid):
-        if isinstance(grid, IconGrid) and grid.limited_area:
-            pytest.xfail(
-                "Execution domain needs to be restricted or boundary taken into account in stencil."
-            )
-
         edge = field_alloc.allocate_indices(dims.EdgeDim, grid=grid, is_halfdim=False)
 
         u_vert = random_field(grid, dims.VertexDim, dims.KDim)
@@ -119,11 +119,15 @@ class TestApplyDiffusionToVn(StencilTest):
         vn = random_field(grid, dims.EdgeDim, dims.KDim)
         nudgecoeff_e = random_field(grid, dims.EdgeDim)
 
-        limited_area = True
+        limited_area = grid.limited_area
         fac_bdydiff_v = 5.0
         nudgezone_diff = 9.0
 
         start_2nd_nudge_line_idx_e = 6
+
+        edge_domain = h_grid.domain(dims.EdgeDim)
+        horizontal_start = grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5))
+        horizontal_end = grid.end_index(edge_domain(h_grid.Zone.LOCAL))
 
         return dict(
             u_vert=u_vert,
@@ -143,8 +147,8 @@ class TestApplyDiffusionToVn(StencilTest):
             fac_bdydiff_v=fac_bdydiff_v,
             start_2nd_nudge_line_idx_e=start_2nd_nudge_line_idx_e,
             limited_area=limited_area,
-            horizontal_start=0,
-            horizontal_end=grid.num_edges,
+            horizontal_start=horizontal_start,
+            horizontal_end=horizontal_end,
             vertical_start=0,
             vertical_end=grid.num_levels,
         )

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_calculate_nabla2_for_z.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_calculate_nabla2_for_z.py
@@ -68,9 +68,9 @@ class TestCalculateNabla2ForZ(StencilTest):
 
         edge_domain = h_grid.domain(dims.EdgeDim)
         horizontal_start = (
-            0
-            if "SimpleGrid" in str(grid)
-            else grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2))
+            grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2))
+            if hasattr(grid, "start_index")
+            else 0
         )
 
         return dict(

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_calculate_nabla2_for_z.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_calculate_nabla2_for_z.py
@@ -14,7 +14,6 @@ from icon4py.model.atmosphere.diffusion.stencils.calculate_nabla2_for_z import (
     calculate_nabla2_for_z,
 )
 from icon4py.model.common import dimension as dims
-from icon4py.model.common.grid.icon import IconGrid
 from icon4py.model.common.test_utils.helpers import StencilTest, random_field
 from icon4py.model.common.type_alias import vpfloat, wpfloat
 
@@ -51,11 +50,6 @@ class TestCalculateNabla2ForZ(StencilTest):
 
     @pytest.fixture
     def input_data(self, grid):
-        if isinstance(grid, IconGrid) and grid.limited_area:
-            pytest.xfail(
-                "Execution domain needs to be restricted or boundary taken into account in stencil."
-            )
-
         kh_smag_e = random_field(grid, dims.EdgeDim, dims.KDim, dtype=vpfloat)
         inv_dual_edge_length = random_field(grid, dims.EdgeDim, dtype=wpfloat)
         theta_v = random_field(grid, dims.CellDim, dims.KDim, dtype=wpfloat)

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_calculate_nabla2_for_z.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_calculate_nabla2_for_z.py
@@ -67,7 +67,11 @@ class TestCalculateNabla2ForZ(StencilTest):
         z_nabla2_e = random_field(grid, dims.EdgeDim, dims.KDim, dtype=wpfloat)
 
         edge_domain = h_grid.domain(dims.EdgeDim)
-        horizontal_start = grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2))
+        horizontal_start = (
+            0
+            if "SimpleGrid" in str(grid)
+            else grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2))
+        )
 
         return dict(
             kh_smag_e=kh_smag_e,

--- a/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_update_theta_and_exner.py
+++ b/model/atmosphere/diffusion/tests/diffusion_stencil_tests/test_update_theta_and_exner.py
@@ -26,9 +26,9 @@ def update_theta_and_exner_numpy(
     exner: np.array,
     rd_o_cvd: float,
 ) -> tuple[np.array]:
-    area = np.expand_dims(area, axis=0)
+    area = np.expand_dims(area, axis=-1)
     z_theta = theta_v
-    theta_v = theta_v + (np.expand_dims(area, axis=-1) * z_temp)
+    theta_v = theta_v + (area * z_temp)
     exner = exner * (1.0 + rd_o_cvd * (theta_v / z_theta - 1.0))
     return theta_v, exner
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/fused_velocity_advection_stencil_19_to_20.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/fused_velocity_advection_stencil_19_to_20.py
@@ -119,6 +119,10 @@ def fused_velocity_advection_stencil_19_to_20(
     extra_diffu: bool,
     nlev: int32,
     nrdmax: int32,
+    horizontal_start: int32,
+    horizontal_end: int32,
+    vertical_start: int32,
+    vertical_end: int32,
 ):
     _fused_velocity_advection_stencil_19_to_20(
         vn,
@@ -145,4 +149,8 @@ def fused_velocity_advection_stencil_19_to_20(
         nlev,
         nrdmax,
         out=ddt_vn_apc,
+        domain={
+            dims.EdgeDim: (horizontal_start, horizontal_end),
+            dims.KDim: (vertical_start, vertical_end),
+        },
     )

--- a/model/atmosphere/dycore/tests/dycore_stencil_tests/test_fused_velocity_advection_stencil_19_to_20.py
+++ b/model/atmosphere/dycore/tests/dycore_stencil_tests/test_fused_velocity_advection_stencil_19_to_20.py
@@ -147,9 +147,9 @@ class TestFusedVelocityAdvectionStencil19To20(StencilTest):
         extra_diffu = True
         edge_domain = h_grid.domain(dims.EdgeDim)
         horizontal_start = (
-            0
-            if "SimpleGrid" in str(grid)
-            else grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2))
+            grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2))
+            if hasattr(grid, "start_index")
+            else 0
         )
 
         return dict(

--- a/model/atmosphere/dycore/tests/dycore_stencil_tests/test_fused_velocity_advection_stencil_19_to_20.py
+++ b/model/atmosphere/dycore/tests/dycore_stencil_tests/test_fused_velocity_advection_stencil_19_to_20.py
@@ -14,7 +14,6 @@ from icon4py.model.atmosphere.dycore.fused_velocity_advection_stencil_19_to_20 i
     fused_velocity_advection_stencil_19_to_20,
 )
 from icon4py.model.common import dimension as dims
-from icon4py.model.common.grid.icon import IconGrid
 from icon4py.model.common.test_utils.helpers import (
     StencilTest,
     as_1D_sparse_field,
@@ -108,11 +107,6 @@ class TestFusedVelocityAdvectionStencil19To20(StencilTest):
 
     @pytest.fixture
     def input_data(self, grid):
-        if isinstance(grid, IconGrid) and grid.limited_area:
-            pytest.xfail(
-                "Execution domain needs to be restricted or boundary taken into account in stencil."
-            )
-
         z_kin_hor_e = random_field(grid, dims.EdgeDim, dims.KDim)
         coeff_gradekin = random_field(grid, dims.EdgeDim, dims.E2CDim)
         coeff_gradekin_new = as_1D_sparse_field(coeff_gradekin, dims.ECDim)

--- a/model/atmosphere/dycore/tests/dycore_stencil_tests/test_fused_velocity_advection_stencil_19_to_20.py
+++ b/model/atmosphere/dycore/tests/dycore_stencil_tests/test_fused_velocity_advection_stencil_19_to_20.py
@@ -146,7 +146,11 @@ class TestFusedVelocityAdvectionStencil19To20(StencilTest):
         nrdmax = 5
         extra_diffu = True
         edge_domain = h_grid.domain(dims.EdgeDim)
-        horizontal_start = grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2))
+        horizontal_start = (
+            0
+            if "SimpleGrid" in str(grid)
+            else grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_2))
+        )
 
         return dict(
             vn=vn,

--- a/model/atmosphere/dycore/tests/dycore_stencil_tests/test_fused_velocity_advection_stencil_1_to_7.py
+++ b/model/atmosphere/dycore/tests/dycore_stencil_tests/test_fused_velocity_advection_stencil_1_to_7.py
@@ -14,7 +14,6 @@ from icon4py.model.atmosphere.dycore.fused_velocity_advection_stencil_1_to_7 imp
     fused_velocity_advection_stencil_1_to_7,
 )
 from icon4py.model.common import dimension as dims
-from icon4py.model.common.grid.icon import IconGrid
 from icon4py.model.common.test_utils.helpers import StencilTest, random_field, zero_field
 from icon4py.model.common.utils import gt4py_field_allocation as field_alloc
 
@@ -203,10 +202,6 @@ class TestFusedVelocityAdvectionStencil1To7(StencilTest):
         pytest.xfail(
             "Verification of z_v_grad_w currently not working, because numpy version incorrect."
         )
-        if isinstance(grid, IconGrid) and grid.limited_area:
-            pytest.xfail(
-                "Execution domain needs to be restricted or boundary taken into account in stencil."
-            )
 
         c_intp = random_field(grid, dims.VertexDim, dims.V2CDim)
         vn = random_field(grid, dims.EdgeDim, dims.KDim)


### PR DESCRIPTION
refactoring of `init_nabla2_factor_in_upper_damping_zone` to a gt4py stencil

removal of:

```python
        if isinstance(grid, IconGrid) and grid.limited_area:
            pytest.xfail(
                "Execution domain needs to be restricted or boundary taken into account in stencil."
            )
```
and consequent changes