### PR TITLE
move scidoc to docstrings of individual stencils 

### DIFF
--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
@@ -1011,27 +1011,6 @@ class SolveNonhydro:
                 offset_provider={},
             )
 
-        # scidoc:
-        # Outputs:
-        #  - z_exner_ex_pr :
-        #     $$
-        #     \exnerprime{\ntilde}{\c}{\k} = (1 + \WtimeExner) \exnerprime{\n}{\c}{\k} - \WtimeExner \exnerprime{\n-1}{\c}{\k}, \k \in [0, \nlev) \\
-        #     \exnerprime{\ntilde}{\c}{\nlev} = 0
-        #     $$
-        #     Compute the temporal extrapolation of perturbed exner function
-        #     using the time backward scheme (see the |ICONTutorial| page 74).
-        #     This variable has nlev+1 levels even though it is defined on full levels.
-        #  - exner_pr :
-        #     $$
-        #     \exnerprime{\n-1}{\c}{\k} = \exnerprime{\ntilde}{\c}{\k}
-        #     $$
-        #     Store the perturbed exner function from the previous time step.
-        #
-        # Inputs:
-        #  - $\WtimeExner$ : exner_exfac
-        #  - $\exnerprime{\n}{\c}{\k}$ : exner - exner_ref_mc
-        #  - $\exnerprime{\n-1}{\c}{\k}$ : exner_pr
-        #
         self._predictor_stencils_2_3(
             exner_exfac=self._metric_state_nonhydro.exner_exfac,
             exner=prognostic_states.current.exner,
@@ -1046,30 +1025,6 @@ class SolveNonhydro:
         )
 
         if self._config.igradp_method == HorizontalPressureDiscretizationType.TAYLOR_HYDRO:
-            # scidoc:
-            # Outputs:
-            #  - z_exner_ic :
-            #     $$
-            #     \exnerprime{\ntilde}{\c}{\k-1/2} = \Wlev \exnerprime{\ntilde}{\c}{\k} + (1 - \Wlev) \exnerprime{\ntilde}{\c}{\k-1}, \quad \k \in [\max(1,\nflatlev), \nlev) \\
-            #     \exnerprime{\ntilde}{\c}{\nlev-1/2} = \sum_{\k=\nlev-1}^{\nlev-3} \Wlev_{\k} \exnerprime{\ntilde}{\c}{\k}
-            #     $$
-            #     Interpolate the perturbation exner from full to half levels.
-            #     The ground level is based on quadratic extrapolation (with
-            #     hydrostatic assumption?).
-            #  - z_dexner_dz_c_1 :
-            #     $$
-            #     \exnerprimedz{\ntilde}{\c}{\k} \approx \frac{\exnerprime{\ntilde}{\c}{\k-1/2} - \exnerprime{\ntilde}{\c}{\k+1/2}}{\Dz{\k}}, \quad \k \in [\max(1,\nflatlev), \nlev]
-            #     $$
-            #     Use the interpolated values to compute the vertical derivative
-            #     of perturbation exner at full levels.
-            #
-            # Inputs:
-            #  - $\Wlev$ : wgtfac_c
-            #  - $\Wlev_{\k}$ : wgtfacq_c
-            #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
-            #  - $\exnerprime{\ntilde}{\c}{\k\pm1/2}$ : z_exner_ic
-            #  - $1 / \Dz{\k}$ : inv_ddqz_z_full
-            #
             self._predictor_stencils_4_5_6(
                 wgtfacq_c_dsl=self._metric_state_nonhydro.wgtfacq_c,
                 z_exner_ex_pr=self.z_exner_ex_pr,
@@ -1129,26 +1084,6 @@ class SolveNonhydro:
         )
 
         if self._config.igradp_method == HorizontalPressureDiscretizationType.TAYLOR_HYDRO:
-            # scidoc:
-            # Outputs:
-            #  - z_dexner_dz_c_2 :
-            #     $$
-            #     \exnerprimedzz{\ntilde}{\c}{\k} = - \frac{1}{2} \left( (\vpotempprime{\n}{\c}{\k-1/2} - \vpotempprime{\n}{\c}{\k+1/2}) \dexrefdz{\c}{\k} + \vpotempprime{\n}{\c}{\k} \ddexrefdzz{\c}{\k} \right), \quad \k \in [\nflatgradp, \nlev) \\
-            #     \ddz{\exnerref{}{}} = - \frac{g}{\cpd \vpotempref{}{}}
-            #     $$
-            #     Compute the second vertical derivative of the perturbed exner function.
-            #     This uses the hydrostatic approximation (see eqs. 13 and 7,8 in
-            #     |ICONSteepSlopePressurePaper|).
-            #     Note that the reference state of temperature (eq. 15 in
-            #     |ICONSteepSlopePressurePaper|) is used when computing
-            #     $\ddz{\vpotempref{\c}{\k}}$ in $\ddexrefdzz{\c}{\k}$.
-            #
-            # Inputs:
-            #  - $\vpotempprime{\n}{\c}{\k\pm1/2}$ : z_theta_v_pr_ic
-            #  - $\vpotempprime{\n}{\c}{\k}$ : z_rth_pr_2
-            #  - $\dexrefdz{}{}$ : d2dexdz2_fac1_mc
-            #  - $\ddexrefdzz{}{}$ : d2dexdz2_fac2_mc
-            #
             self._compute_approx_of_2nd_vertical_derivative_of_exner(
                 z_theta_v_pr_ic=self.z_theta_v_pr_ic,
                 d2dexdz2_fac1_mc=self._metric_state_nonhydro.d2dexdz2_fac1_mc,
@@ -1271,20 +1206,6 @@ class SolveNonhydro:
                     offset_provider=self._grid.offset_providers,
                 )
 
-        # scidoc:
-        # Outputs:
-        #  - z_gradh_exner :
-        #     $$
-        #     \exnerprimegradh{\ntilde}{\e}{\k} = \Cgrad \Gradn_{\offProv{e2c}} \exnerprime{\ntilde}{\c}{\k}, \quad \k \in [0, \nflatlev)
-        #     $$
-        #     Compute the horizontal gradient (at constant height) of the
-        #     temporal extrapolation of perturbed exner function on flat levels,
-        #     unaffected by the terrain following deformation.
-        #
-        # Inputs:
-        #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
-        #  - $\Cgrad$ : inverse_dual_edge_lengths
-        #
         self._compute_horizontal_gradient_of_exner_pressure_for_flat_coordinates(
             inv_dual_edge_length=self._edge_geometry.inverse_dual_edge_lengths,
             z_exner_ex_pr=self.z_exner_ex_pr,
@@ -1297,26 +1218,6 @@ class SolveNonhydro:
         )
 
         if self._config.igradp_method == HorizontalPressureDiscretizationType.TAYLOR_HYDRO:
-            # scidoc:
-            # Outputs:
-            #  - z_gradh_exner :
-            #     $$
-            #     \exnerprimegradh{\ntilde}{\e}{\k} &&= \left.\pdxn{\exnerprime{}{}{}}\right|_{s} - \left.\pdxn{h}\right|_{s}\exnerprimedz{}{}{}\\
-            #                                       &&= \Wedge \Gradn_{\offProv{e2c}} \exnerprime{\ntilde}{\c}{\k}
-            #                                         - \pdxn{h} \sum_{\offProv{e2c}} \Whor \exnerprimedz{\ntilde}{\c}{\k},
-            #                                           \quad \k \in [\nflatlev, \nflatgradp]
-            #     $$
-            #     Compute $\exnerprimegradh{}{}{}$ on non-flat levels, affected
-            #     by the terrain following deformation, i.e. those levels for
-            #     which $\pdxn{h} \neq 0$ (eq. 14 in |ICONdycorePaper| or eq. 5
-            #     in |ICONSteepSlopePressurePaper|).
-            #
-            # Inputs:
-            #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
-            #  - $\Wedge$ : inverse_dual_edge_lengths
-            #  - $\exnerprimedz{\ntilde}{\c}{\k}$ : z_dexner_dz_c_1
-            #  - $\Whor$ : c_lin_e
-            #
             self._compute_horizontal_gradient_of_exner_pressure_for_nonflat_coordinates(
                 inv_dual_edge_length=self._edge_geometry.inverse_dual_edge_lengths,
                 z_exner_ex_pr=self.z_exner_ex_pr,
@@ -1331,32 +1232,7 @@ class SolveNonhydro:
                 offset_provider=self._grid.offset_providers,
             )
 
-            # scidoc:
-            # Outputs:
-            #  - z_gradh_exner :
-            #     $$
-            #     \exnerprimegradh{\ntilde}{\e}{\k} &&= \Wedge (\exnerprime{*}{\c_1}{} - \exnerprime{*}{\c_0}{}) \\
-            #                                       &&= \Wedge \Gradn_{\offProv{e2c}} \left[ \exnerprime{\ntilde}{\c}{\k^*} + \dzgradp \left( \exnerprimedz{\ntilde}{\c}{\k^*} + \dzgradp \exnerprimedzz{\ntilde}{\c}{\k^*} \right) \right],
-            #                                           \quad \k \in [\nflatgradp+1, \nlev)
-            #     $$
-            #     Compute $\exnerprimegradh{}{}{}$ when the height of
-            #     neighboring cells is in another level.
-            #     The usual centered difference approximation is used for the
-            #     gradient (eq. 6 in |ICONSteepSlopePressurePaper|), but instead
-            #     of cell center values, the exner function is reconstructed
-            #     using a second order Taylor-series expansion (eq. 8 in
-            #     |ICONSteepSlopePressurePaper|).
-            #     $k^*$ is the level index of the neighboring (horizontally, not
-            #     terrain-following) cell center and $h^*$ is its height.
-            #
-            # Inputs:
-            #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
-            #  - $\exnerprimedz{\ntilde}{\c}{\k}$ : z_dexner_dz_c_1
-            #  - $\exnerprimedzz{\ntilde}{\c}{\k}$ : z_dexner_dz_c_2
-            #  - $\Wedge$ : inverse_dual_edge_lengths
-            #  - $\dzgradp$ : zdiff_gradp
-            #  - $\k^*$ : vertoffset_gradp
-            #
+
             self._compute_horizontal_gradient_of_exner_pressure_for_multiple_levels(
                 inv_dual_edge_length=self._edge_geometry.inverse_dual_edge_lengths,
                 z_exner_ex_pr=self.z_exner_ex_pr,
@@ -1372,38 +1248,6 @@ class SolveNonhydro:
                 offset_provider=self._grid.offset_providers,
             )
 
-            # scidoc:
-            # Outputs:
-            #  - z_hydro_corr :
-            #     $$
-            #     \exnhydrocorr{\e} = \frac{g}{\cpd} \Wedge 4 \frac{ \vpotemp{}{\c_1}{\k} - \vpotemp{}{\c_0}{\k} }{ (\vpotemp{}{\c_1}{\k} + \vpotemp{}{\c_0}{\k})^2 },
-            #     $$
-            #     with
-            #     $$
-            #     \vpotemp{}{\c_i}{\k} = \vpotemp{}{\c_i}{\k^*} + \dzgradp \frac{\vpotemp{}{\c_i}{\k^*-1/2} - \vpotemp{}{\c_i}{\k^*+1/2}}{\Dz{\k^*}}
-            #     $$
-            #     Compute the hydrostatically approximated correction term that
-            #     replaces the downward extrapolation (last term in eq. 10 in
-            #     |ICONSteepSlopePressurePaper|).
-            #     This is only computed for the bottom-most level because all
-            #     edges which have a neighboring cell center inside terrain
-            #     beyond a certain limit use the same correction term at $k^*$
-            #     level in eq. 10 in |ICONSteepSlopePressurePaper| (see also the
-            #     last paragraph on page 3724 for the discussion).
-            #     $\c_i$ are the indexes of the adjacent cell centers using
-            #     $\offProv{e2c}$;
-            #     $k^*$ is the level index of the neighboring (horizontally, not
-            #     terrain-following) cell center and $h^*$ is its height.
-            #
-            # Inputs:
-            #  - $\vpotemp{}{\c}{\k}$ : theta_v
-            #  - $\vpotemp{}{\c}{\k\pm1/2}$ : theta_v_ic
-            #  - $\frac{g}{\cpd}$ : grav_o_cpd
-            #  - $\Wedge$ : inverse_dual_edge_lengths
-            #  - $1 / \Dz{\k}$ : inv_ddqz_z_full
-            #  - $\dzgradp$ : zdiff_gradp
-            #  - $\k^*$ : vertoffset_gradp
-            #
             self._compute_hydrostatic_correction_term(
                 theta_v=prognostic_states.current.theta_v,
                 ikoffset=self._metric_state_nonhydro.vertoffset_gradp,
@@ -1428,26 +1272,6 @@ class SolveNonhydro:
                 allocator=self._backend.allocator,
             )
 
