### PR TITLE
Improve nox configuration

### DIFF
--- a/model/common/tests/stencil_tests/test_cell_2_edge_interpolation.py
+++ b/model/common/tests/stencil_tests/test_cell_2_edge_interpolation.py
@@ -33,6 +33,8 @@ class TestCell2EdgeInterpolation(helpers.StencilTest):
 
     @pytest.fixture
     def input_data(self, grid):
+        if grid.get_offset_provider("E2C").has_skip_values:
+            pytest.xfail("Stencil does not support missing neighbors.")
         in_field = data_alloc.random_field(grid, dims.CellDim, dims.KDim, dtype=ta.wpfloat)
         coeff = data_alloc.random_field(grid, dims.EdgeDim, dims.E2CDim, dtype=ta.wpfloat)
         out_field = data_alloc.zero_field(grid, dims.EdgeDim, dims.KDim, dtype=ta.wpfloat)

--- a/model/common/tests/stencil_tests/test_compute_cell_2_vertex_interpolation.py
+++ b/model/common/tests/stencil_tests/test_compute_cell_2_vertex_interpolation.py
@@ -23,7 +23,7 @@ class TestComputeCells2VertsInterpolation(helpers.StencilTest):
     OUTPUTS = ("vert_out",)
 
     @staticmethod
-    def reference(grid, cell_in: np.array, c_int: np.array, **kwargs) -> dict:
+    def reference(grid, cell_in: np.ndarray, c_int: np.ndarray, **kwargs) -> dict:
         v2c = grid.connectivities[dims.V2CDim]
         c_int = np.expand_dims(c_int, axis=-1)
         out_field = np.sum(cell_in[v2c] * c_int, axis=1)
@@ -34,6 +34,8 @@ class TestComputeCells2VertsInterpolation(helpers.StencilTest):
 
     @pytest.fixture
     def input_data(self, grid):
+        if grid.get_offset_provider("V2C").has_skip_values:
+            pytest.xfail("Stencil does not support missing neighbors.")
         cell_in = data_alloc.random_field(grid, dims.CellDim, dims.KDim, dtype=types.wpfloat)
         c_int = data_alloc.random_field(grid, dims.VertexDim, dims.V2CDim, dtype=types.wpfloat)
         vert_out = data_alloc.zero_field(grid, dims.VertexDim, dims.KDim, dtype=types.wpfloat)

--- a/model/common/tests/stencil_tests/test_diagnose_surface_pressure.py
+++ b/model/common/tests/stencil_tests/test_diagnose_surface_pressure.py
@@ -24,9 +24,9 @@ class TestDiagnoseSurfacePressure(helpers.StencilTest):
     @staticmethod
     def reference(
         grid,
-        exner: np.array,
-        virtual_temperature: np.array,
-        ddqz_z_full: np.array,
+        exner: np.ndarray,
+        virtual_temperature: np.ndarray,
+        ddqz_z_full: np.ndarray,
         **kwargs,
     ) -> dict:
         surface_pressure = np.zeros((grid.num_cells, grid.num_levels + 1), dtype=ta.wpfloat)
@@ -45,12 +45,13 @@ class TestDiagnoseSurfacePressure(helpers.StencilTest):
 
     @pytest.fixture
     def input_data(self, grid):
