### PR TITLE
Fix nlevp1 bug in dycore

### DIFF
--- a/model/atmosphere/dycore/README.md
+++ b/model/atmosphere/dycore/README.md
@@ -4,16 +4,16 @@
 
 Contains code ported from ICON `src/atm_dyn_iconam`, which is the dynamical core of the ICON model.
 
-## Attention
+## Treatment of stencils operating on different vertical levels
 
 Variables in ICON can either sit on full levels or half levels. Let's denote the number of full levels is nlev.
 Full-level variables have nlev levels in vertical dimension, while half-level variables have nlev+1 in vertical dimension.
-Do not output full-level and half-level variables together when running a gt4py program if you need to access the nlev+1 level because it will cause random behavior (most probably illegal memory access).
+When running a GT4Py program over nlev+1 levels, do not output full-level and half-level variables together in a field_operator until the upper vertical bound of nlev+1 because the nlev+1 level will also be written for a full-level variable, which is out-of-bounds.
 The following code is an example:
 
 ```python
 @field_operator
-def foo(
+def _foo(
     input_var,
     k_field,
     nlev,
@@ -36,13 +36,13 @@ def foo(
     horizontal_start,
     horizontal_end,
     vertical_start,
-   vertical_end,
+    vertical_end,
 ):
     _foo(
         input_var,
         k_field,
         nlev,
-        out=(full_level_var, half_level_var),
+        out=(half_level_var, full_level_var),
         domain={
             CellDim: (horizontal_start, horizontal_end),
             KDim: (vertical_start, vertical_end),
@@ -63,6 +63,52 @@ foo(
     offset_provider={},
 )
 ```
+
+Here is a fix to the example above:
+
+```python
+@program
+def foo(
+    input_var,
+    full_level_var,
+    half_level_var,
+    horizontal_start,
+    horizontal_end,
+    vertical_start,
+    vertical_end,
+):
+    _compute_var(
+        input_var,
+        out=(half_level_var, full_level_var),
+        domain={
+            CellDim: (horizontal_start, horizontal_end),
+            KDim: (vertical_start, vertical_end - 1),
+        }
+    )
+    _init_cell_kdim_field_with_zero_vp(
+        out=half_level_var,
+        domain={
+            CellDim: (horizontal_start, horizontal_end),
+            KDim: (vertical_end - 1, vertical_end),
+        }
+    )
+)
+
+foo(
+    input_var=input_var,
+    full_level_var=full_level_var,
+    half_level_var=half_level_var,
+    horizontal_start=start_cell,
+    horizontal_end=end_cell,
+    vertical_start=0,
+    vertical_end=nlev + 1,
+    offset_provider={},
+)
+```
+
+In the fix above, the original field_operator `_foo` is removed and the GT4Py program directly calls `_compute_var` and `_init_cell_kdim_field_with_zero_vp` separately with different vertical bounds.
+The illegal access to nlev+1 level of the full-level variable can thus be avoided by calling `_compute_var` with vertical bounds of (0, nlev).
+The computation on nlev+1 level `half_level_var = where(k_field == nlev, _init_cell_kdim_field_with_zero_vp(), half_level_var)` in the removed field_operator `_foo` is instead performed explicitly by calling `_init_cell_kdim_field_with_zero_vp` with another vertical bounds of (nlev, nlev+1).
 
 ## Installation instructions
 

--- a/model/atmosphere/dycore/README.md
+++ b/model/atmosphere/dycore/README.md
@@ -4,6 +4,66 @@
 
 Contains code ported from ICON `src/atm_dyn_iconam`, which is the dynamical core of the ICON model.
 