-            # scidoc:
-            # Outputs:
-            #  - z_gradh_exner :
-            #     $$
-            #     \exnerprimegradh{\ntilde}{\e}{\k} = \exnerprimegradh{\ntilde}{\e}{\k} + \exnhydrocorr{\e} (h_k - h_{k^*}), \quad \e \in \IDXpg
-            #     $$
-            #     Apply the hydrostatic correction term to the horizontal
-            #     gradient (at constant height) of the temporal extrapolation of
-            #     perturbed exner function (eq. 10 in
-            #     |ICONSteepSlopePressurePaper|).
-            #     This is only applied to edges for which the adjacent cell
-            #     center (horizontally, not terrain-following) would be
-            #     underground, i.e. edges in the $\IDXpg$ set.
-            #
-            # Inputs:
-            #  - $\exnerprimegradh{\ntilde}{\e}{\k}$ : z_gradh_exner
-            #  - $\exnhydrocorr{\e}$ : hydro_corr_horizontal
-            #  - $(h_k - h_{k^*})$ : pg_exdist
-            #  - $\IDXpg$ : ipeidx_dsl
-            #
             self._apply_hydrostatic_correction_to_horizontal_gradient_of_exner_pressure(
                 ipeidx_dsl=self._metric_state_nonhydro.ipeidx_dsl,
                 pg_exdist=self._metric_state_nonhydro.pg_exdist,
@@ -1460,23 +1284,7 @@ class SolveNonhydro:
                 offset_provider={},
             )
 
-        # scidoc:
-        # Outputs:
-        #  - vn :
-        #     $$
-        #     \vn{\n+1^*}{\e}{\k} = \vn{\n}{\e}{\k} - \Dt \left( \advvn{\n}{\e}{\k} + \cpd \vpotemp{\n}{\e}{\k} \exnerprimegradh{\ntilde}{\e}{\k} \right)
-        #     $$
-        #     Update the normal wind speed with the advection and pressure
-        #     gradient terms.
-        #
-        # Inputs:
-        #  - $\vn{\n}{\e}{\k}$ : vn
-        #  - $\Dt$ : dtime
-        #  - $\advvn{\n}{\e}{\k}$ : ddt_vn_apc_pc[self.ntl1]
-        #  - $\vpotemp{\n}{\e}{\k}$ : z_theta_v_e
-        #  - $\exnerprimegradh{\ntilde}{\e}{\k}$ : z_gradh_exner
-        #  - $\cpd$ : CPD
-        #
+
         self._add_temporal_tendencies_to_vn(
             vn_nnow=prognostic_states.current.vn,
             ddt_vn_apc_ntl1=diagnostic_state_nh.ddt_vn_apc_pc.predictor,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
@@ -1232,7 +1232,6 @@ class SolveNonhydro:
                 offset_provider=self._grid.offset_providers,
             )
 
-
             self._compute_horizontal_gradient_of_exner_pressure_for_multiple_levels(
                 inv_dual_edge_length=self._edge_geometry.inverse_dual_edge_lengths,
                 z_exner_ex_pr=self.z_exner_ex_pr,
@@ -1283,7 +1282,6 @@ class SolveNonhydro:
                 vertical_end=self._grid.num_levels,
                 offset_provider={},
             )
