### PR TITLE
add ghex package name to git uri

### DIFF
--- a/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/test_parallel_diffusion.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/mpi_tests/test_parallel_diffusion.py
@@ -61,37 +61,7 @@ def test_parallel_diffusion(
     print(
         f"rank={processor_props.rank}/{processor_props.comm_size}: using local grid with {icon_grid.num_cells} Cells, {icon_grid.num_edges} Edges, {icon_grid.num_vertices} Vertices"
     )
-    metric_state = diffusion_states.DiffusionMetricState(
-        mask_hdiff=metrics_savepoint.mask_hdiff(),
-        theta_ref_mc=metrics_savepoint.theta_ref_mc(),
-        wgtfac_c=metrics_savepoint.wgtfac_c(),
-        zd_intcoef=metrics_savepoint.zd_intcoef(),
-        zd_vertoffset=metrics_savepoint.zd_vertoffset(),
-        zd_diffcoef=metrics_savepoint.zd_diffcoef(),
-    )
-    cell_geometry = grid_savepoint.construct_cell_geometry()
-    edge_geometry = grid_savepoint.construct_edge_geometry()
-
-    interpolation_state = diffusion_states.DiffusionInterpolationState(
-        e_bln_c_s=helpers.as_1D_sparse_field(interpolation_savepoint.e_bln_c_s(), dims.CEDim),
-        rbf_coeff_1=interpolation_savepoint.rbf_vec_coeff_v1(),
-        rbf_coeff_2=interpolation_savepoint.rbf_vec_coeff_v2(),
-        geofac_div=helpers.as_1D_sparse_field(interpolation_savepoint.geofac_div(), dims.CEDim),
-        geofac_n2s=interpolation_savepoint.geofac_n2s(),
-        geofac_grg_x=interpolation_savepoint.geofac_grg()[0],
-        geofac_grg_y=interpolation_savepoint.geofac_grg()[1],
-        nudgecoeff_e=interpolation_savepoint.nudgecoeff_e(),
-    )
-
-    vertical_config = v_grid.VerticalGridConfig(
-        icon_grid.num_levels,
-        lowest_layer_thickness=lowest_layer_thickness,
-        model_top_height=model_top_height,
-        stretch_factor=stretch_factor,
-        rayleigh_damping_height=damping_height,
-    )
     config = utils.construct_diffusion_config(experiment, ndyn_substeps=ndyn_substeps)
-    diffusion_params = diffusion_.DiffusionParams(config)
     dtime = savepoint_diffusion_init.get_metadata("dtime").get("dtime")
     print(
         f"rank={processor_props.rank}/{processor_props.comm_size}:  setup: using {processor_props.comm_name} with {processor_props.comm_size} nodes"
@@ -99,18 +69,6 @@ def test_parallel_diffusion(
 
     diffusion = diffusion_instance  # the fixture makes sure that the orchestrator cache is cleared properly between pytest runs -if applicable-
 
-    diffusion.Diffusion(
-        grid=icon_grid,
-        config=config,
-        params=diffusion_params,
-        vertical_grid=v_grid.VerticalGrid(
-            vertical_config, grid_savepoint.vct_a(), grid_savepoint.vct_b()
-        ),
-        metric_state=metric_state,
-        interpolation_state=interpolation_state,
-        edge_params=edge_geometry,
-        cell_params=cell_geometry,
-    )
     print(f"rank={processor_props.rank}/{processor_props.comm_size}: diffusion initialized ")
 
     diagnostic_state = diffusion_states.DiffusionDiagnosticState(

--- a/model/atmosphere/dycore/tests/dycore_tests/mpi_tests/test_parallel_solve_nonhydro.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/mpi_tests/test_parallel_solve_nonhydro.py
@@ -74,7 +74,7 @@ def test_run_solve_nonhydro_single_step(
         f"rank={processor_props.rank}/{processor_props.comm_size}: number of halo cells {np.count_nonzero(np.invert(owned_cells))}"
     )
 
-    config = utils.construct_solve_nh_config(experiment, ndyn_substeps=ndyn_substeps)
+    config = utils.construct_solve_nh_config(experiment, ndyn=ndyn_substeps)
     sp = savepoint_nonhydro_init
     sp_step_exit = savepoint_nonhydro_step_exit
     nonhydro_params = nh.NonHydrostaticParams(config)

--- a/model/common/tests/grid_tests/mpi_tests/test_parallel_icon.py
+++ b/model/common/tests/grid_tests/mpi_tests/test_parallel_icon.py
@@ -9,6 +9,7 @@ import logging
 import re
 
 import pytest
+from ghex.context import make_context
 
 import icon4py.model.common.dimension as dims
 import icon4py.model.common.grid.horizontal as h_grid
@@ -21,14 +22,19 @@ from .. import utils
 
 
 try:
-    import mpi4py  # noqa F401:  import mpi4py to check for optional mpi dependency
+    import mpi4py  # F401:  import mpi4py to check for optional mpi dependency
 except ImportError:
     pytest.skip("Skipping parallel on single node installation", allow_module_level=True)
 
 
 @pytest.mark.parametrize("processor_props", [True], indirect=True)
 def test_props(processor_props):  # noqa: F811  # fixture
+    """dummy test to check whether the MPI initialization anc GHEX setup works."""
     assert processor_props.comm
+    assert isinstance(
+        processor_props.comm, mpi4py.MPI.Comm
+    ), "comm needs to be an instance of MPI.Comm"
+    make_context(processor_props.comm)
 
 
 LOCAL_IDX_2 = {

--- a/model/common/tests/grid_tests/mpi_tests/test_parallel_icon.py
+++ b/model/common/tests/grid_tests/mpi_tests/test_parallel_icon.py
@@ -29,7 +29,7 @@ except ImportError:
 
 @pytest.mark.parametrize("processor_props", [True], indirect=True)
 def test_props(processor_props):  # noqa: F811  # fixture
-    """dummy test to check whether the MPI initialization anc GHEX setup works."""
+    """dummy test to check whether the MPI initialization and GHEX setup works."""
     assert processor_props.comm
     assert isinstance(
         processor_props.comm, mpi4py.MPI.Comm

--- a/model/common/tests/grid_tests/mpi_tests/test_parallel_icon.py
+++ b/model/common/tests/grid_tests/mpi_tests/test_parallel_icon.py
@@ -9,7 +9,6 @@ import logging
 import re
 
 import pytest
-from ghex.context import make_context
 
 import icon4py.model.common.dimension as dims
 import icon4py.model.common.grid.horizontal as h_grid
@@ -27,14 +26,18 @@ except ImportError:
     pytest.skip("Skipping parallel on single node installation", allow_module_level=True)
 
 
+@pytest.mark.mpi
 @pytest.mark.parametrize("processor_props", [True], indirect=True)
 def test_props(processor_props):  # noqa: F811  # fixture
     """dummy test to check whether the MPI initialization and GHEX setup works."""
+    import ghex.context as ghex
+
     assert processor_props.comm
+
     assert isinstance(
         processor_props.comm, mpi4py.MPI.Comm
     ), "comm needs to be an instance of MPI.Comm"
-    make_context(processor_props.comm)
+    ghex.make_context(processor_props.comm)
 
 
 LOCAL_IDX_2 = {

--- a/requirements-dev-opt.txt
+++ b/requirements-dev-opt.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ghex-org/GHEX.git@master#subdirectory=bindings/python
+ghex@git+https://github.com/ghex-org/GHEX.git@master#subdirectory=bindings/python
 -r base-requirements-dev.txt
 # icon4py model
 -e ./model/common[all]
@@ -10,5 +10,4 @@ git+https://github.com/ghex-org/GHEX.git@master#subdirectory=bindings/python
 
 # icon4pytools
 -e ./tools
-
 


### PR DESCRIPTION
(FIX) Adding package name `ghex` to git uri for installation in requirements file.

This replaces [PR 583](https://github.com/C2SM/icon4py/pull/583)

Adding ghex package name to the git uri in the requirements file seems to fix the issue with the ghex build with  mpi4py 4.0.

(I don't really understand why it fixes the issue, but it is certainly not wrong to have to specify the package name`

*additional changes:*
fix tests to recent changes. 