+## Attention
+
+Variables in ICON can either sit on full levels or half levels. Let's denote the number of full levels is nlev.
+Full-level variables have nlev levels in vertical dimension, while half-level variables have nlev+1 in vertical dimension.
+Do not output full-level and half-level variables together when running a gt4py program if you need to access the nlev+1 level because it will cause random behavior (most probably illegal memory access).
+The following code is an example:
+
+```python
+@field_operator
+def foo(
+    input_var,
+    k_field,
+    nlev,
+):
+    (half_level_var, full_level_var) =  where(
+        (k_field >= 0) & (k_field < nlev),
+        _compute_var(input_var),
+        (half_level_var, full_level_var),
+    )
+    half_level_var = where(k_field == nlev, _init_cell_kdim_field_with_zero_vp(), half_level_var)
+    return half_level_var, full_level_var
+
+@program
+def foo(
+    input_var,
+    k_field,
+    nlev,
+    full_level_var,
+    half_level_var,
+    horizontal_start,
+    horizontal_end,
+    vertical_start,
+   vertical_end,
+):
+    _foo(
+        input_var,
+        k_field,
+        nlev,
+        out=(full_level_var, half_level_var),
+        domain={
+            CellDim: (horizontal_start, horizontal_end),
+            KDim: (vertical_start, vertical_end),
+        }
+    )
+)
+
+foo(
+    input_var=input_var,
+    full_level_var=full_level_var,
+    half_level_var=half_level_var,
+    k_field=k_field,
+    nlev=nlev,
+    horizontal_start=start_cell,
+    horizontal_end=end_cell,
+    vertical_start=0,
+    vertical_end=nlev + 1,
+    offset_provider={},
+)
+```
+
 ## Installation instructions
 
 Check the `README.md` at the root of the `model` folder for installation instructions.

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/compute_virtual_potential_temperatures_and_pressure_gradient.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/compute_virtual_potential_temperatures_and_pressure_gradient.py
@@ -82,7 +82,6 @@ def _compute_virtual_potential_temperatures(
     wgtfac_c: fa.CellKField[vpfloat],
     z_rth_pr_2: fa.CellKField[vpfloat],
     theta_v: fa.CellKField[wpfloat],
-    d_exner_dz_ref_ic: fa.CellKField[vpfloat],
 ) -> tuple[
     fa.CellKField[vpfloat],
     fa.CellKField[wpfloat],

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro.py
@@ -585,7 +585,7 @@ class SolveNonhydro:
         self._predictor_stencils_4_5_6 = nhsolve_prog.predictor_stencils_4_5_6.with_backend(
             self._backend
         )
-        self.compute_perturbed_rho_and_potential_temperatures_at_half_and_full_levels = nhsolve_prog.compute_perturbed_rho_and_potential_temperatures_at_half_and_full_levels.with_backend(
+        self._compute_pressure_gradient_and_perturbed_rho_and_potential_temperatures = nhsolve_prog.compute_pressure_gradient_and_perturbed_rho_and_potential_temperatures.with_backend(
             self._backend
         )
         self._predictor_stencils_11_lower_upper = (
@@ -993,8 +993,6 @@ class SolveNonhydro:
             z_exner_ex_pr=self.z_exner_ex_pr,
             horizontal_start=self._start_cell_lateral_boundary_level_3,
             horizontal_end=self._end_cell_halo,
-            k_field=self.k_field,
-            nlev=self.grid.num_levels,
             vertical_start=0,
             vertical_end=self.grid.num_levels + 1,
             offset_provider={},
@@ -1008,8 +1006,6 @@ class SolveNonhydro:
                 wgtfac_c=self.metric_state_nonhydro.wgtfac_c,
                 inv_ddqz_z_full=self.metric_state_nonhydro.inv_ddqz_z_full,
                 z_dexner_dz_c_1=self.z_dexner_dz_c_1,
-                k_field=self.k_field,
-                nlev=self.grid.num_levels,
                 horizontal_start=self._start_cell_lateral_boundary_level_3,
                 horizontal_end=self._end_cell_halo,
                 vertical_start=max(1, self.vertical_params.nflatlev),
@@ -1021,7 +1017,7 @@ class SolveNonhydro:
                 # Perturbation Exner pressure on top half level
                 raise NotImplementedError("nflatlev=1 not implemented")
 
-        self.compute_perturbed_rho_and_potential_temperatures_at_half_and_full_levels(
+        self._compute_pressure_gradient_and_perturbed_rho_and_potential_temperatures(
             rho=prognostic_state[nnow].rho,
             rho_ref_mc=self.metric_state_nonhydro.rho_ref_mc,
             theta_v=prognostic_state[nnow].theta_v,
@@ -1038,7 +1034,6 @@ class SolveNonhydro:
             theta_v_ic=diagnostic_state_nh.theta_v_ic,
             z_th_ddz_exner_c=self.z_th_ddz_exner_c,
             k_field=self.k_field,
-            nlev=self.grid.num_levels,
             horizontal_start=self._start_cell_lateral_boundary_level_3,
             horizontal_end=self._end_cell_halo,
             vertical_start=0,
@@ -1457,9 +1452,7 @@ class SolveNonhydro:
             z_flxdiv_theta=self.z_flxdiv_theta,
             theta_v_ic=diagnostic_state_nh.theta_v_ic,
             ddt_exner_phy=diagnostic_state_nh.ddt_exner_phy,
-            k_field=self.k_field,
             dtime=dtime,
-            nlev=self.grid.num_levels,
             horizontal_start=self._start_cell_nudging,
             horizontal_end=self._end_cell_local,
             vertical_start=0,
@@ -1585,9 +1578,7 @@ class SolveNonhydro:
                 rho_new=prognostic_state[nnew].rho,
                 exner_new=prognostic_state[nnew].exner,
                 w_new=prognostic_state[nnew].w,
-                k_field=self.k_field,
                 dtime=dtime,
-                nlev=self.grid.num_levels,
                 horizontal_start=self._start_cell_lateral_boundary,
                 horizontal_end=self._end_cell_lateral_boundary_level_4,
                 vertical_start=0,
@@ -1981,9 +1972,7 @@ class SolveNonhydro:
             z_flxdiv_theta=self.z_flxdiv_theta,
             theta_v_ic=diagnostic_state_nh.theta_v_ic,
             ddt_exner_phy=diagnostic_state_nh.ddt_exner_phy,
-            k_field=self.k_field,
             dtime=dtime,
-            nlev=self.grid.num_levels,
             horizontal_start=self._start_cell_nudging,
             horizontal_end=self._end_cell_local,
             vertical_start=0,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro_program.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/nh_solve/solve_nonhydro_program.py
@@ -236,7 +236,6 @@ def _compute_pressure_gradient_and_perturbed_rho_and_potential_temperatures(
 
 
 @gtx.program(grid_type=gtx.GridType.UNSTRUCTURED)
-# def compute_perturbed_rho_and_potential_temperatures_at_half_and_full_levels(
 def compute_pressure_gradient_and_perturbed_rho_and_potential_temperatures(
     rho: fa.CellKField[float],
     rho_ref_mc: fa.CellKField[float],
@@ -557,7 +556,7 @@ def stencils_39_40(
 
 
 @gtx.field_operator
-def _stencils_42_44_45_45b(
+def _stencils_42_44_45(
     z_w_expl: fa.CellKField[float],
     w_nnow: fa.CellKField[float],
     ddt_w_adv_ntl1: fa.CellKField[float],
@@ -625,9 +624,8 @@ def _stencils_42_44_45_45b(
         ),
         (z_beta, z_alpha),
     )
-    z_alpha = where(k_field == nlev, _init_cell_kdim_field_with_zero_vp(), z_alpha)
-
     z_q = where(k_field == 0, _init_cell_kdim_field_with_zero_vp(), z_q)
+
     return z_w_expl, z_contr_w_fl_l, z_beta, z_alpha, z_q
 
 
@@ -664,7 +662,7 @@ def stencils_42_44_45_45b(
     vertical_start: gtx.int32,
     vertical_end: gtx.int32,
 ):
-    _stencils_42_44_45_45b(
+    _stencils_42_44_45(
         z_w_expl,
         w_nnow,
         ddt_w_adv_ntl1,
@@ -694,7 +692,14 @@ def stencils_42_44_45_45b(
         out=(z_w_expl, z_contr_w_fl_l, z_beta, z_alpha, z_q),
         domain={
             dims.CellDim: (horizontal_start, horizontal_end),
-            dims.KDim: (vertical_start, vertical_end),
+            dims.KDim: (vertical_start, vertical_end - 1),
+        },
+    )
+    _init_cell_kdim_field_with_zero_vp(
+        out=z_alpha,
+        domain={
+            dims.CellDim: (horizontal_start, horizontal_end),
+            dims.KDim: (vertical_end - 1, vertical_end),
         },
     )
 

--- a/model/driver/src/icon4py/model/driver/test_cases/utils.py
+++ b/model/driver/src/icon4py/model/driver/test_cases/utils.py
@@ -145,14 +145,18 @@ def zonalwind_2_normalwind_numpy(
             u
             + jw_up
             * xp.exp(
-                -10.0
-                * xp.arccos(
-                    xp.sin(lat_perturbation_center) * xp.sin(edge_lat)
-                    + xp.cos(lat_perturbation_center)
-                    * xp.cos(edge_lat)
-                    * xp.cos(edge_lon - lon_perturbation_center)
+                -(
+                    (
+                        10.0
+                        * xp.arccos(
+                            xp.sin(lat_perturbation_center) * xp.sin(edge_lat)
+                            + xp.cos(lat_perturbation_center)
+                            * xp.cos(edge_lat)
+                            * xp.cos(edge_lon - lon_perturbation_center)
+                        )
+                    )
+                    ** 2
                 )
-                ** 2
             ),
             u,
         )


### PR DESCRIPTION
A temporary fix of the illegal memory access caused by writing or reading full-level variables in a `field_operator` at `nlevp1` in `solve_nonhydro_program.py`. For example,
```
@field_operator
def foo(
    input_var,
    k_field,
    nlev,
):
    (half_level_var, full_level_var) =  where(
        (k_field >= 0) & (k_field < nlev),
        _compute_var(input_var),
        (half_level_var, full_level_var),
    )
    half_level_var = where(k_field == nlev, _init_cell_kdim_field_with_zero_vp(), half_level_var)
    return half_level_var, full_level_var

@program
def foo(
    input_var,
    k_field,
    nlev,
    full_level_var,
    half_level_var,
    horizontal_start,
    horizontal_end,
    vertical_start,
   vertical_end,
):
    _foo(
        input_var,
        k_field,
        nlev,
        out=(full_level_var, half_level_var),
        domain={
            dims.CellDim: (horizontal_start, horizontal_end),
            dims.KDim: (vertical_start, vertical_end),
        }
    )
)

foo(
    input_var=input_var,
    full_level_var=full_level_var,
    half_level_var=half_level_var,
    k_field=k_field,
    nlev=nlev,
    horizontal_start=start_cell,
    horizontal_end=end_cell,
    vertical_start=0,
    vertical_end=nlev + 1,
    offset_provider={},
)
```
The above example will lead to random behavior when the nvelp1 level is accessed for `full_level_var`.
There are five stencils that need to be fixed:
1. predictor_stencils_2_3
2. predictor_stencils_4_5_6
3. stencils_42_44_45_45b
4. stencils_43_44_45_45b
5. stencils_47_48_49
6. stencils_61_62
