### PR TITLE
CI fix: make validation consistent with numpy fields

### DIFF
--- a/model/common/src/icon4py/model/common/test_utils/helpers.py
+++ b/model/common/src/icon4py/model/common/test_utils/helpers.py
@@ -174,7 +174,7 @@ def _test_validation(self, grid, backend, input_data):
     reference_outputs = self.reference(
         grid,
         **{
-            k: v.ndarray if isinstance(v, gt_common.Field) else np.array(v)
+            k: v.asnumpy() if isinstance(v, gt_common.Field) else np.array(v)
             for k, v in input_data.items()
         },
     )
@@ -193,7 +193,7 @@ def _test_validation(self, grid, backend, input_data):
         )
 
         assert np.allclose(
-            input_data[name].ndarray[gtslice],
+            input_data[name].asnumpy()[gtslice],
             reference_outputs[name][refslice],
             equal_nan=True,
         ), f"Validation failed for '{name}'"


### PR DESCRIPTION
The operator used for validation of test results (`np.allclose`) is from NumPy, therefore the fields passed to this operator should be NumPy arrays. This fixes errors observed in the DaCe CI pipeline.