### PR TITLE
Use tagged release until compatibility with gt4py main is restored

### DIFF
--- a/base-requirements-dev.txt
+++ b/base-requirements-dev.txt
@@ -1,5 +1,5 @@
 # VCS
--e git+https://github.com/GridTools/gt4py.git@main#egg=gt4py
+-e git+https://github.com/GridTools/gt4py.git@icon4py_20241113#egg=gt4py  # use tagged release until #596 & gt4py#1738 is merged
 git+https://github.com/GridTools/serialbox#egg=serialbox&subdirectory=src/serialbox-python
 
 # PyPI

--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -1,3 +1,3 @@
 # VCS
-gt4py @ git+https://github.com/GridTools/gt4py.git@main
+gt4py @ git+https://github.com/GridTools/gt4py.git@icon4py_20241113  # use tagged release until #596 & gt4py#1738 is merged
 


### PR DESCRIPTION
Recently merged changes in gt4py (https://github.com/GridTools/gt4py/pull/1648) are incompatible with icon4py (e.g. missing support for dynamic shifts and new IR format). This PR fixes gt4py until the respective PRs restoring compatibility are merged (https://github.com/GridTools/gt4py/pulls & https://github.com/C2SM/icon4py/pull/596).