### PR TITLE
Small refactor of common.utils adding Swapping and chainable

### DIFF
--- a/model/common/src/icon4py/model/common/components/__init__.py
+++ b/model/common/src/icon4py/model/common/components/__init__.py
@@ -1,0 +1,7 @@
+# ICON4Py - ICON inspired code in Python and GT4Py
+#
+# Copyright (c) 2022-2024, ETH Zurich and MeteoSwiss
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause

--- a/model/common/src/icon4py/model/common/decomposition/definitions.py
+++ b/model/common/src/icon4py/model/common/decomposition/definitions.py
@@ -16,8 +16,8 @@ from typing import Any, Optional, Protocol, Sequence, runtime_checkable
 
 from gt4py.next import Dimension
 
+from icon4py.model.common import utils
 from icon4py.model.common.settings import xp
-from icon4py.model.common.utils import builder
 
 
 try:
@@ -75,7 +75,7 @@ class DecompositionInfo:
         OWNED = 1
         HALO = 2
 
-    @builder.builder
+    @utils.chainable
     def with_dimension(self, dim: Dimension, global_index: xp.ndarray, owner_mask: xp.ndarray):
         self._global_index[dim] = global_index
         self._owner_mask[dim] = owner_mask

--- a/model/common/src/icon4py/model/common/grid/base.py
+++ b/model/common/src/icon4py/model/common/grid/base.py
@@ -15,10 +15,9 @@ from typing import Callable, Dict
 import gt4py.next as gtx
 import numpy as np
 
-from icon4py.model.common import dimension as dims
+from icon4py.model.common import dimension as dims, utils
 from icon4py.model.common.grid import utils as grid_utils
 from icon4py.model.common.settings import xp
-from icon4py.model.common.utils import builder
 
 
 class MissingConnectivity(ValueError):
@@ -113,12 +112,12 @@ class BaseGrid(ABC):
 
         return offset_providers
 
-    @builder.builder
+    @utils.chainable
     def with_connectivities(self, connectivity: Dict[gtx.Dimension, np.ndarray]):
         self.connectivities.update({d: k.astype(gtx.int32) for d, k in connectivity.items()})
         self.size.update({d: t.shape[1] for d, t in connectivity.items()})
 
-    @builder.builder
+    @utils.chainable
     def with_config(self, config: GridConfig):
         self.config = config
         self._update_size()

--- a/model/common/src/icon4py/model/common/grid/icon.py
+++ b/model/common/src/icon4py/model/common/grid/icon.py
@@ -13,9 +13,8 @@ import uuid
 import gt4py.next as gtx
 import numpy as np
 
-from icon4py.model.common import dimension as dims
+from icon4py.model.common import dimension as dims, utils
 from icon4py.model.common.grid import base, horizontal as h_grid
-from icon4py.model.common.utils import builder
 
 
 log = logging.getLogger(__name__)
@@ -86,7 +85,7 @@ class IconGrid(base.BaseGrid):
             ),
         }
 
-    @builder.builder
+    @utils.chainable
     def with_start_end_indices(
         self, dim: gtx.Dimension, start_indices: np.ndarray, end_indices: np.ndarray
     ):
@@ -94,7 +93,7 @@ class IconGrid(base.BaseGrid):
         self._start_indices[dim] = start_indices.astype(gtx.int32)
         self._end_indices[dim] = end_indices.astype(gtx.int32)
 
-    @builder.builder
+    @utils.chainable
     def with_global_params(self, global_params: GlobalGridParams):
         self.global_properties = global_params
 

--- a/model/common/src/icon4py/model/common/utils/__init__.py
+++ b/model/common/src/icon4py/model/common/utils/__init__.py
@@ -6,12 +6,12 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
 
-def builder(func):
-    """Use as decorator on builder functions."""
+from ._common import Swapping, chainable
 
-    def wrapper(self, *args, **kwargs):
-        func(self, *args, **kwargs)
-        return self
 
-    return wrapper
+__all__ = [
+    "chainable",
+    "Swapping",
+]

--- a/model/common/src/icon4py/model/common/utils/_common.py
+++ b/model/common/src/icon4py/model/common/utils/_common.py
@@ -1,0 +1,127 @@
+# ICON4Py - ICON inspired code in Python and GT4Py
+#
+# Copyright (c) 2022-2024, ETH Zurich and MeteoSwiss
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+# ICON4Py - ICON inspired code in Python and GT4Py
+#
+# Copyright (c) 2022-2024, ETH Zurich and MeteoSwiss
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import Concatenate, Generic, ParamSpec, TypeVar
+
+
+__all__ = [
+    "chainable",
+    "Swapping",
+]
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def chainable(method_fn: Callable[Concatenate[T, P], None]) -> Callable[Concatenate[T, P], T]:
+    """
+    Make an instance method return the actual instance so it can used in a chain of calls.
+
+    Typically used for simple fluent interfaces.
+
+    Examples:
+        >>> class A:
+        ...     @chainable
+        ...     def set_value(self, value: int) -> None:
+        ...         self.value = value
+        ...
+        ...     @chainable
+        ...     def increment(self, value: int) -> None:
+        ...         self.value += value
+        ...
+        ...
+        ... a = A()
+        ... a.set_value(1).increment(2)
+        ... a.value
+        3
+    """
+
+    @functools.wraps(method_fn)
+    def wrapper(self: T, *args: P.args, **kwargs: P.kwargs) -> T:
+        method_fn(self, *args, **kwargs)
+        return self
+
+    return wrapper
+
+
+class Swapping(Generic[T]):
+    """
+    Generic double container for swapping between two values.
+
+    This is useful for double buffering in numerical algorithms.
+
+    Examples:
+        >>> a = Swapping(current=1, other=2)
+        Swapping(1, 2)
+
+        >>> a.swap()
+        Swapping(current=2, other=1)
+
+        >>> a.current = 3
+        ... a
+        Swapping(current=3, other=1)
+
+        >>> a != ~a
+        True
+
+        >>> a == ~~a
+        True
+
+        >>> a.current == (~a).other
+        True
+
+        >>> b = ~a
+        ... a.swap()
+        ... a == b
+        True
+    """
+
+    __slots__ = ("current", "_other", "__weakref__")
+
+    current: T
+    _other: T
+
+    @property
+    def other(self) -> T:
+        return self._other
+
+    def __init__(self, current: T, other: T) -> None:
+        self.current = current
+        self._other = other
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(current={self.current!r}, other={self._other!r})"
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, Swapping)
+            and self.current == other.current
+            and self._other == other._other
+        )
+
+    # `__hash__` is implicitly set to None when `__eq__` is redefined, so instances are not hashable.
+
+    def swap(self) -> None:
+        self.current, self._other = self._other, self.current
+
+    def __invert__(self) -> Swapping[T]:
+        return type(self)(current=self._other, other=self.current)

--- a/model/common/src/icon4py/model/common/utils/_common.py
+++ b/model/common/src/icon4py/model/common/utils/_common.py
@@ -7,15 +7,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
-# ICON4Py - ICON inspired code in Python and GT4Py
-#
-# Copyright (c) 2022-2024, ETH Zurich and MeteoSwiss
-# All rights reserved.
-#
-# Please, refer to the LICENSE file in the root directory.
-# SPDX-License-Identifier: BSD-3-Clause
-
-
 from __future__ import annotations
 
 import functools


### PR DESCRIPTION
Add the`Swapping` class inside `model.common.utils` as a generic utility for double buffering. Additionally, rename the `builder` class  to `chainable` and move it to the same `_common` module as `Swapping`. 
