### PR TITLE
restrict mpi4py to version below 4.0

### DIFF
--- a/model/common/pyproject.toml
+++ b/model/common/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = ">=3.10"
 [project.optional-dependencies]
 all = ["icon4py-common[ghex,io,dace]"]
 dace = ["dace>=0.16.1"]
-ghex = ["ghex", "mpi4py"]
+ghex = ["ghex", "mpi4py<4.0"]
 io = [
   "icon4py-common[netcdf]",
   "xarray[complete]>=2024.3.0",


### PR DESCRIPTION
(FIX) Restrict version to `mpi4py<4.0`.

`mpi4py<=4.0` seems to be incompatible with GHEX: `make_context` throws a TypeError, even thow the communicator that you pass in is a `mpi4py.MPI.Comm` according to a type check.