### PR TITLE
adding polybox url for additional advection data

### DIFF
--- a/model/common/src/icon4py/model/common/test_utils/datatest_fixtures.py
+++ b/model/common/src/icon4py/model/common/test_utils/datatest_fixtures.py
@@ -43,6 +43,7 @@ def download_ser_data(request, processor_props, ranked_data_path, experiment, py
 
     try:
         destination_path = dt_utils.get_datapath_for_experiment(ranked_data_path, experiment)
+        advection_uri = None
         if experiment == dt_utils.GLOBAL_EXPERIMENT:
             uri = dt_utils.DATA_URIS_APE[processor_props.comm_size]
         elif experiment == dt_utils.JABW_EXPERIMENT:
@@ -53,12 +54,20 @@ def download_ser_data(request, processor_props, ranked_data_path, experiment, py
             uri = dt_utils.DATA_URIS_WK[processor_props.comm_size]
         else:
             uri = dt_utils.DATA_URIS[processor_props.comm_size]
+            advection_uri = dt_utils.DATA_URIS_ADVECTION.get(processor_props.comm_size)
 
         data_file = ranked_data_path.joinpath(
             f"{experiment}_mpitask{processor_props.comm_size}.tar.gz"
         ).name
         if processor_props.rank == 0:
             data.download_and_extract(uri, ranked_data_path, destination_path, data_file)
+            if advection_uri:
+                advection_path = dt_utils.get_datapath_for_experiment(
+                    ranked_data_path, f"{experiment}/advection"
+                )
+                data.download_and_extract(
+                    advection_uri, ranked_data_path, advection_path, f"advection_{data_file}"
+                )
         if processor_props.comm:
             processor_props.comm.barrier()
     except KeyError as err:

--- a/model/common/src/icon4py/model/common/test_utils/datatest_utils.py
+++ b/model/common/src/icon4py/model/common/test_utils/datatest_utils.py
@@ -66,6 +66,7 @@ DATA_URIS_APE = {1: "https://polybox.ethz.ch/index.php/s/y9WRP1mpPlf2BtM/downloa
 DATA_URIS_JABW = {1: "https://polybox.ethz.ch/index.php/s/kp9Rab00guECrEd/download"}
 DATA_URIS_GAUSS3D = {1: "https://polybox.ethz.ch/index.php/s/IiRimdJH2ZBZ1od/download"}
 DATA_URIS_WK = {1: "https://polybox.ethz.ch/index.php/s/91DEUGmAkBgrXO6/download"}
+DATA_URIS_ADVECTION = {1: "https://polybox.ethz.ch/index.php/s/KV6FYstcGysNDOj/download"}
 
 
 def get_global_grid_params(experiment: str) -> tuple[int, int]:


### PR DESCRIPTION
Adding polybox URL for the additional serialized data for the advection tests.

- download and extract addittional data needed for advection tests in case of single nodes runs for `MCH_CH_R04B09_DSL`.
 