-
 
         self._add_temporal_tendencies_to_vn(
             vn_nnow=prognostic_states.current.vn,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro_stencils.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro_stencils.py
@@ -116,12 +116,6 @@ def predictor_stencils_2_3(
     vertical_start: gtx.int32,
     vertical_end: gtx.int32,
 ):
-    # TODO:
-    #  - The first operation on z_exner_ex_pr should be done in a generic
-    #    math (1+a)*x - a*y program
-    #  - In the stencil, _extrapolate_temporally_exner_pressure doesn't only
-    #    do what the name suggests: it also updates exner_pr, which is not
-    #    what the name implies.
     _extrapolate_temporally_exner_pressure(
         exner_exfac,
         exner,
@@ -159,6 +153,7 @@ def predictor_stencils_4_5_6(
     #  - The value of z_exner_ic at the model top level is not updated
     #    and assumed to be zero. It should be treated in the same way as
     #    the ground level.
+
     _interpolate_to_surface(
         wgtfacq_c_dsl,
         z_exner_ex_pr,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro_stencils.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro_stencils.py
@@ -153,7 +153,6 @@ def predictor_stencils_4_5_6(
     #  - The value of z_exner_ic at the model top level is not updated
     #    and assumed to be zero. It should be treated in the same way as
     #    the ground level.
-
     _interpolate_to_surface(
         wgtfacq_c_dsl,
         z_exner_ex_pr,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/add_temporal_tendencies_to_vn.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/add_temporal_tendencies_to_vn.py
@@ -24,7 +24,27 @@ def _add_temporal_tendencies_to_vn(
     dtime: wpfloat,
     cpd: wpfloat,
 ) -> fa.EdgeKField[wpfloat]:
-    """Formerly known as _mo_solve_nonhydro_stencil_24."""
+    """
+    Formerly known as _mo_solve_nonhydro_stencil_24.
+
+    # scidoc:
+    # Outputs:
+    #  - vn :
+    #     $$
+    #     \vn{\n+1^*}{\e}{\k} = \vn{\n}{\e}{\k} - \Dt \left( \advvn{\n}{\e}{\k} + \cpd \vpotemp{\n}{\e}{\k} \exnerprimegradh{\ntilde}{\e}{\k} \right)
+    #     $$
+    #     Update the normal wind speed with the advection and pressure
+    #     gradient terms.
+    #
+    # Inputs:
+    #  - $\vn{\n}{\e}{\k}$ : vn
+    #  - $\Dt$ : dtime
+    #  - $\advvn{\n}{\e}{\k}$ : ddt_vn_apc_pc[self.ntl1]
+    #  - $\vpotemp{\n}{\e}{\k}$ : z_theta_v_e
+    #  - $\exnerprimegradh{\ntilde}{\e}{\k}$ : z_gradh_exner
+    #  - $\cpd$ : CPD
+    #
+    """
     z_gradh_exner_wp = astype(z_gradh_exner, wpfloat)
 
     vn_nnew_wp = vn_nnow + dtime * (

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/apply_hydrostatic_correction_to_horizontal_gradient_of_exner_pressure.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/apply_hydrostatic_correction_to_horizontal_gradient_of_exner_pressure.py
@@ -40,11 +40,11 @@ def _apply_hydrostatic_correction_to_horizontal_gradient_of_exner_pressure(
     #
     # Inputs:
     #  - $\exnerprimegradh{\ntilde}{\e}{\k}$ : z_gradh_exner
-    #  - $\exnhydrocorr{\e}$ : hydro_corr_horizontal
+    #  - $\exnhydrocorr{\e}$ : z_hydro_corr
     #  - $(h_k - h_{k^*})$ : pg_exdist
     #  - $\IDXpg$ : ipeidx_dsl
     #
-    
+
     """
     z_gradh_exner_vp = where(ipeidx_dsl, z_gradh_exner + z_hydro_corr * pg_exdist, z_gradh_exner)
     return z_gradh_exner_vp

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/apply_hydrostatic_correction_to_horizontal_gradient_of_exner_pressure.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/apply_hydrostatic_correction_to_horizontal_gradient_of_exner_pressure.py
@@ -21,7 +21,31 @@ def _apply_hydrostatic_correction_to_horizontal_gradient_of_exner_pressure(
     z_hydro_corr: gtx.Field[gtx.Dims[dims.EdgeDim], vpfloat],
     z_gradh_exner: fa.EdgeKField[vpfloat],
 ) -> fa.EdgeKField[vpfloat]:
-    """Formerly known as _mo_solve_nonhydro_stencil_22."""
+    """
+    Formerly known as _mo_solve_nonhydro_stencil_22.
+
+    # scidoc:
+    # Outputs:
+    #  - z_gradh_exner :
+    #     $$
+    #     \exnerprimegradh{\ntilde}{\e}{\k} = \exnerprimegradh{\ntilde}{\e}{\k} + \exnhydrocorr{\e} (h_k - h_{k^*}), \quad \e \in \IDXpg
+    #     $$
+    #     Apply the hydrostatic correction term to the horizontal
+    #     gradient (at constant height) of the temporal extrapolation of
+    #     perturbed exner function (eq. 10 in
+    #     |ICONSteepSlopePressurePaper|).
+    #     This is only applied to edges for which the adjacent cell
+    #     center (horizontally, not terrain-following) would be
+    #     underground, i.e. edges in the $\IDXpg$ set.
+    #
+    # Inputs:
+    #  - $\exnerprimegradh{\ntilde}{\e}{\k}$ : z_gradh_exner
+    #  - $\exnhydrocorr{\e}$ : hydro_corr_horizontal
+    #  - $(h_k - h_{k^*})$ : pg_exdist
+    #  - $\IDXpg$ : ipeidx_dsl
+    #
+    
+    """
     z_gradh_exner_vp = where(ipeidx_dsl, z_gradh_exner + z_hydro_corr * pg_exdist, z_gradh_exner)
     return z_gradh_exner_vp
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_advective_normal_wind_tendency.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_advective_normal_wind_tendency.py
@@ -35,7 +35,39 @@ def _compute_advective_normal_wind_tendency(
     vn_ie: fa.EdgeKField[vpfloat],
     ddqz_z_full_e: fa.EdgeKField[vpfloat],
 ) -> fa.EdgeKField[vpfloat]:
-    """Formerly known as _mo_velocity_advection_stencil_19."""
+    """
+    Formerly known as _mo_velocity_advection_stencil_19.
+
+    # scidoc:
+    # Outputs:
+    #  - ddt_vn_apc_pc[ntnd] :
+    #     $$
+    #     \advvn{\n}{\e}{\k} &&= \pdxn{\kinehori{}{}{}} + \vt{}{}{} (\vortvert{}{}{} + \coriolis{}) + \pdz{\vn{}{}{}} (\w{}{}{} - \wcc{}{}{}) \\
+    #                        &&= \Gradn_{\offProv{e2c}} \Cgrad \kinehori{\n}{c}{\k} + \kinehori{\n}{\e}{\k} \Gradn_{\offProv{e2c}} \Cgrad     \\
+    #                        &&+ \vt{\n}{\e}{\k} (\coriolis{\e} + 1/2 \sum_{\offProv{e2v}} \vortvert{\n}{\v}{\k})                             \\
+    #                        &&+ \frac{\vn{\n}{\e}{\k-1/2} - \vn{\n}{\e}{\k+1/2}}{\Dz{k}}
+    #                            \sum_{\offProv{e2c}} \Whor (\w{\n}{\c}{\k} - \wcc{\n}{\c}{\k})
+    #     $$
+    #     Compute the advective tendency of the normal wind (eq. 13 in
+    #     |ICONdycorePaper|).
+    #     The edge-normal derivative of the kinetic energy is computed by
+    #     combining the first order approximation across adiacent cell
+    #     centres (eq. 7 in |BonaventuraRingler2005|) with the edge value of
+    #     the kinetic energy (TODO: this needs explaining and a reference).
+    #
+    # Inputs:
+    #  - $\Cgrad$ : coeff_gradekin
+    #  - $\kinehori{\n}{\e}{\k}$ : z_kin_hor_e
+    #  - $\kinehori{\n}{\c}{\k}$ : z_ekinh
+    #  - $\vt{\n}{\e}{\k}$ : vt
+    #  - $\coriolis{\e}$ : f_e
+    #  - $\vortvert{\n}{\v}{\k}$ : zeta
+    #  - $\Whor$ : c_lin_e
+    #  - $(\w{\n}{\c}{\k} - \wcc{\n}{\c}{\k})$ : z_w_con_c_full
+    #  - $\vn{\n}{\e}{\k\pm1/2}$ : vn_ie
+    #  - $\Dz{\k}$ : ddqz_z_full_e
+    #
+    """
     vt_wp, z_w_con_c_full_wp, ddqz_z_full_e_wp = astype(
         (vt, z_w_con_c_full, ddqz_z_full_e), wpfloat
     )

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_approx_of_2nd_vertical_derivative_of_exner.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_approx_of_2nd_vertical_derivative_of_exner.py
@@ -21,7 +21,32 @@ def _compute_approx_of_2nd_vertical_derivative_of_exner(
     d2dexdz2_fac2_mc: fa.CellKField[vpfloat],
     z_rth_pr_2: fa.CellKField[vpfloat],
 ) -> fa.CellKField[vpfloat]:
-    """Formerly known as _mo_solve_nonhydro_stencil_12."""
+    """
+    Formerly known as _mo_solve_nonhydro_stencil_12.
+
+    # scidoc:
+    # Outputs:
+    #  - z_dexner_dz_c_2 :
+    #     $$
+    #     \exnerprimedzz{\ntilde}{\c}{\k} = - \frac{1}{2} \left( (\vpotempprime{\n}{\c}{\k-1/2} - \vpotempprime{\n}{\c}{\k+1/2}) \dexrefdz{\c}{\k} + \vpotempprime{\n}{\c}{\k} \ddexrefdzz{\c}{\k} \right), \quad \k \in [\nflatgradp, \nlev) \\
+    #     \ddz{\exnerref{}{}} = - \frac{g}{\cpd \vpotempref{}{}}
+    #     $$
+    #     Compute the second vertical derivative of the perturbed exner function.
+    #     This uses the hydrostatic approximation (see eqs. 13 and 7,8 in
+    #     |ICONSteepSlopePressurePaper|).
+    #     Note that the reference state of temperature (eq. 15 in
+    #     |ICONSteepSlopePressurePaper|) is used when computing
+    #     $\ddz{\vpotempref{\c}{\k}}$ in $\ddexrefdzz{\c}{\k}$.
+    #
+    # Inputs:
+    #  - $\vpotempprime{\n}{\c}{\k\pm1/2}$ : z_theta_v_pr_ic
+    #  - $\vpotempprime{\n}{\c}{\k}$ : z_rth_pr_2
+    #  - $\dexrefdz{}{}$ : d2dexdz2_fac1_mc
+    #  - $\ddexrefdzz{}{}$ : d2dexdz2_fac2_mc
+    #
+    
+
+    """
     z_dexner_dz_c_2_vp = -vpfloat("0.5") * (
         (z_theta_v_pr_ic - z_theta_v_pr_ic(Koff[1])) * d2dexdz2_fac1_mc
         + z_rth_pr_2 * d2dexdz2_fac2_mc

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_contravariant_correction.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_contravariant_correction.py
@@ -25,40 +25,22 @@ def _compute_contravariant_correction(
     Formerly known as _mo_solve_nonhydro_stencil_35 or mo_velocity_advection_stencil_04.
 
     # scidoc:
-        # Outputs:
-        #  - z_w_concorr_me :
-        #     $$
-        #     \wcc{\n}{\e}{\k} = \vn{\n}{\e}{\k} \pdxn{z} + \vt{\n}{\e}{\k} \pdxt{z}, \quad \k \in [\nflatlev, \nlev)
-        #     $$
-        #     Compute the contravariant correction to the vertical wind due to
-        #     terrain-following coordinate. $\pdxn{}$ and $\pdxt{}$ are the
-        #     horizontal derivatives along the normal and tangent directions
-        #     respectively (eq. 17 in |ICONdycorePaper|).
-        #  - vn_ie :
-        #     $$
-        #     \vn{\n}{\e}{-1/2} = \vn{\n}{\e}{0}
-        #     $$
-        #     Set the normal wind at model top equal to the normal wind at the
-        #     first full level.
-        #  - z_vt_ie :
-        #     $$
-        #     \vt{\n}{\e}{-1/2} = \vt{\n}{\e}{0}
-        #     $$
-        #     Set the tangential wind at model top equal to the tangential wind
-        #     at the first full level.
-        #  - z_kin_hor_e :
-        #     $$
-        #     \kinehori{\n}{\e}{0} = \frac{1}{2} \left( \vn{\n}{\e}{0}^2 + \vt{\n}{\e}{0}^2 \right)
-        #     $$
-        #     Compute the horizontal kinetic energy on the first full level.
-        #
-        # Inputs:
-        #  - $\vn{\n}{\e}{\k}$ : vn
-        #  - $\vt{\n}{\e}{\k}$ : vt
-        #  - $\pdxn{z}$ : ddxn_z_full
-        #  - $\pdxt{z}$ : ddxt_z_full
-        #
-        
+    # Outputs:
+    #  - z_w_concorr_me :
+    #     $$
+    #     \wcc{\n}{\e}{\k} = \vn{\n}{\e}{\k} \pdxn{z} + \vt{\n}{\e}{\k} \pdxt{z}, \quad \k \in [\nflatlev, \nlev)
+    #     $$
+    #     Compute the contravariant correction to the vertical wind due to
+    #     terrain-following coordinate. $\pdxn{}$ and $\pdxt{}$ are the
+    #     horizontal derivatives along the normal and tangent directions
+    #     respectively (eq. 17 in |ICONdycorePaper|).
+    #
+    # Inputs:
+    #  - $\vn{\n}{\e}{\k}$ : vn
+    #  - $\pdxn{z}$ : ddxn_z_full
+    #  - $\pdxt{z}$ : ddxt_z_full
+    #
+
     """
     ddxn_z_full_wp = astype(ddxn_z_full, wpfloat)
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_contravariant_correction.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_contravariant_correction.py
@@ -21,7 +21,45 @@ def _compute_contravariant_correction(
     ddxt_z_full: fa.EdgeKField[vpfloat],
     vt: fa.EdgeKField[vpfloat],
 ) -> fa.EdgeKField[vpfloat]:
-    """Formerly known as _mo_solve_nonhydro_stencil_35 or mo_velocity_advection_stencil_04."""
+    """
+    Formerly known as _mo_solve_nonhydro_stencil_35 or mo_velocity_advection_stencil_04.
+
+    # scidoc:
+        # Outputs:
+        #  - z_w_concorr_me :
+        #     $$
+        #     \wcc{\n}{\e}{\k} = \vn{\n}{\e}{\k} \pdxn{z} + \vt{\n}{\e}{\k} \pdxt{z}, \quad \k \in [\nflatlev, \nlev)
+        #     $$
+        #     Compute the contravariant correction to the vertical wind due to
+        #     terrain-following coordinate. $\pdxn{}$ and $\pdxt{}$ are the
+        #     horizontal derivatives along the normal and tangent directions
+        #     respectively (eq. 17 in |ICONdycorePaper|).
+        #  - vn_ie :
+        #     $$
+        #     \vn{\n}{\e}{-1/2} = \vn{\n}{\e}{0}
+        #     $$
+        #     Set the normal wind at model top equal to the normal wind at the
+        #     first full level.
+        #  - z_vt_ie :
+        #     $$
+        #     \vt{\n}{\e}{-1/2} = \vt{\n}{\e}{0}
+        #     $$
+        #     Set the tangential wind at model top equal to the tangential wind
+        #     at the first full level.
+        #  - z_kin_hor_e :
+        #     $$
+        #     \kinehori{\n}{\e}{0} = \frac{1}{2} \left( \vn{\n}{\e}{0}^2 + \vt{\n}{\e}{0}^2 \right)
+        #     $$
+        #     Compute the horizontal kinetic energy on the first full level.
+        #
+        # Inputs:
+        #  - $\vn{\n}{\e}{\k}$ : vn
+        #  - $\vt{\n}{\e}{\k}$ : vt
+        #  - $\pdxn{z}$ : ddxn_z_full
+        #  - $\pdxt{z}$ : ddxt_z_full
+        #
+        
+    """
     ddxn_z_full_wp = astype(ddxn_z_full, wpfloat)
 
     z_w_concorr_me_wp = vn * ddxn_z_full_wp + astype(vt * ddxt_z_full, wpfloat)

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_first_vertical_derivative.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_first_vertical_derivative.py
@@ -23,30 +23,19 @@ def _compute_first_vertical_derivative(
     Formerly known as _mo_solve_nonhydro_stencil_06.
 
     # scidoc:
-        # Outputs:
-        #  - z_exner_ic :
-        #     $$
-        #     \exnerprime{\ntilde}{\c}{\k-1/2} = \Wlev \exnerprime{\ntilde}{\c}{\k} + (1 - \Wlev) \exnerprime{\ntilde}{\c}{\k-1}, \quad \k \in [\max(1,\nflatlev), \nlev) \\
-        #     \exnerprime{\ntilde}{\c}{\nlev-1/2} = \sum_{\k=\nlev-1}^{\nlev-3} \Wlev_{\k} \exnerprime{\ntilde}{\c}{\k}
-        #     $$
-        #     Interpolate the perturbation exner from full to half levels.
-        #     The ground level is based on quadratic extrapolation (with
-        #     hydrostatic assumption?).
-        #  - z_dexner_dz_c_1 :
-        #     $$
-        #     \exnerprimedz{\ntilde}{\c}{\k} \approx \frac{\exnerprime{\ntilde}{\c}{\k-1/2} - \exnerprime{\ntilde}{\c}{\k+1/2}}{\Dz{\k}}, \quad \k \in [\max(1,\nflatlev), \nlev]
-        #     $$
-        #     Use the interpolated values to compute the vertical derivative
-        #     of perturbation exner at full levels.
-        #
-        # Inputs:
-        #  - $\Wlev$ : wgtfac_c
-        #  - $\Wlev_{\k}$ : wgtfacq_c
-        #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
-        #  - $\exnerprime{\ntilde}{\c}{\k\pm1/2}$ : z_exner_ic
-        #  - $1 / \Dz{\k}$ : inv_ddqz_z_full
-        #
-        
+    # Outputs:
+    #  - z_dexner_dz_c_1 :
+    #     $$
+    #     \exnerprimedz{\ntilde}{\c}{\k} \approx \frac{\exnerprime{\ntilde}{\c}{\k-1/2} - \exnerprime{\ntilde}{\c}{\k+1/2}}{\Dz{\k}}, \quad \k \in [\max(1,\nflatlev), \nlev]
+    #     $$
+    #     Use the interpolated values to compute the vertical derivative
+    #     of perturbation exner at full levels.
+    #
+    # Inputs:
+    #  - $\exnerprime{\ntilde}{\c}{\k\pm1/2}$ : z_exner_ic
+    #  - $1 / \Dz{\k}$ : inv_ddqz_z_full
+    #
+
 
     """
     z_dexner_dz_c_1 = (z_exner_ic - z_exner_ic(Koff[1])) * inv_ddqz_z_full

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_first_vertical_derivative.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_first_vertical_derivative.py
@@ -19,7 +19,36 @@ def _compute_first_vertical_derivative(
     z_exner_ic: fa.CellKField[vpfloat],
     inv_ddqz_z_full: fa.CellKField[vpfloat],
 ) -> fa.CellKField[vpfloat]:
-    """Formerly known as _mo_solve_nonhydro_stencil_06."""
+    """
+    Formerly known as _mo_solve_nonhydro_stencil_06.
+
+    # scidoc:
+        # Outputs:
+        #  - z_exner_ic :
+        #     $$
+        #     \exnerprime{\ntilde}{\c}{\k-1/2} = \Wlev \exnerprime{\ntilde}{\c}{\k} + (1 - \Wlev) \exnerprime{\ntilde}{\c}{\k-1}, \quad \k \in [\max(1,\nflatlev), \nlev) \\
+        #     \exnerprime{\ntilde}{\c}{\nlev-1/2} = \sum_{\k=\nlev-1}^{\nlev-3} \Wlev_{\k} \exnerprime{\ntilde}{\c}{\k}
+        #     $$
+        #     Interpolate the perturbation exner from full to half levels.
+        #     The ground level is based on quadratic extrapolation (with
+        #     hydrostatic assumption?).
+        #  - z_dexner_dz_c_1 :
+        #     $$
+        #     \exnerprimedz{\ntilde}{\c}{\k} \approx \frac{\exnerprime{\ntilde}{\c}{\k-1/2} - \exnerprime{\ntilde}{\c}{\k+1/2}}{\Dz{\k}}, \quad \k \in [\max(1,\nflatlev), \nlev]
+        #     $$
+        #     Use the interpolated values to compute the vertical derivative
+        #     of perturbation exner at full levels.
+        #
+        # Inputs:
+        #  - $\Wlev$ : wgtfac_c
+        #  - $\Wlev_{\k}$ : wgtfacq_c
+        #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
+        #  - $\exnerprime{\ntilde}{\c}{\k\pm1/2}$ : z_exner_ic
+        #  - $1 / \Dz{\k}$ : inv_ddqz_z_full
+        #
+        
+
+    """
     z_dexner_dz_c_1 = (z_exner_ic - z_exner_ic(Koff[1])) * inv_ddqz_z_full
     return z_dexner_dz_c_1
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_gradient_of_exner_pressure_for_flat_coordinates.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_gradient_of_exner_pressure_for_flat_coordinates.py
@@ -20,7 +20,26 @@ def _compute_horizontal_gradient_of_exner_pressure_for_flat_coordinates(
     inv_dual_edge_length: fa.EdgeField[wpfloat],
     z_exner_ex_pr: fa.CellKField[vpfloat],
 ) -> fa.EdgeKField[vpfloat]:
-    """Formerly known as _mo_solve_nonhydro_stencil_18."""
+    """
+    # scidoc:
+    # Outputs:
+    #  - z_gradh_exner :
+    #     $$
+    #     \exnerprimegradh{\ntilde}{\e}{\k} = \Cgrad \Gradn_{\offProv{e2c}} \exnerprime{\ntilde}{\c}{\k}, \quad \k \in [0, \nflatlev)
+    #     $$
+    #     Compute the horizontal gradient (at constant height) of the
+    #     temporal extrapolation of perturbed exner function on flat levels,
+    #     unaffected by the terrain following deformation.
+    #
+    # Inputs:
+    #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
+    #  - $\Cgrad$ : inverse_dual_edge_lengths
+    #
+    
+
+    Formerly known as _mo_solve_nonhydro_stencil_18.
+
+    """
     z_gradh_exner_wp = inv_dual_edge_length * astype(
         z_exner_ex_pr(E2C[1]) - z_exner_ex_pr(E2C[0]), wpfloat
     )

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_gradient_of_exner_pressure_for_flat_coordinates.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_gradient_of_exner_pressure_for_flat_coordinates.py
@@ -35,7 +35,7 @@ def _compute_horizontal_gradient_of_exner_pressure_for_flat_coordinates(
     #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
     #  - $\Cgrad$ : inverse_dual_edge_lengths
     #
-    
+
 
     Formerly known as _mo_solve_nonhydro_stencil_18.
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_gradient_of_exner_pressure_for_multiple_levels.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_gradient_of_exner_pressure_for_multiple_levels.py
@@ -52,7 +52,7 @@ def _compute_horizontal_gradient_of_exner_pressure_for_multiple_levels(
         #  - $\exnerprimedzz{\ntilde}{\c}{\k}$ : z_dexner_dz_c_2
         #  - $\Wedge$ : inverse_dual_edge_lengths
         #  - $\dzgradp$ : zdiff_gradp
-        #  - $\k^*$ : vertoffset_gradp
+        #  - $\k^*$ : ikoffset
         #
     """
     z_exner_ex_pr_0 = z_exner_ex_pr(E2C[0])(as_offset(Koff, ikoffset(E2EC[0])))

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_gradient_of_exner_pressure_for_multiple_levels.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_gradient_of_exner_pressure_for_multiple_levels.py
@@ -25,7 +25,36 @@ def _compute_horizontal_gradient_of_exner_pressure_for_multiple_levels(
     z_dexner_dz_c_1: fa.CellKField[vpfloat],
     z_dexner_dz_c_2: fa.CellKField[vpfloat],
 ) -> fa.EdgeKField[vpfloat]:
-    """Formerly known as _mo_solve_nonhydro_stencil_20."""
+    """
+    Formerly known as _mo_solve_nonhydro_stencil_20.
+
+    # scidoc:
+        # Outputs:
+        #  - z_gradh_exner :
+        #     $$
+        #     \exnerprimegradh{\ntilde}{\e}{\k} &&= \Wedge (\exnerprime{*}{\c_1}{} - \exnerprime{*}{\c_0}{}) \\
+        #                                       &&= \Wedge \Gradn_{\offProv{e2c}} \left[ \exnerprime{\ntilde}{\c}{\k^*} + \dzgradp \left( \exnerprimedz{\ntilde}{\c}{\k^*} + \dzgradp \exnerprimedzz{\ntilde}{\c}{\k^*} \right) \right],
+        #                                           \quad \k \in [\nflatgradp+1, \nlev)
+        #     $$
+        #     Compute $\exnerprimegradh{}{}{}$ when the height of
+        #     neighboring cells is in another level.
+        #     The usual centered difference approximation is used for the
+        #     gradient (eq. 6 in |ICONSteepSlopePressurePaper|), but instead
+        #     of cell center values, the exner function is reconstructed
+        #     using a second order Taylor-series expansion (eq. 8 in
+        #     |ICONSteepSlopePressurePaper|).
+        #     $k^*$ is the level index of the neighboring (horizontally, not
+        #     terrain-following) cell center and $h^*$ is its height.
+        #
+        # Inputs:
+        #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
+        #  - $\exnerprimedz{\ntilde}{\c}{\k}$ : z_dexner_dz_c_1
+        #  - $\exnerprimedzz{\ntilde}{\c}{\k}$ : z_dexner_dz_c_2
+        #  - $\Wedge$ : inverse_dual_edge_lengths
+        #  - $\dzgradp$ : zdiff_gradp
+        #  - $\k^*$ : vertoffset_gradp
+        #
+    """
     z_exner_ex_pr_0 = z_exner_ex_pr(E2C[0])(as_offset(Koff, ikoffset(E2EC[0])))
     z_exner_ex_pr_1 = z_exner_ex_pr(E2C[1])(as_offset(Koff, ikoffset(E2EC[1])))
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_gradient_of_exner_pressure_for_nonflat_coordinates.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_gradient_of_exner_pressure_for_nonflat_coordinates.py
@@ -45,6 +45,29 @@ def compute_horizontal_gradient_of_exner_pressure_for_nonflat_coordinates(
     vertical_start: gtx.int32,
     vertical_end: gtx.int32,
 ):
+    """
+    # scidoc:
+    # Outputs:
+    #  - z_gradh_exner :
+    #     $$
+    #     \exnerprimegradh{\ntilde}{\e}{\k} &&= \left.\pdxn{\exnerprime{}{}{}}\right|_{s} - \left.\pdxn{h}\right|_{s}\exnerprimedz{}{}{}\\
+    #                                       &&= \Wedge \Gradn_{\offProv{e2c}} \exnerprime{\ntilde}{\c}{\k}
+    #                                         - \pdxn{h} \sum_{\offProv{e2c}} \Whor \exnerprimedz{\ntilde}{\c}{\k},
+    #                                           \quad \k \in [\nflatlev, \nflatgradp]
+    #     $$
+    #     Compute $\exnerprimegradh{}{}{}$ on non-flat levels, affected
+    #     by the terrain following deformation, i.e. those levels for
+    #     which $\pdxn{h} \neq 0$ (eq. 14 in |ICONdycorePaper| or eq. 5
+    #     in |ICONSteepSlopePressurePaper|).
+    #
+    # Inputs:
+    #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
+    #  - $\Wedge$ : inverse_dual_edge_lengths
+    #  - $\exnerprimedz{\ntilde}{\c}{\k}$ : z_dexner_dz_c_1
+    #  - $\Whor$ : c_lin_e
+    #
+
+    """
     _compute_horizontal_gradient_of_exner_pressure_for_nonflat_coordinates(
         inv_dual_edge_length,
         z_exner_ex_pr,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_kinetic_energy.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_kinetic_energy.py
@@ -23,20 +23,13 @@ def _compute_horizontal_kinetic_energy(
     fa.EdgeKField[vpfloat],
     fa.EdgeKField[vpfloat],
 ]:
-    """Formerly known as _mo_solve_nonhydro_stencil_37 or _mo_velocity_advection_stencil_05."""
+    """Formerly known as _mo_solve_nonhydro_stencil_37 or _mo_velocity_advection_stencil_05.
+
     # TODO: This stencil doesn't only do what the name implies. It also
     # assigns to vn_ie_wp and z_vt_ie_vp. These things should be separated.
 
     # scidoc:
     # Outputs:
-    #  - z_w_concorr_me :
-    #     $$
-    #     \wcc{\n}{\e}{\k} = \vn{\n}{\e}{\k} \pdxn{z} + \vt{\n}{\e}{\k} \pdxt{z}, \quad \k \in [\nflatlev, \nlev)
-    #     $$
-    #     Compute the contravariant correction to the vertical wind due to
-    #     terrain-following coordinate. $\pdxn{}$ and $\pdxt{}$ are the
-    #     horizontal derivatives along the normal and tangent directions
-    #     respectively (eq. 17 in |ICONdycorePaper|).
     #  - vn_ie :
     #     $$
     #     \vn{\n}{\e}{-1/2} = \vn{\n}{\e}{0}
@@ -58,10 +51,8 @@ def _compute_horizontal_kinetic_energy(
     # Inputs:
     #  - $\vn{\n}{\e}{\k}$ : vn
     #  - $\vt{\n}{\e}{\k}$ : vt
-    #  - $\pdxn{z}$ : ddxn_z_full
-    #  - $\pdxt{z}$ : ddxt_z_full
     #
-
+    """
     vn_ie_wp = vn
     z_vt_ie_vp = vt
     z_kin_hor_e_wp = wpfloat("0.5") * (vn * vn + astype(vt * vt, wpfloat))

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_kinetic_energy.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_horizontal_kinetic_energy.py
@@ -26,6 +26,42 @@ def _compute_horizontal_kinetic_energy(
     """Formerly known as _mo_solve_nonhydro_stencil_37 or _mo_velocity_advection_stencil_05."""
     # TODO: This stencil doesn't only do what the name implies. It also
     # assigns to vn_ie_wp and z_vt_ie_vp. These things should be separated.
+
+    # scidoc:
+    # Outputs:
+    #  - z_w_concorr_me :
+    #     $$
+    #     \wcc{\n}{\e}{\k} = \vn{\n}{\e}{\k} \pdxn{z} + \vt{\n}{\e}{\k} \pdxt{z}, \quad \k \in [\nflatlev, \nlev)
+    #     $$
+    #     Compute the contravariant correction to the vertical wind due to
+    #     terrain-following coordinate. $\pdxn{}$ and $\pdxt{}$ are the
+    #     horizontal derivatives along the normal and tangent directions
+    #     respectively (eq. 17 in |ICONdycorePaper|).
+    #  - vn_ie :
+    #     $$
+    #     \vn{\n}{\e}{-1/2} = \vn{\n}{\e}{0}
+    #     $$
+    #     Set the normal wind at model top equal to the normal wind at the
+    #     first full level.
+    #  - z_vt_ie :
+    #     $$
+    #     \vt{\n}{\e}{-1/2} = \vt{\n}{\e}{0}
+    #     $$
+    #     Set the tangential wind at model top equal to the tangential wind
+    #     at the first full level.
+    #  - z_kin_hor_e :
+    #     $$
+    #     \kinehori{\n}{\e}{0} = \frac{1}{2} \left( \vn{\n}{\e}{0}^2 + \vt{\n}{\e}{0}^2 \right)
+    #     $$
+    #     Compute the horizontal kinetic energy on the first full level.
+    #
+    # Inputs:
+    #  - $\vn{\n}{\e}{\k}$ : vn
+    #  - $\vt{\n}{\e}{\k}$ : vt
+    #  - $\pdxn{z}$ : ddxn_z_full
+    #  - $\pdxt{z}$ : ddxt_z_full
+    #
+
     vn_ie_wp = vn
     z_vt_ie_vp = vt
     z_kin_hor_e_wp = wpfloat("0.5") * (vn * vn + astype(vt * vt, wpfloat))

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_hydrostatic_correction_term.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_hydrostatic_correction_term.py
@@ -56,7 +56,7 @@ def _compute_hydrostatic_correction_term(
     #  - $\vpotemp{}{\c}{\k}$ : theta_v
     #  - $\vpotemp{}{\c}{\k\pm1/2}$ : theta_v_ic
     #  - $\frac{g}{\cpd}$ : grav_o_cpd
-    #  - $\Wedge$ : inverse_dual_edge_lengths
+    #  - $\Wedge$ : inv_dual_edge_lengths
     #  - $1 / \Dz{\k}$ : inv_ddqz_z_full
     #  - $\dzgradp$ : zdiff_gradp
     #  - $\k^*$ : vertoffset_gradp

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_hydrostatic_correction_term.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_hydrostatic_correction_term.py
@@ -26,7 +26,43 @@ def _compute_hydrostatic_correction_term(
     inv_dual_edge_length: fa.EdgeField[wpfloat],
     grav_o_cpd: wpfloat,
 ) -> fa.EdgeKField[vpfloat]:
-    """Formerly known as _mo_solve_nonhydro_stencil_21."""
+    """
+    Formerly known as _mo_solve_nonhydro_stencil_21.
+
+    # scidoc:
+    # Outputs:
+    #  - z_hydro_corr :
+    #     $$
+    #     \exnhydrocorr{\e} = \frac{g}{\cpd} \Wedge 4 \frac{ \vpotemp{}{\c_1}{\k} - \vpotemp{}{\c_0}{\k} }{ (\vpotemp{}{\c_1}{\k} + \vpotemp{}{\c_0}{\k})^2 },
+    #     $$
+    #     with
+    #     $$
+    #     \vpotemp{}{\c_i}{\k} = \vpotemp{}{\c_i}{\k^*} + \dzgradp \frac{\vpotemp{}{\c_i}{\k^*-1/2} - \vpotemp{}{\c_i}{\k^*+1/2}}{\Dz{\k^*}}
+    #     $$
+    #     Compute the hydrostatically approximated correction term that
+    #     replaces the downward extrapolation (last term in eq. 10 in
+    #     |ICONSteepSlopePressurePaper|).
+    #     This is only computed for the bottom-most level because all
+    #     edges which have a neighboring cell center inside terrain
+    #     beyond a certain limit use the same correction term at $k^*$
+    #     level in eq. 10 in |ICONSteepSlopePressurePaper| (see also the
+    #     last paragraph on page 3724 for the discussion).
+    #     $\c_i$ are the indexes of the adjacent cell centers using
+    #     $\offProv{e2c}$;
+    #     $k^*$ is the level index of the neighboring (horizontally, not
+    #     terrain-following) cell center and $h^*$ is its height.
+    #
+    # Inputs:
+    #  - $\vpotemp{}{\c}{\k}$ : theta_v
+    #  - $\vpotemp{}{\c}{\k\pm1/2}$ : theta_v_ic
+    #  - $\frac{g}{\cpd}$ : grav_o_cpd
+    #  - $\Wedge$ : inverse_dual_edge_lengths
+    #  - $1 / \Dz{\k}$ : inv_ddqz_z_full
+    #  - $\dzgradp$ : zdiff_gradp
+    #  - $\k^*$ : vertoffset_gradp
+    #
+
+    """
     zdiff_gradp_wp = astype(zdiff_gradp, wpfloat)
 
     theta_v_0 = theta_v(E2C[0])(as_offset(Koff, ikoffset(E2EC[0])))

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_perturbation_of_rho_and_theta.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_perturbation_of_rho_and_theta.py
@@ -42,6 +42,7 @@ def compute_perturbation_of_rho_and_theta(
     vertical_start: gtx.int32,
     vertical_end: gtx.int32,
 ):
+    
     _compute_perturbation_of_rho_and_theta(
         rho,
         rho_ref_mc,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_perturbation_of_rho_and_theta.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_perturbation_of_rho_and_theta.py
@@ -42,7 +42,6 @@ def compute_perturbation_of_rho_and_theta(
     vertical_start: gtx.int32,
     vertical_end: gtx.int32,
 ):
-    
     _compute_perturbation_of_rho_and_theta(
         rho,
         rho_ref_mc,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_tangential_wind.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_tangential_wind.py
@@ -20,7 +20,24 @@ def _compute_tangential_wind(
     vn: fa.EdgeKField[wpfloat],
     rbf_vec_coeff_e: gtx.Field[gtx.Dims[dims.EdgeDim, dims.E2C2EDim], wpfloat],
 ) -> fa.EdgeKField[vpfloat]:
-    """Formerly knowan as _mo_velocity_advection_stencil_01."""
+    """
+    Formerly knowan as _mo_velocity_advection_stencil_01.
+
+    # scidoc:
+    # Outputs:
+    #  - vt :
+    #     $$
+    #     \vt{\n}{\e}{\k} = \sum_{\offProv{e2c2e}} \Wrbf \vn{\n}{\e}{\k}
+    #     $$
+    #     Compute the tangential velocity by RBF interpolation from four neighboring
+    #     edges (diamond shape) projected along the tangential direction.
+    #
+    # Inputs:
+    #  - $\Wrbf$ : rbf_vec_coeff_e
+    #  - $\vn{\n}{\e}{\k}$ : vn
+    #
+    
+    """
     vt_wp = neighbor_sum(rbf_vec_coeff_e * vn(E2C2E), axis=E2C2EDim)
     return astype(vt_wp, vpfloat)
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_tangential_wind.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_tangential_wind.py
@@ -36,7 +36,7 @@ def _compute_tangential_wind(
     #  - $\Wrbf$ : rbf_vec_coeff_e
     #  - $\vn{\n}{\e}{\k}$ : vn
     #
-    
+
     """
     vt_wp = neighbor_sum(rbf_vec_coeff_e * vn(E2C2E), axis=E2C2EDim)
     return astype(vt_wp, vpfloat)

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/correct_contravariant_vertical_velocity.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/correct_contravariant_vertical_velocity.py
@@ -18,7 +18,35 @@ def _correct_contravariant_vertical_velocity(
     z_w_con_c: fa.CellKField[vpfloat],
     w_concorr_c: fa.CellKField[vpfloat],
 ) -> fa.CellKField[vpfloat]:
-    """Formerly known as _mo_velocity_advection_stencil_13."""
+    """
+    Formerly known as _mo_velocity_advection_stencil_13.
+
+    # scidoc:
+    # Outputs:
+    #  - z_w_con_c :
+    #     $$
+    #     (\w{\n}{\c}{\k-1/2} - \wcc{\n}{\c}{\k-1/2}) =
+    #     \begin{cases}
+    #         \w{\n}{\c}{\k-1/2},                        & \k \in [0, \nflatlev+1)     \\
+    #         \w{\n}{\c}{\k-1/2} - \wcc{\n}{\c}{\k-1/2}, & \k \in [\nflatlev+1, \nlev) \\
+    #         0,                                         & \k = \nlev
+    #     \end{cases}
+    #     $$
+    #     Subtract the contravariant correction $\wcc{}{}{}$ from the
+    #     vertical wind $\w{}{}{}$ in the terrain-following levels. This is
+    #     done for convevnience here, instead of directly in the advection
+    #     tendency update, because the result needs to be interpolated to
+    #     edge centers and full levels for later use.
+    #     The papers do not use a new symbol for this variable, and the code
+    #     ambiguosly mixes the variable names used for
+    #     $\wcc{}{}{}$ and $(\w{}{}{} - \wcc{}{}{})$.
+    #
+    # Inputs:
+    #  - $\w{\n}{\c}{\k\pm1/2}$ : w
+    #  - $\wcc{\n}{\c}{\k\pm1/2}$ : w_concorr_c
+    #
+    
+    """
     z_w_con_c_vp = z_w_con_c - w_concorr_c
     return z_w_con_c_vp
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/extrapolate_temporally_exner_pressure.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/extrapolate_temporally_exner_pressure.py
@@ -21,7 +21,42 @@ def _extrapolate_temporally_exner_pressure(
     exner_ref_mc: fa.CellKField[vpfloat],
     exner_pr: fa.CellKField[wpfloat],
 ) -> tuple[fa.CellKField[vpfloat], fa.CellKField[wpfloat]]:
-    """Formerly known as _mo_solve_nonhydro_stencil_02."""
+    """
+    Formerly known as _mo_solve_nonhydro_stencil_02.
+
+    # TODO:
+    #  - The first operation on z_exner_ex_pr should be done in a generic
+    #    math (1+a)*x - a*y program
+    #  - In the stencil, _extrapolate_temporally_exner_pressure doesn't only
+    #    do what the name suggests: it also updates exner_pr, which is not
+    #    what the name implies.
+    
+
+    # scidoc:
+    # Outputs:
+    #  - z_exner_ex_pr :
+    #     $$
+    #     \exnerprime{\ntilde}{\c}{\k} = (1 + \WtimeExner) \exnerprime{\n}{\c}{\k} - \WtimeExner \exnerprime{\n-1}{\c}{\k}, \k \in [0, \nlev) \\
+    #     \exnerprime{\ntilde}{\c}{\nlev} = 0
+    #     $$
+    #     Compute the temporal extrapolation of perturbed exner function
+    #     using the time backward scheme (see the |ICONTutorial| page 74).
+    #     This variable has nlev+1 levels even though it is defined on full levels.
+    #  - exner_pr :
+    #     $$
+    #     \exnerprime{\n-1}{\c}{\k} = \exnerprime{\ntilde}{\c}{\k}
+    #     $$
+    #     Store the perturbed exner function from the previous time step.
+    #
+    # Inputs:
+    #  - $\WtimeExner$ : exner_exfac
+    #  - $\exnerprime{\n}{\c}{\k}$ : exner - exner_ref_mc
+    #  - $\exnerprime{\n-1}{\c}{\k}$ : exner_pr
+    #
+    
+
+
+    """
     exner_exfac_wp, exner_ref_mc_wp = astype((exner_exfac, exner_ref_mc), wpfloat)
 
     z_exner_ex_pr_wp = (wpfloat("1.0") + exner_exfac_wp) * (

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_contravariant_vertical_velocity_to_full_levels.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_contravariant_vertical_velocity_to_full_levels.py
@@ -18,7 +18,24 @@ from icon4py.model.common.type_alias import vpfloat
 def _interpolate_contravariant_vertical_velocity_to_full_levels(
     z_w_con_c: fa.CellKField[vpfloat],
 ) -> fa.CellKField[vpfloat]:
-    """Formerly know as _mo_velocity_advection_stencil_15."""
+    """
+    Formerly know as _mo_velocity_advection_stencil_15.
+
+    # scidoc:
+    # Outputs:
+    #  - z_w_con_c_full :
+    #     $$
+    #     (\w{\n}{\c}{\k} - \wcc{\n}{\c}{\k}) = \frac{1}{2} [ (\w{\n}{\c}{\k-1/2} - \wcc{\n}{\c}{\k-1/2})
+    #                                                       + (\w{\n}{\c}{\k+1/2} - \wcc{\n}{\c}{\k+1/2}) ]
+    #     $$
+    #     Interpolate the vertical wind with contravariant correction from
+    #     half to full levels.
+    #
+    # Inputs:
+    #  - $(\w{\n}{\c}{\k\pm1/2} - \wcc{\n}{\c}{\k\pm1/2})$ : z_w_con_c
+    #
+    
+    """
     z_w_con_c_full_vp = vpfloat("0.5") * (z_w_con_c + z_w_con_c(Koff[1]))
     return z_w_con_c_full_vp
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_contravariant_vertical_velocity_to_full_levels.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_contravariant_vertical_velocity_to_full_levels.py
@@ -34,7 +34,7 @@ def _interpolate_contravariant_vertical_velocity_to_full_levels(
     # Inputs:
     #  - $(\w{\n}{\c}{\k\pm1/2} - \wcc{\n}{\c}{\k\pm1/2})$ : z_w_con_c
     #
-    
+
     """
     z_w_con_c_full_vp = vpfloat("0.5") * (z_w_con_c + z_w_con_c(Koff[1]))
     return z_w_con_c_full_vp

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_cell_center.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_cell_center.py
@@ -20,7 +20,25 @@ def _interpolate_to_cell_center(
     interpolant: fa.EdgeKField[vpfloat],
     e_bln_c_s: gtx.Field[gtx.Dims[dims.CEDim], wpfloat],
 ) -> fa.CellKField[vpfloat]:
-    """Formerly known as mo_velocity_advection_stencil_08 or mo_velocity_advection_stencil_09."""
+    """
+    Formerly known as mo_velocity_advection_stencil_08 or mo_velocity_advection_stencil_09.
+
+    # scidoc:
+    # Outputs:
+    #  - z_ekinh :
+    #     $$
+    #     \kinehori{\n}{\c}{\k} = \sum_{\offProv{c2e}} \Whor \kinehori{\n}{\e}{\k}
+    #     $$
+    #     Interpolate the horizonal kinetic energy from edge to cell center.
+    #
+    # Inputs:
+    #  - $\Whor$ : e_bln_c_s
+    #  - $\kinehori{\n}{\e}{\k}$ : z_kin_hor_e
+    #
+    
+    """
+
+
     interpolant_wp = astype(interpolant, wpfloat)
     interpolation_wp = neighbor_sum(e_bln_c_s(C2CE) * interpolant_wp(C2E), axis=C2EDim)
     return astype(interpolation_wp, vpfloat)

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_cell_center.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_cell_center.py
@@ -25,7 +25,7 @@ def _interpolate_to_cell_center(
 
     # scidoc:
     # Outputs:
-    #  - z_ekinh :
+    #  - interpolation :
     #     $$
     #     \kinehori{\n}{\c}{\k} = \sum_{\offProv{c2e}} \Whor \kinehori{\n}{\e}{\k}
     #     $$
@@ -33,11 +33,10 @@ def _interpolate_to_cell_center(
     #
     # Inputs:
     #  - $\Whor$ : e_bln_c_s
-    #  - $\kinehori{\n}{\e}{\k}$ : z_kin_hor_e
+    #  - $\kinehori{\n}{\e}{\k}$ : interpolant
     #
-    
-    """
 
+    """
 
     interpolant_wp = astype(interpolant, wpfloat)
     interpolation_wp = neighbor_sum(e_bln_c_s(C2CE) * interpolant_wp(C2E), axis=C2EDim)

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_half_levels_vp.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_half_levels_vp.py
@@ -33,7 +33,7 @@ def _interpolate_to_half_levels_vp(
 
     # scidoc:
     # Outputs:
-    #  - z_exner_ic :
+    #  - interpolation_to_half_levels :
     #     $$
     #     \exnerprime{\ntilde}{\c}{\k-1/2} = \Wlev \exnerprime{\ntilde}{\c}{\k} + (1 - \Wlev) \exnerprime{\ntilde}{\c}{\k-1}, \quad \k \in [\max(1,\nflatlev), \nlev) \\
     #     \exnerprime{\ntilde}{\c}{\nlev-1/2} = \sum_{\k=\nlev-1}^{\nlev-3} \Wlev_{\k} \exnerprime{\ntilde}{\c}{\k}
@@ -41,19 +41,10 @@ def _interpolate_to_half_levels_vp(
     #     Interpolate the perturbation exner from full to half levels.
     #     The ground level is based on quadratic extrapolation (with
     #     hydrostatic assumption?).
-    #  - z_dexner_dz_c_1 :
-    #     $$
-    #     \exnerprimedz{\ntilde}{\c}{\k} \approx \frac{\exnerprime{\ntilde}{\c}{\k-1/2} - \exnerprime{\ntilde}{\c}{\k+1/2}}{\Dz{\k}}, \quad \k \in [\max(1,\nflatlev), \nlev]
-    #     $$
-    #     Use the interpolated values to compute the vertical derivative
-    #     of perturbation exner at full levels.
-    #
     # Inputs:
     #  - $\Wlev$ : wgtfac_c
     #  - $\Wlev_{\k}$ : wgtfacq_c
-    #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
-    #  - $\exnerprime{\ntilde}{\c}{\k\pm1/2}$ : z_exner_ic
-    #  - $1 / \Dz{\k}$ : inv_ddqz_z_full
+    #  - $\exnerprime{\ntilde}{\c}{\k}$ : interpolant
     #
 
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_half_levels_vp.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_half_levels_vp.py
@@ -29,6 +29,34 @@ def _interpolate_to_half_levels_vp(
         interpolant: CellDim variables at full levels
     Returns:
         CellDim variables at half levels
+
+
+    # scidoc:
+    # Outputs:
+    #  - z_exner_ic :
+    #     $$
+    #     \exnerprime{\ntilde}{\c}{\k-1/2} = \Wlev \exnerprime{\ntilde}{\c}{\k} + (1 - \Wlev) \exnerprime{\ntilde}{\c}{\k-1}, \quad \k \in [\max(1,\nflatlev), \nlev) \\
+    #     \exnerprime{\ntilde}{\c}{\nlev-1/2} = \sum_{\k=\nlev-1}^{\nlev-3} \Wlev_{\k} \exnerprime{\ntilde}{\c}{\k}
+    #     $$
+    #     Interpolate the perturbation exner from full to half levels.
+    #     The ground level is based on quadratic extrapolation (with
+    #     hydrostatic assumption?).
+    #  - z_dexner_dz_c_1 :
+    #     $$
+    #     \exnerprimedz{\ntilde}{\c}{\k} \approx \frac{\exnerprime{\ntilde}{\c}{\k-1/2} - \exnerprime{\ntilde}{\c}{\k+1/2}}{\Dz{\k}}, \quad \k \in [\max(1,\nflatlev), \nlev]
+    #     $$
+    #     Use the interpolated values to compute the vertical derivative
+    #     of perturbation exner at full levels.
+    #
+    # Inputs:
+    #  - $\Wlev$ : wgtfac_c
+    #  - $\Wlev_{\k}$ : wgtfacq_c
+    #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
+    #  - $\exnerprime{\ntilde}{\c}{\k\pm1/2}$ : z_exner_ic
+    #  - $1 / \Dz{\k}$ : inv_ddqz_z_full
+    #
+
+
     """
     interpolation_to_half_levels_vp = wgtfac_c * interpolant + (
         vpfloat("1.0") - wgtfac_c

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_surface.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_surface.py
@@ -21,31 +21,23 @@ def _interpolate_to_surface(
 ) -> fa.CellKField[vpfloat]:
     """
     Formerly known as _mo_solve_nonhydro_stencil_04.
+
     # scidoc:
-        # Outputs:
-        #  - z_exner_ic :
-        #     $$
-        #     \exnerprime{\ntilde}{\c}{\k-1/2} = \Wlev \exnerprime{\ntilde}{\c}{\k} + (1 - \Wlev) \exnerprime{\ntilde}{\c}{\k-1}, \quad \k \in [\max(1,\nflatlev), \nlev) \\
-        #     \exnerprime{\ntilde}{\c}{\nlev-1/2} = \sum_{\k=\nlev-1}^{\nlev-3} \Wlev_{\k} \exnerprime{\ntilde}{\c}{\k}
-        #     $$
-        #     Interpolate the perturbation exner from full to half levels.
-        #     The ground level is based on quadratic extrapolation (with
-        #     hydrostatic assumption?).
-        #  - z_dexner_dz_c_1 :
-        #     $$
-        #     \exnerprimedz{\ntilde}{\c}{\k} \approx \frac{\exnerprime{\ntilde}{\c}{\k-1/2} - \exnerprime{\ntilde}{\c}{\k+1/2}}{\Dz{\k}}, \quad \k \in [\max(1,\nflatlev), \nlev]
-        #     $$
-        #     Use the interpolated values to compute the vertical derivative
-        #     of perturbation exner at full levels.
-        #
-        # Inputs:
-        #  - $\Wlev$ : wgtfac_c
-        #  - $\Wlev_{\k}$ : wgtfacq_c
-        #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
-        #  - $\exnerprime{\ntilde}{\c}{\k\pm1/2}$ : z_exner_ic
-        #  - $1 / \Dz{\k}$ : inv_ddqz_z_full
-        #
-        
+    # Outputs:
+    #  - interpolation_to_surface :
+    #     $$
+    #     \exnerprime{\ntilde}{\c}{\k-1/2} = \Wlev \exnerprime{\ntilde}{\c}{\k} + (1 - \Wlev) \exnerprime{\ntilde}{\c}{\k-1}, \quad \k \in [\max(1,\nflatlev), \nlev) \\
+    #     \exnerprime{\ntilde}{\c}{\nlev-1/2} = \sum_{\k=\nlev-1}^{\nlev-3} \Wlev_{\k} \exnerprime{\ntilde}{\c}{\k}
+    #     $$
+    #     Interpolate the perturbation exner from full to half levels.
+    #     The ground level is based on quadratic extrapolation (with
+    #     hydrostatic assumption?).
+    # Inputs:
+    #  - $\Wlev$ : wgtfac_c
+    #  - $\Wlev_{\k}$ : wgtfacq_c
+    #  - $\exnerprime{\ntilde}{\c}{\k}$ : interpolant
+    #
+    
     """
     interpolation_to_surface = (
         wgtfacq_c(Koff[-1]) * interpolant(Koff[-1])

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_surface.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_to_surface.py
@@ -19,7 +19,34 @@ def _interpolate_to_surface(
     wgtfacq_c: fa.CellKField[vpfloat],
     interpolant: fa.CellKField[vpfloat],
 ) -> fa.CellKField[vpfloat]:
-    """Formerly known as _mo_solve_nonhydro_stencil_04."""
+    """
+    Formerly known as _mo_solve_nonhydro_stencil_04.
+    # scidoc:
+        # Outputs:
+        #  - z_exner_ic :
+        #     $$
+        #     \exnerprime{\ntilde}{\c}{\k-1/2} = \Wlev \exnerprime{\ntilde}{\c}{\k} + (1 - \Wlev) \exnerprime{\ntilde}{\c}{\k-1}, \quad \k \in [\max(1,\nflatlev), \nlev) \\
+        #     \exnerprime{\ntilde}{\c}{\nlev-1/2} = \sum_{\k=\nlev-1}^{\nlev-3} \Wlev_{\k} \exnerprime{\ntilde}{\c}{\k}
+        #     $$
+        #     Interpolate the perturbation exner from full to half levels.
+        #     The ground level is based on quadratic extrapolation (with
+        #     hydrostatic assumption?).
+        #  - z_dexner_dz_c_1 :
+        #     $$
+        #     \exnerprimedz{\ntilde}{\c}{\k} \approx \frac{\exnerprime{\ntilde}{\c}{\k-1/2} - \exnerprime{\ntilde}{\c}{\k+1/2}}{\Dz{\k}}, \quad \k \in [\max(1,\nflatlev), \nlev]
+        #     $$
+        #     Use the interpolated values to compute the vertical derivative
+        #     of perturbation exner at full levels.
+        #
+        # Inputs:
+        #  - $\Wlev$ : wgtfac_c
+        #  - $\Wlev_{\k}$ : wgtfacq_c
+        #  - $\exnerprime{\ntilde}{\c}{\k}$ : z_exner_ex_pr
+        #  - $\exnerprime{\ntilde}{\c}{\k\pm1/2}$ : z_exner_ic
+        #  - $1 / \Dz{\k}$ : inv_ddqz_z_full
+        #
+        
+    """
     interpolation_to_surface = (
         wgtfacq_c(Koff[-1]) * interpolant(Koff[-1])
         + wgtfacq_c(Koff[-2]) * interpolant(Koff[-2])

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_vn_and_vt_to_ie_and_compute_ekin_on_edges.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_vn_and_vt_to_ie_and_compute_ekin_on_edges.py
@@ -29,7 +29,36 @@ def _interpolate_vn_and_vt_to_ie_and_compute_ekin_on_edges(
     fa.EdgeKField[vpfloat],
     fa.EdgeKField[vpfloat],
 ]:
-    """Formerly known as _mo_solve_nonhydro_stencil_36."""
+    """
+    Formerly known as _mo_solve_nonhydro_stencil_36.
+
+    # scidoc:
+    # Outputs:
+    #   - vn_ie :
+    #     $$
+    #     \vn{\n}{\e}{-1/2} = \vn{\n}{\e}{0}
+    #     $$
+    #     Set the normal wind at model top equal to the normal wind at the
+    #     first full level.
+    #  - z_vt_ie :
+    #     $$
+    #     \vt{\n}{\e}{-1/2} = \vt{\n}{\e}{0}
+    #     $$
+    #     Set the tangential wind at model top equal to the tangential wind
+    #     at the first full level.
+    #  - z_kin_hor_e :
+    #     $$
+    #     \kinehori{\n}{\e}{0} = \frac{1}{2} \left( \vn{\n}{\e}{0}^2 + \vt{\n}{\e}{0}^2 \right)
+    #     $$
+    #     Compute the horizontal kinetic energy on the first full level.
+    #
+    # Inputs:
+    #  - $\vn{\n}{\e}{\k}$ : vn
+    #  - $\vt{\n}{\e}{\k}$ : vt
+    #  - $$ : wgtfac_e
+    #
+    """
+
     z_vt_ie = _interpolate_vt_to_interface_edges(wgtfac_e=wgtfac_e, vt=vt)
     vn_ie, z_kin_hor_e = _interpolate_vn_to_ie_and_compute_ekin_on_edges(
         wgtfac_e=wgtfac_e, vn=vn, vt=vt

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_vn_to_ie_and_compute_ekin_on_edges.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/interpolate_vn_to_ie_and_compute_ekin_on_edges.py
@@ -24,7 +24,29 @@ def _interpolate_vn_to_ie_and_compute_ekin_on_edges(
     vn: fa.EdgeKField[wpfloat],
     vt: fa.EdgeKField[vpfloat],
 ) -> tuple[fa.EdgeKField[vpfloat], fa.EdgeKField[vpfloat]]:
-    """Formerly known as _mo_velocity_advection_stencil_02."""
+    """
+    Formerly known as _mo_velocity_advection_stencil_02.
+
+    # scidoc:
+    # Outputs:
+    #  - vn_ie :
+    #     $$
+    #     \vn{\n}{\e}{\k-1/2} = \Wlev \vn{\n}{\e}{\k} + (1 - \Wlev) \vn{\n}{\e}{\k-1}, \quad \k \in [1, \nlev)
+    #     $$
+    #     Interpolate the normal velocity from full to half levels.
+    #  - z_kin_hor_e :
+    #     $$
+    #     \kinehori{\n}{\e}{\k} = \frac{1}{2} \left( \vn{\n}{\e}{\k}^2 + \vt{\n}{\e}{\k}^2 \right), \quad \k \in [1, \nlev)
+    #     $$
+    #     Compute the horizontal kinetic energy. Exclude the first full level.
+    #
+    # Inputs:
+    #  - $\Wlev$ : wgtfac_e
+    #  - $\vn{\n}{\e}{\k}$ : vn
+    #  - $\vt{\n}{\e}{\k}$ : vt
+    #
+
+    """
     # TODO: This stencil fusion with the one below is not optimal:
     # _compute_horizontal_kinetic_energy is wasting computation by assigning
     # vn_ie and vt_ie which are thrown away.

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/mo_math_divrot_rot_vertex_ri_dsl.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/mo_math_divrot_rot_vertex_ri_dsl.py
@@ -20,6 +20,21 @@ def _mo_math_divrot_rot_vertex_ri_dsl(
     vec_e: fa.EdgeKField[wpfloat],
     geofac_rot: gtx.Field[gtx.Dims[dims.VertexDim, V2EDim], wpfloat],
 ) -> fa.VertexKField[vpfloat]:
+    """
+    # scidoc:
+    # Outputs:
+    #  - zeta :
+    #     $$
+    #     \vortvert{\n}{\v}{\k} = \sum_{\offProv{v2e}} \Crot \vn{\n}{\e}{\k}
+    #     $$
+    #     Compute the vorticity on vertices using the discrete Stokes
+    #     theorem (eq. 5 in |BonaventuraRingler2005|).
+    #
+    # Inputs:
+    #  - $\Crot$ : geofac_rot
+    #  - $\vn{\n}{\e}{\k}$ : vn
+    #
+        """
     rot_vec_wp = neighbor_sum(vec_e(V2E) * geofac_rot, axis=V2EDim)
     return astype(rot_vec_wp, vpfloat)
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/mo_math_divrot_rot_vertex_ri_dsl.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/mo_math_divrot_rot_vertex_ri_dsl.py
@@ -23,7 +23,7 @@ def _mo_math_divrot_rot_vertex_ri_dsl(
     """
     # scidoc:
     # Outputs:
-    #  - zeta :
+    #  - rot_vec :
     #     $$
     #     \vortvert{\n}{\v}{\k} = \sum_{\offProv{v2e}} \Crot \vn{\n}{\e}{\k}
     #     $$
@@ -32,9 +32,10 @@ def _mo_math_divrot_rot_vertex_ri_dsl(
     #
     # Inputs:
     #  - $\Crot$ : geofac_rot
-    #  - $\vn{\n}{\e}{\k}$ : vn
+    #  - $\vn{\n}{\e}{\k}$ : vec_e
     #
-        """
+
+    """
     rot_vec_wp = neighbor_sum(vec_e(V2E) * geofac_rot, axis=V2EDim)
     return astype(rot_vec_wp, vpfloat)
 

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity_advection.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity_advection.py
@@ -217,19 +217,6 @@ class VelocityAdvection:
                 offset_provider=self.grid.offset_providers,
             )
 
-        # scidoc:
-        # Outputs:
-        #  - zeta :
-        #     $$
-        #     \vortvert{\n}{\v}{\k} = \sum_{\offProv{v2e}} \Crot \vn{\n}{\e}{\k}
-        #     $$
-        #     Compute the vorticity on vertices using the discrete Stokes
-        #     theorem (eq. 5 in |BonaventuraRingler2005|).
-        #
-        # Inputs:
-        #  - $\Crot$ : geofac_rot
-        #  - $\vn{\n}{\e}{\k}$ : vn
-        #
         self._mo_math_divrot_rot_vertex_ri_dsl(
             vec_e=prognostic_state.vn,
             geofac_rot=self.interpolation_state.geofac_rot,
@@ -241,19 +228,6 @@ class VelocityAdvection:
             offset_provider=self.grid.offset_providers,
         )
 
-        # scidoc:
-        # Outputs:
-        #  - vt :
-        #     $$
-        #     \vt{\n}{\e}{\k} = \sum_{\offProv{e2c2e}} \Wrbf \vn{\n}{\e}{\k}
-        #     $$
-        #     Compute the tangential velocity by RBF interpolation from four neighboring
-        #     edges (diamond shape) projected along the tangential direction.
-        #
-        # Inputs:
-        #  - $\Wrbf$ : rbf_vec_coeff_e
-        #  - $\vn{\n}{\e}{\k}$ : vn
-        #
         self._compute_tangential_wind(
             vn=prognostic_state.vn,
             rbf_vec_coeff_e=self.interpolation_state.rbf_vec_coeff_e,
@@ -265,24 +239,6 @@ class VelocityAdvection:
             offset_provider=self.grid.offset_providers,
         )
 
-        # scidoc:
-        # Outputs:
-        #  - vn_ie :
-        #     $$
-        #     \vn{\n}{\e}{\k-1/2} = \Wlev \vn{\n}{\e}{\k} + (1 - \Wlev) \vn{\n}{\e}{\k-1}, \quad \k \in [1, \nlev)
-        #     $$
-        #     Interpolate the normal velocity from full to half levels.
-        #  - z_kin_hor_e :
-        #     $$
-        #     \kinehori{\n}{\e}{\k} = \frac{1}{2} \left( \vn{\n}{\e}{\k}^2 + \vt{\n}{\e}{\k}^2 \right), \quad \k \in [1, \nlev)
-        #     $$
-        #     Compute the horizontal kinetic energy. Exclude the first full level.
-        #
-        # Inputs:
-        #  - $\Wlev$ : wgtfac_e
-        #  - $\vn{\n}{\e}{\k}$ : vn
-        #  - $\vt{\n}{\e}{\k}$ : vt
-        #
         self._interpolate_vn_to_ie_and_compute_ekin_on_edges(
             wgtfac_e=self.metric_state.wgtfac_e,
             vn=prognostic_state.vn,
@@ -308,40 +264,6 @@ class VelocityAdvection:
                 offset_provider=self.grid.offset_providers,
             )
 
-        # scidoc:
-        # Outputs:
-        #  - z_w_concorr_me :
-        #     $$
-        #     \wcc{\n}{\e}{\k} = \vn{\n}{\e}{\k} \pdxn{z} + \vt{\n}{\e}{\k} \pdxt{z}, \quad \k \in [\nflatlev, \nlev)
-        #     $$
-        #     Compute the contravariant correction to the vertical wind due to
-        #     terrain-following coordinate. $\pdxn{}$ and $\pdxt{}$ are the
-        #     horizontal derivatives along the normal and tangent directions
-        #     respectively (eq. 17 in |ICONdycorePaper|).
-        #  - vn_ie :
-        #     $$
-        #     \vn{\n}{\e}{-1/2} = \vn{\n}{\e}{0}
-        #     $$
-        #     Set the normal wind at model top equal to the normal wind at the
-        #     first full level.
-        #  - z_vt_ie :
-        #     $$
-        #     \vt{\n}{\e}{-1/2} = \vt{\n}{\e}{0}
-        #     $$
-        #     Set the tangential wind at model top equal to the tangential wind
-        #     at the first full level.
-        #  - z_kin_hor_e :
-        #     $$
-        #     \kinehori{\n}{\e}{0} = \frac{1}{2} \left( \vn{\n}{\e}{0}^2 + \vt{\n}{\e}{0}^2 \right)
-        #     $$
-        #     Compute the horizontal kinetic energy on the first full level.
-        #
-        # Inputs:
-        #  - $\vn{\n}{\e}{\k}$ : vn
-        #  - $\vt{\n}{\e}{\k}$ : vt
-        #  - $\pdxn{z}$ : ddxn_z_full
-        #  - $\pdxt{z}$ : ddxt_z_full
-        #
         self._fused_stencils_4_5(
             vn=prognostic_state.vn,
             vt=diagnostic_state.vt,
@@ -388,18 +310,6 @@ class VelocityAdvection:
                 offset_provider=self.grid.offset_providers,
             )
 
-        # scidoc:
-        # Outputs:
-        #  - z_ekinh :
-        #     $$
-        #     \kinehori{\n}{\c}{\k} = \sum_{\offProv{c2e}} \Whor \kinehori{\n}{\e}{\k}
-        #     $$
-        #     Interpolate the horizonal kinetic energy from edge to cell center.
-        #
-        # Inputs:
-        #  - $\Whor$ : e_bln_c_s
-        #  - $\kinehori{\n}{\e}{\k}$ : z_kin_hor_e
-        #
         self._interpolate_to_cell_center(
             interpolant=z_kin_hor_e,
             e_bln_c_s=self.interpolation_state.e_bln_c_s,
@@ -411,24 +321,6 @@ class VelocityAdvection:
             offset_provider=self.grid.offset_providers,
         )
 
-        # scidoc:
-        # Outputs:
-        #  - z_w_concorr_mc :
-        #     $$
-        #     \wcc{\n}{\c}{\k} = \sum_{\offProv{c2e}} \Whor \wcc{\n}{\e}{\k}
-        #     $$
-        #     Interpolate the contravariant correction from edge to cell center.
-        #  - w_concorr_c :
-        #     $$
-        #     \wcc{\n}{\c}{\k-1/2} = \Wlev \wcc{\n}{\c}{\k} + (1 - \Wlev) \wcc{\n}{\c}{\k-1}, \quad \k \in [\nflatlev+1, \nlev)
-        #     $$
-        #     Interpolate the contravariant correction from full to half levels.
-        #
-        # Inputs:
-        #  - $\wcc{\n}{\e}{\k}$ : z_w_concorr_me
-        #  - $\Whor$ : e_bln_c_s
-        #  - $\Wlev$ : wgtfac_c
-        #
         self._fused_stencils_9_10(
             z_w_concorr_me=z_w_concorr_me,
             e_bln_c_s=self.interpolation_state.e_bln_c_s,
@@ -445,30 +337,6 @@ class VelocityAdvection:
             offset_provider=self.grid.offset_providers,
         )
 
-        # scidoc:
-        # Outputs:
-        #  - z_w_con_c :
-        #     $$
-        #     (\w{\n}{\c}{\k-1/2} - \wcc{\n}{\c}{\k-1/2}) =
-        #     \begin{cases}
-        #         \w{\n}{\c}{\k-1/2},                        & \k \in [0, \nflatlev+1)     \\
-        #         \w{\n}{\c}{\k-1/2} - \wcc{\n}{\c}{\k-1/2}, & \k \in [\nflatlev+1, \nlev) \\
-        #         0,                                         & \k = \nlev
-        #     \end{cases}
-        #     $$
-        #     Subtract the contravariant correction $\wcc{}{}{}$ from the
-        #     vertical wind $\w{}{}{}$ in the terrain-following levels. This is
-        #     done for convevnience here, instead of directly in the advection
-        #     tendency update, because the result needs to be interpolated to
-        #     edge centers and full levels for later use.
-        #     The papers do not use a new symbol for this variable, and the code
-        #     ambiguosly mixes the variable names used for
-        #     $\wcc{}{}{}$ and $(\w{}{}{} - \wcc{}{}{})$.
-        #
-        # Inputs:
-        #  - $\w{\n}{\c}{\k\pm1/2}$ : w
-        #  - $\wcc{\n}{\c}{\k\pm1/2}$ : w_concorr_c
-        #
         self._fused_stencils_11_to_13(
             w=prognostic_state.w,
             w_concorr_c=diagnostic_state.w_concorr_c,
@@ -501,19 +369,6 @@ class VelocityAdvection:
 
         self._update_levmask_from_cfl_clipping()
 
-        # scidoc:
-        # Outputs:
-        #  - z_w_con_c_full :
-        #     $$
-        #     (\w{\n}{\c}{\k} - \wcc{\n}{\c}{\k}) = \frac{1}{2} [ (\w{\n}{\c}{\k-1/2} - \wcc{\n}{\c}{\k-1/2})
-        #                                                       + (\w{\n}{\c}{\k+1/2} - \wcc{\n}{\c}{\k+1/2}) ]
-        #     $$
-        #     Interpolate the vertical wind with contravariant correction from
-        #     half to full levels.
-        #
-        # Inputs:
-        #  - $(\w{\n}{\c}{\k\pm1/2} - \wcc{\n}{\c}{\k\pm1/2})$ : z_w_con_c
-        #
         self._interpolate_contravariant_vertical_velocity_to_full_levels(
             z_w_con_c=self.z_w_con_c,
             z_w_con_c_full=self.z_w_con_c_full,
@@ -564,35 +419,7 @@ class VelocityAdvection:
 
         self.levelmask = self.levmask
 
-        # scidoc:
-        # Outputs:
-        #  - ddt_vn_apc_pc[ntnd] :
-        #     $$
-        #     \advvn{\n}{\e}{\k} &&= \pdxn{\kinehori{}{}{}} + \vt{}{}{} (\vortvert{}{}{} + \coriolis{}) + \pdz{\vn{}{}{}} (\w{}{}{} - \wcc{}{}{}) \\
-        #                        &&= \Gradn_{\offProv{e2c}} \Cgrad \kinehori{\n}{c}{\k} + \kinehori{\n}{\e}{\k} \Gradn_{\offProv{e2c}} \Cgrad     \\
-        #                        &&+ \vt{\n}{\e}{\k} (\coriolis{\e} + 1/2 \sum_{\offProv{e2v}} \vortvert{\n}{\v}{\k})                             \\
-        #                        &&+ \frac{\vn{\n}{\e}{\k-1/2} - \vn{\n}{\e}{\k+1/2}}{\Dz{k}}
-        #                            \sum_{\offProv{e2c}} \Whor (\w{\n}{\c}{\k} - \wcc{\n}{\c}{\k})
-        #     $$
-        #     Compute the advective tendency of the normal wind (eq. 13 in
-        #     |ICONdycorePaper|).
-        #     The edge-normal derivative of the kinetic energy is computed by
-        #     combining the first order approximation across adiacent cell
-        #     centres (eq. 7 in |BonaventuraRingler2005|) with the edge value of
-        #     the kinetic energy (TODO: this needs explaining and a reference).
-        #
-        # Inputs:
-        #  - $\Cgrad$ : coeff_gradekin
-        #  - $\kinehori{\n}{\e}{\k}$ : z_kin_hor_e
-        #  - $\kinehori{\n}{\c}{\k}$ : z_ekinh
-        #  - $\vt{\n}{\e}{\k}$ : vt
-        #  - $\coriolis{\e}$ : f_e
-        #  - $\vortvert{\n}{\v}{\k}$ : zeta
-        #  - $\Whor$ : c_lin_e
-        #  - $(\w{\n}{\c}{\k} - \wcc{\n}{\c}{\k})$ : z_w_con_c_full
-        #  - $\vn{\n}{\e}{\k\pm1/2}$ : vn_ie
-        #  - $\Dz{\k}$ : ddqz_z_full_e
-        #
+
         self._compute_advective_normal_wind_tendency(
             z_kin_hor_e=z_kin_hor_e,
             coeff_gradekin=self.metric_state.coeff_gradekin,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity_advection.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity_advection.py
@@ -419,7 +419,6 @@ class VelocityAdvection:
 
         self.levelmask = self.levmask
 
-
         self._compute_advective_normal_wind_tendency(
             z_kin_hor_e=z_kin_hor_e,
             coeff_gradekin=self.metric_state.coeff_gradekin,

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity_advection_stencils.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity_advection_stencils.py
@@ -146,29 +146,6 @@ def _fused_stencils_9_10(
     nflatlev_startindex: gtx.int32,
     nlev: gtx.int32,
 ) -> tuple[fa.CellKField[float], fa.CellKField[float]]:
-    """
-    # scidoc:
-    # Outputs:
-    #  - z_w_concorr_mc :
-    #     $$
-    #     \wcc{\n}{\c}{\k} = \sum_{\offProv{c2e}} \Whor \wcc{\n}{\e}{\k}
-    #     $$
-    #     Interpolate the contravariant correction from edge to cell center.
-    #  - w_concorr_c :
-    #     $$
-    #     \wcc{\n}{\c}{\k-1/2} = \Wlev \wcc{\n}{\c}{\k} + (1 - \Wlev) \wcc{\n}{\c}{\k-1}, \quad \k \in [\nflatlev+1, \nlev)
-    #     $$
-    #     Interpolate the contravariant correction from full to half levels.
-    #
-    # Inputs:
-    #  - $\wcc{\n}{\e}{\k}$ : z_w_concorr_me
-    #  - $\Whor$ : e_bln_c_s
-    #  - $\Wlev$ : wgtfac_c
-    #
-
-    """
-
-
     local_z_w_concorr_mc = where(
         (k_field >= nflatlev_startindex) & (k_field < nlev),
         _interpolate_to_cell_center(z_w_concorr_me, e_bln_c_s),

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity_advection_stencils.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity_advection_stencils.py
@@ -146,6 +146,29 @@ def _fused_stencils_9_10(
     nflatlev_startindex: gtx.int32,
     nlev: gtx.int32,
 ) -> tuple[fa.CellKField[float], fa.CellKField[float]]:
+    """
+    # scidoc:
+    # Outputs:
+    #  - z_w_concorr_mc :
+    #     $$
+    #     \wcc{\n}{\c}{\k} = \sum_{\offProv{c2e}} \Whor \wcc{\n}{\e}{\k}
+    #     $$
+    #     Interpolate the contravariant correction from edge to cell center.
+    #  - w_concorr_c :
+    #     $$
+    #     \wcc{\n}{\c}{\k-1/2} = \Wlev \wcc{\n}{\c}{\k} + (1 - \Wlev) \wcc{\n}{\c}{\k-1}, \quad \k \in [\nflatlev+1, \nlev)
+    #     $$
+    #     Interpolate the contravariant correction from full to half levels.
+    #
+    # Inputs:
+    #  - $\wcc{\n}{\e}{\k}$ : z_w_concorr_me
+    #  - $\Whor$ : e_bln_c_s
+    #  - $\Wlev$ : wgtfac_c
+    #
+
+    """
+
+
     local_z_w_concorr_mc = where(
         (k_field >= nflatlev_startindex) & (k_field < nlev),
         _interpolate_to_cell_center(z_w_concorr_me, e_bln_c_s),


### PR DESCRIPTION
Move the #scidoc strings from `SolveNonHydro` and  `VelocityAdvection` to the doc string of the individual stencil field operators.

- Adapted some of the outputs and input namings where they changed from the stencil call to the stencil implementation
- Split some of the #scidocs were they collected previousely fused stencils that most likely will not longer be used.