-        exner = data_alloc.random_field(grid, dims.CellDim, dims.KDim, low=1.0e-6, dtype=ta.wpfloat)
+        low = 1.0e-2
+        exner = data_alloc.random_field(grid, dims.CellDim, dims.KDim, low=low, dtype=ta.wpfloat)
         virtual_temperature = data_alloc.random_field(
-            grid, dims.CellDim, dims.KDim, low=1.0e-6, dtype=ta.wpfloat
+            grid, dims.CellDim, dims.KDim, low=low, dtype=ta.wpfloat
         )
         ddqz_z_full = data_alloc.random_field(
-            grid, dims.CellDim, dims.KDim, low=1.0e-6, dtype=ta.wpfloat
+            grid, dims.CellDim, dims.KDim, low=low, dtype=ta.wpfloat
         )
         surface_pressure = data_alloc.zero_field(
             grid, dims.CellDim, dims.KDim, dtype=ta.wpfloat, extend={dims.KDim: 1}

--- a/model/common/tests/stencil_tests/test_edge_2_cell_vector_rbf_interpolation.py
+++ b/model/common/tests/stencil_tests/test_edge_2_cell_vector_rbf_interpolation.py
@@ -35,6 +35,8 @@ class TestEdge2CellVectorRBFInterpolation(helpers.StencilTest):
 
     @pytest.fixture
     def input_data(self, grid):
+        if grid.get_offset_provider("C2E2C2E").has_skip_values:
+            pytest.xfail("Stencil does not support missing neighbors.")
         p_e_in = data_alloc.random_field(grid, dims.EdgeDim, dims.KDim, dtype=ta.wpfloat)
         ptr_coeff_1 = data_alloc.random_field(grid, dims.CellDim, dims.C2E2C2EDim, dtype=ta.wpfloat)
         ptr_coeff_2 = data_alloc.random_field(grid, dims.CellDim, dims.C2E2C2EDim, dtype=ta.wpfloat)

--- a/model/common/tests/stencil_tests/test_mo_intp_rbf_rbf_vec_interpol_vertex.py
+++ b/model/common/tests/stencil_tests/test_mo_intp_rbf_rbf_vec_interpol_vertex.py
@@ -24,8 +24,8 @@ class TestMoIntpRbfRbfVecInterpolVertex(StencilTest):
 
     @staticmethod
     def reference(
-        grid, p_e_in: np.array, ptr_coeff_1: np.array, ptr_coeff_2: np.array, **kwargs
-    ) -> tuple[np.array]:
+        grid, p_e_in: np.ndarray, ptr_coeff_1: np.ndarray, ptr_coeff_2: np.ndarray, **kwargs
+    ) -> dict[str, np.ndarray]:
         v2e = grid.connectivities[dims.V2EDim]
         ptr_coeff_1 = np.expand_dims(ptr_coeff_1, axis=-1)
         p_u_out = np.sum(p_e_in[v2e] * ptr_coeff_1, axis=1)
@@ -37,6 +37,8 @@ class TestMoIntpRbfRbfVecInterpolVertex(StencilTest):
 
     @pytest.fixture
     def input_data(self, grid):
+        if grid.get_offset_provider("V2E").has_skip_values:
+            pytest.xfail("Stencil does not support missing neighbors.")
         p_e_in = data_alloc.random_field(grid, dims.EdgeDim, dims.KDim, dtype=wpfloat)
         ptr_coeff_1 = data_alloc.random_field(grid, dims.VertexDim, dims.V2EDim, dtype=wpfloat)
         ptr_coeff_2 = data_alloc.random_field(grid, dims.VertexDim, dims.V2EDim, dtype=wpfloat)

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,6 +14,7 @@ from typing import Final, Literal, TypeAlias
 
 import nox
 
+
 # -- Parameter sets --
 ModelSubpackagePath: TypeAlias = Literal[
     "atmosphere/advection",
@@ -82,9 +83,9 @@ def test_model_stencils(session: nox.Session, subpackage: ModelSubpackagePath) -
         "driver",
     }
     if subpackage in notest_subpackages:
-        session.skip(f"no tests configured")
+        session.skip("no tests configured")
     elif subpackage == "common":
-        session.skip(f"tests broken")  # TODO: Enable tests
+        session.skip("tests broken")  # TODO: Enable tests
     else:
         session.notify(
             f"test_model-{session.python}(selection='stencils', subpackage='{subpackage}')"
@@ -144,7 +145,7 @@ def _selection_to_pytest_args(selection: ModelTestsSubset) -> list[str]:
     
     match selection:
         case "datatest":
-            pytest_args.append("--datatest")
+            pytest_args.extend(["-k", "not stencil_test", "--datatest"])
         case "stencils":
             pytest_args.extend(["-k", "stencil_tests"])
         case "basic":

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,8 +84,6 @@ def test_model_stencils(session: nox.Session, subpackage: ModelSubpackagePath) -
     }
     if subpackage in notest_subpackages:
         session.skip("no tests configured")
-    elif subpackage == "common":
-        session.skip("tests broken")  # TODO: Enable tests
     else:
         session.notify(
             f"test_model-{session.python}(selection='stencils', subpackage='{subpackage}')"


### PR DESCRIPTION
In `nox` configuration
- Exclude stencil_tests from `datatest` selection in nox
- Enable stencil tests for `model/common`