### PR TITLE
Remove non-used functionality from py2fgen

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,14 +68,14 @@ repos:
   - id: tach
     name: Check inter-package dependencies
 
-# TODO(egparedes): fix and activate mypy hook 
-# - repo: local
-#   hooks:
-#   - id: mypy
-#     name: mypy static type checker
-#     entry: bash -c 'mypy tools/src/icon4py/tools model/common/src/icon4py/model/common'
-#     language: system
-#     types_or: [python, pyi]
-#     pass_filenames: false
-#     require_serial: true
-#     stages: [pre-commit]
+
+- repo: local
+  hooks:
+  - id: mypy
+    name: mypy static type checker
+    entry: bash -c 'mypy tools/src/icon4py/tools' # model/common/src/icon4py/model/common # TODO(egparedes): fix and activate mypy hook for all packages
+    language: system
+    types_or: [python, pyi]
+    pass_filenames: false
+    require_serial: true
+    stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ disallow_untyped_defs = true
 #   '^tests/liskov/*.py',
 #   '^tests/py2f/*.py',
 # ]
-ignore_missing_imports = true
+ignore_missing_imports = false
 implicit_reexport = true
 install_types = true
 non_interactive = true

--- a/tools/src/icon4py/tools/common/metadata.py
+++ b/tools/src/icon4py/tools/common/metadata.py
@@ -58,7 +58,7 @@ class DummyConnectivity(Connectivity):
     neighbor_axis: Dimension = Dimension("unused")
     index_type: type[int] = int
 
-    def mapped_index(self, cur_index, neigh_index) -> int:
+    def mapped_index(self, cur_index, neigh_index) -> int:  # type: ignore[no-untyped-def]  # code will disappear with next gt4py version
         raise AssertionError("Unreachable")
         return 0
 
@@ -89,7 +89,7 @@ def _get_field_infos(fvprog: Program) -> dict[str, FieldInfo]:
     assert all(
         _is_list_of_names(body.args) for body in fvprog.past_stage.past_node.body
     ), "Found unsupported expression in input arguments."
-    input_arg_ids = set(arg.id for body in fvprog.past_stage.past_node.body for arg in body.args)  # type: ignore[attr-defined] # Checked in the assert
+    input_arg_ids = set(arg.id for body in fvprog.past_stage.past_node.body for arg in body.args)
 
     out_args = (body.kwargs["out"] for body in fvprog.past_stage.past_node.body)
     output_fields = []

--- a/tools/src/icon4py/tools/icon4pygen/cli.py
+++ b/tools/src/icon4py/tools/icon4pygen/cli.py
@@ -25,7 +25,9 @@ class ModuleType(click.ParamType):
         f"{dycore_import_path}.mo_velocity_advection_stencil_",
     ]
 
-    def shell_complete(self, ctx, param, incomplete):
+    def shell_complete(
+        self, ctx: click.Context, param: click.Parameter, incomplete: str
+    ) -> list[click.shell_completion.CompletionItem]:
         if len(incomplete) > 0 and incomplete.endswith(":"):
             completions = [incomplete + incomplete[:-1].split(".")[-1]]
         else:

--- a/tools/src/icon4py/tools/liskov/cli.py
+++ b/tools/src/icon4py/tools/liskov/cli.py
@@ -23,7 +23,9 @@ from icon4py.tools.liskov.pipeline.collection import (
 logger = setup_logger(__name__)
 
 
-def split_comma(ctx, param, value) -> Optional[tuple[str]]:
+def split_comma(
+    ctx: click.Context, param: click.Parameter, value: str
+) -> Optional[tuple[str, ...]]:
     return tuple(v.strip() for v in value.split(",")) if value else None
 
 

--- a/tools/src/icon4py/tools/liskov/codegen/integration/template.py
+++ b/tools/src/icon4py/tools/liskov/codegen/integration/template.py
@@ -175,7 +175,7 @@ class EndStencilStatement(EndBasicStencilStatement):
     noprofile: Optional[bool]
     noaccenddata: Optional[bool]
 
-    def __post_init__(self, *args, **kwargs) -> None:
+    def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         all_fields = [Field(**asdict(f)) for f in self.stencil_data.fields]
         self.bounds_fields = BoundsFields(**asdict(self.stencil_data.bounds))
         self.name = self.stencil_data.name

--- a/tools/src/icon4py/tools/liskov/parsing/validation.py
+++ b/tools/src/icon4py/tools/liskov/parsing/validation.py
@@ -158,7 +158,7 @@ class DirectiveSemanticsValidator:
         def _identify_unbalanced_directives(
             directives: Sequence[ts.ParsedDirective],
             directive_types: tuple[Type[ts.ParsedDirective], ...],
-        ):
+        ) -> None:
             directive_counts: dict[str, int] = defaultdict(int)
             for directive in directives:
                 if isinstance(directive, directive_types):

--- a/tools/src/icon4py/tools/py2fgen/cli.py
+++ b/tools/src/icon4py/tools/py2fgen/cli.py
@@ -21,7 +21,7 @@ from icon4py.tools.py2fgen.plugin import generate_and_compile_cffi_plugin
 from icon4py.tools.py2fgen.settings import GT4PyBackend
 
 
-def parse_comma_separated_list(ctx, param, value) -> list[str]:
+def parse_comma_separated_list(ctx: click.Context, param: click.Parameter, value: str) -> list[str]:
     # Splits the input string by commas and strips any leading/trailing whitespace from the strings
     return [item.strip() for item in value.split(",")]
 

--- a/tools/src/icon4py/tools/py2fgen/generate.py
+++ b/tools/src/icon4py/tools/py2fgen/generate.py
@@ -61,7 +61,6 @@ def generate_python_wrapper(
         module_name=plugin.module_name,
         plugin_name=plugin.plugin_name,
         functions=plugin.functions,
-        imports=plugin.imports,
         backend=backend,
         debug_mode=debug_mode,
         limited_area=limited_area,

--- a/tools/src/icon4py/tools/py2fgen/parsing.py
+++ b/tools/src/icon4py/tools/py2fgen/parsing.py
@@ -6,9 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import ast
 import importlib
-import inspect
 from inspect import signature, unwrap
 from types import ModuleType
 from typing import Callable, List
@@ -19,46 +17,15 @@ from icon4py.tools.py2fgen.template import CffiPlugin, Func, FuncParameter
 from icon4py.tools.py2fgen.utils import parse_type_spec
 
 
-class ImportStmtVisitor(ast.NodeVisitor):
-    """AST Visitor to extract import statements."""
-
-    def __init__(self):
-        self.import_statements: list[str] = []
-
-    def visit_Import(self, node):
-        for alias in node.names:
-            import_statement = f"import {alias.name}" + (
-                f" as {alias.asname}" if alias.asname else ""
-            )
-            self.import_statements.append(import_statement)
-
-    def visit_ImportFrom(self, node):
-        for alias in node.names:
-            import_statement = f"from {node.module} import {alias.name}" + (
-                f" as {alias.asname}" if alias.asname else ""
-            )
-            self.import_statements.append(import_statement)
-
-
 def parse(module_name: str, functions: list[str], plugin_name: str) -> CffiPlugin:
     module = importlib.import_module(module_name)
-    parsed_imports = _extract_import_statements(module)
     parsed_functions = [_parse_function(module, f) for f in functions]
 
     return CffiPlugin(
         module_name=module_name,
         plugin_name=plugin_name,
         functions=parsed_functions,
-        imports=parsed_imports,
     )
-
-
-def _extract_import_statements(module: ModuleType) -> list[str]:
-    src = inspect.getsource(module)
-    tree = ast.parse(src)
-    visitor = ImportStmtVisitor()
-    visitor.visit(tree)
-    return visitor.import_statements
 
 
 def _parse_function(module: ModuleType, function_name: str) -> Func:

--- a/tools/src/icon4py/tools/py2fgen/parsing.py
+++ b/tools/src/icon4py/tools/py2fgen/parsing.py
@@ -9,14 +9,11 @@
 import ast
 import importlib
 import inspect
-import re
 from inspect import signature, unwrap
 from types import ModuleType
 from typing import Callable, List
 
-from gt4py.next import Dimension
-from gt4py.next.ffront.decorator import Program
-from gt4py.next.type_system.type_translation import from_type_hint
+from gt4py.next.type_system import type_translation as gtx_type_translation
 
 from icon4py.tools.py2fgen.template import CffiPlugin, Func, FuncParameter
 from icon4py.tools.py2fgen.utils import parse_type_spec
@@ -43,30 +40,10 @@ class ImportStmtVisitor(ast.NodeVisitor):
             self.import_statements.append(import_statement)
 
 
-class TypeHintVisitor(ast.NodeVisitor):
-    """AST Visitor to extract function parameter type hints."""
-
-    def __init__(self):
-        self.type_hints: dict[str, str] = {}
-
-    def visit_FunctionDef(self, node):
-        for arg in node.args.args:
-            if arg.annotation:
-                annotation = ast.unparse(arg.annotation)
-                self.type_hints[arg.arg] = annotation
-            else:
-                raise TypeError(
-                    f"Missing type hint for parameter '{arg.arg}' in function '{node.name}'"
-                )
-
-
 def parse(module_name: str, functions: list[str], plugin_name: str) -> CffiPlugin:
     module = importlib.import_module(module_name)
     parsed_imports = _extract_import_statements(module)
-
-    parsed_functions: list[Func] = []
-    for f in functions:
-        parsed_functions.append(_parse_function(module, f))
+    parsed_functions = [_parse_function(module, f) for f in functions]
 
     return CffiPlugin(
         module_name=module_name,
@@ -86,67 +63,16 @@ def _extract_import_statements(module: ModuleType) -> list[str]:
 
 def _parse_function(module: ModuleType, function_name: str) -> Func:
     func = unwrap(getattr(module, function_name))
-    is_gt4py_program = isinstance(func, Program)
-    type_hints = _extract_type_hint_strings(module, func, is_gt4py_program, function_name)
-
-    params = (
-        _get_gt4py_func_params(func, type_hints)
-        if is_gt4py_program
-        else _get_simple_func_params(func, type_hints)
-    )
-
-    return Func(name=function_name, args=params, is_gt4py_program=is_gt4py_program)
+    params = _parse_params(func)
+    return Func(name=function_name, args=params)
 
 
-def _extract_type_hint_strings(
-    module: ModuleType, func: Callable, is_gt4py_program: bool, function_name: str
-):
-    src = extract_function_signature(
-        inspect.getsource(module) if is_gt4py_program else inspect.getsource(func), function_name
-    )
-    tree = ast.parse(src)
-    visitor = TypeHintVisitor()
-    visitor.visit(tree)
-    return visitor.type_hints
-
-
-def extract_function_signature(code: str, function_name: str) -> str:
-    # This pattern attempts to match function definitions
-    pattern = rf"\bdef\s+{re.escape(function_name)}\s*\(([\s\S]*?)\)\s*:"
-
-    match = re.search(pattern, code)
-
-    if match:
-        # Constructing the full signature with empty return for ease of parsing by AST visitor
-        signature = match.group()
-        return signature.strip() + "\n  return None"
-    else:
-        raise Exception(f"Could not parse function signature from the following code:\n {code}")
-
-
-def _get_gt4py_func_params(func: Program, type_hints: dict[str, str]) -> List[FuncParameter]:
-    return [
-        FuncParameter(
-            name=p.id,
-            d_type=parse_type_spec(p.type)[1],
-            dimensions=parse_type_spec(p.type)[0],
-            py_type_hint=type_hints[p.id],
-        )
-        for p in func.past_stage.past_node.params
-    ]
-
-
-def _get_simple_func_params(func: Callable, type_hints: dict[str, str]) -> List[FuncParameter]:
+def _parse_params(func: Callable) -> List[FuncParameter]:
     sig_params = signature(func, follow_wrapped=False).parameters
-    return [
-        FuncParameter(
-            name=s,
-            d_type=parse_type_spec(from_type_hint(param.annotation))[1],
-            dimensions=[
-                Dimension(value=d.value)
-                for d in parse_type_spec(from_type_hint(param.annotation))[0]
-            ],
-            py_type_hint=type_hints.get(s, None),
-        )
-        for s, param in sig_params.items()
-    ]
+    params = []
+    for s, param in sig_params.items():
+        gt4py_type = gtx_type_translation.from_type_hint(param.annotation)
+        dims, dtype = parse_type_spec(gt4py_type)
+        params.append(FuncParameter(name=s, d_type=dtype, dimensions=dims))
+
+    return params

--- a/tools/src/icon4py/tools/py2fgen/plugin.py
+++ b/tools/src/icon4py/tools/py2fgen/plugin.py
@@ -7,120 +7,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging
-import math
-import typing
 from pathlib import Path
 
 import cffi
-import numpy as np
-from cffi import FFI
-from numpy.typing import NDArray
 
 from icon4py.tools.common.logger import setup_logger
 
 
-if typing.TYPE_CHECKING:
-    import cupy as cp  # type: ignore
-
-ffi = FFI()  # needed for unpack and unpack_gpu functions
-
 logger = setup_logger(__name__)
-
-
-def unpack(ptr, *sizes: int) -> NDArray:  # type: ignore[no-untyped-def] # CData type not public?
-    """
-    Converts a C pointer into a NumPy array to directly manipulate memory allocated in Fortran.
-    This function is needed for operations requiring in-place modification of CPU data, enabling
-    changes made in Python to reflect immediately in the original Fortran memory space.
-
-    Args:
-        ptr (CData): A CFFI pointer to the beginning of the data array in CPU memory. This pointer
-                     should reference a contiguous block of memory whose total size matches the product
-                     of the specified dimensions.
-        *sizes (int): Variable length argument list specifying the dimensions of the array.
-                      These sizes determine the shape of the resulting NumPy array.
-
-    Returns:
-        np.ndarray: A NumPy array that provides a direct view of the data pointed to by `ptr`.
-                    This array shares the underlying data with the original Fortran code, allowing
-                    modifications made through the array to affect the original data.
-    """
-    length = math.prod(sizes)
-    c_type = ffi.getctype(ffi.typeof(ptr).item)
-
-    # Map C data types to NumPy dtypes
-    dtype_map: dict[str, np.dtype] = {
-        "int": np.dtype(np.int32),
-        "double": np.dtype(np.float64),
-    }
-    dtype = dtype_map.get(c_type, np.dtype(c_type))
-
-    # Create a NumPy array from the buffer, specifying the Fortran order
-    arr = np.frombuffer(ffi.buffer(ptr, length * ffi.sizeof(c_type)), dtype=dtype).reshape(  # type: ignore
-        sizes, order="F"
-    )
-    return arr
-
-
-def unpack_gpu(ptr, *sizes: int):  # type: ignore[no-untyped-def] # CData type not public?
-    """
-    Converts a C pointer into a CuPy array to directly manipulate memory allocated in Fortran.
-    This function is needed for operations that require in-place modification of GPU data,
-    enabling changes made in Python to reflect immediately in the original Fortran memory space.
-
-    Args:
-        ptr (cffi.CData): A CFFI pointer to GPU memory allocated by OpenACC, representing
-                          the starting address of the data. This pointer must correspond to
-                          a contiguous block of memory whose total size matches the product
-                          of the specified dimensions.
-        *sizes (int): Variable length argument list specifying the dimensions of the array.
-                      These sizes determine the shape of the resulting CuPy array.
-
-    Returns:
-        cp.ndarray: A CuPy array that provides a direct view of the data pointed to by `ptr`.
-                    This array shares the underlying data with the original Fortran code, allowing
-                    modifications made through the array to affect the original data.
-    """
-
-    if not sizes:
-        raise ValueError("Sizes must be provided to determine the array shape.")
-
-    length = math.prod(sizes)
-    c_type = ffi.getctype(ffi.typeof(ptr).item)
-
-    dtype_map = {
-        "int": cp.int32,
-        "double": cp.float64,
-    }
-    dtype = dtype_map.get(c_type, None)
-    if dtype is None:
-        raise ValueError(f"Unsupported C data type: {c_type}")
-
-    itemsize = ffi.sizeof(c_type)
-    total_size = length * itemsize
-
-    # cupy array from OpenACC device pointer
-    current_device = cp.cuda.Device()
-    ptr_val = int(ffi.cast("uintptr_t", ptr))
-    mem = cp.cuda.UnownedMemory(ptr_val, total_size, owner=ptr, device_id=current_device.id)
-    memptr = cp.cuda.MemoryPointer(mem, 0)
-    arr = cp.ndarray(shape=sizes, dtype=dtype, memptr=memptr, order="F")
-    return arr
-
-
-def int_array_to_bool_array(int_array: NDArray) -> NDArray:
-    """
-    Converts a NumPy array of integers to a boolean array.
-    In the input array, 0 represents False, and any non-zero value (1 or -1) represents True.
-
-    Args:
-        int_array: A NumPy array of integers.
-
-    Returns:
-        A NumPy array of booleans.
-    """
-    bool_array = int_array != 0
-    return bool_array
 
 
 def generate_and_compile_cffi_plugin(

--- a/tools/src/icon4py/tools/py2fgen/plugin.py
+++ b/tools/src/icon4py/tools/py2fgen/plugin.py
@@ -27,7 +27,7 @@ ffi = FFI()  # needed for unpack and unpack_gpu functions
 logger = setup_logger(__name__)
 
 
-def unpack(ptr, *sizes: int) -> NDArray:
+def unpack(ptr, *sizes: int) -> NDArray:  # type: ignore[no-untyped-def] # CData type not public?
     """
     Converts a C pointer into a NumPy array to directly manipulate memory allocated in Fortran.
     This function is needed for operations requiring in-place modification of CPU data, enabling
@@ -62,7 +62,7 @@ def unpack(ptr, *sizes: int) -> NDArray:
     return arr
 
 
-def unpack_gpu(ptr, *sizes: int):
+def unpack_gpu(ptr, *sizes: int):  # type: ignore[no-untyped-def] # CData type not public?
     """
     Converts a C pointer into a CuPy array to directly manipulate memory allocated in Fortran.
     This function is needed for operations that require in-place modification of GPU data,

--- a/tools/src/icon4py/tools/py2fgen/settings.py
+++ b/tools/src/icon4py/tools/py2fgen/settings.py
@@ -9,9 +9,10 @@ import dataclasses
 import os
 from enum import Enum
 from functools import cached_property
+from types import ModuleType
 
 import numpy as np
-from gt4py.next import itir_python as run_roundtrip
+from gt4py.next import backend as gtx_backend, itir_python as run_roundtrip
 from gt4py.next.program_processors.runners.gtfn import (
     run_gtfn_cached,
     run_gtfn_gpu_cached,
@@ -19,7 +20,7 @@ from gt4py.next.program_processors.runners.gtfn import (
 
 
 try:
-    import dace  # type: ignore[import-not-found, import-untyped]
+    import dace  # type: ignore[import-untyped]
     from gt4py.next.program_processors.runners.dace import (
         run_dace_cpu,
         run_dace_cpu_noopt,
@@ -31,6 +32,24 @@ except ImportError:
     from typing import Optional
 
     dace: Optional[ModuleType] = None  # type: ignore[no-redef] # definition needed here
+
+
+def env_flag_to_bool(name: str, default: bool) -> bool:  # copied from gt4py.next.config
+    """Recognize true or false signaling string values."""
+    flag_value = None
+    if name in os.environ:
+        flag_value = os.environ[name].lower()
+    match flag_value:
+        case None:
+            return default
+        case "0" | "false" | "off":
+            return False
+        case "1" | "true" | "on":
+            return True
+        case _:
+            raise ValueError(
+                "Invalid environment flag value: use '0 | false | off' or '1 | true | on'."
+            )
 
 
 class Device(Enum):
@@ -51,7 +70,7 @@ class GT4PyBackend(Enum):
 @dataclasses.dataclass
 class Icon4PyConfig:
     @cached_property
-    def icon4py_backend(self):
+    def icon4py_backend(self) -> str:
         backend = os.environ.get("ICON4PY_BACKEND", "CPU")
         if hasattr(GT4PyBackend, backend):
             return backend
@@ -62,12 +81,12 @@ class Icon4PyConfig:
             )
 
     @cached_property
-    def icon4py_dace_orchestration(self):
+    def icon4py_dace_orchestration(self) -> bool:
         # Any value other than None will be considered as True
-        return os.environ.get("ICON4PY_DACE_ORCHESTRATION", None)
+        return env_flag_to_bool("ICON4PY_DACE_ORCHESTRATION", False)
 
     @cached_property
-    def array_ns(self):
+    def array_ns(self) -> ModuleType:
         if self.device == Device.GPU:
             import cupy as cp  # type: ignore[import-not-found]
 
@@ -76,8 +95,8 @@ class Icon4PyConfig:
             return np
 
     @cached_property
-    def gt4py_runner(self):
-        backend_map = {
+    def gt4py_runner(self) -> gtx_backend.Backend:
+        backend_map: dict[str, gtx_backend.Backend] = {
             GT4PyBackend.CPU.name: run_gtfn_cached,
             GT4PyBackend.GPU.name: run_gtfn_gpu_cached,
             GT4PyBackend.ROUNDTRIP.name: run_roundtrip,
@@ -92,7 +111,7 @@ class Icon4PyConfig:
         return backend_map[self.icon4py_backend]
 
     @cached_property
-    def device(self):
+    def device(self) -> Device:
         device_map = {
             GT4PyBackend.CPU.name: Device.CPU,
             GT4PyBackend.GPU.name: Device.GPU,
@@ -109,12 +128,12 @@ class Icon4PyConfig:
         return device
 
     @cached_property
-    def limited_area(self):
-        return os.environ.get("ICON4PY_LAM", False)
+    def limited_area(self) -> bool:
+        return env_flag_to_bool("ICON4PY_LAM", False)
 
     @cached_property
-    def parallel_run(self):
-        return os.environ.get("ICON4PY_PARALLEL", False)
+    def parallel_run(self) -> bool:
+        return env_flag_to_bool("ICON4PY_PARALLEL", False)
 
 
 config = Icon4PyConfig()

--- a/tools/src/icon4py/tools/py2fgen/template.py
+++ b/tools/src/icon4py/tools/py2fgen/template.py
@@ -30,11 +30,11 @@ from icon4py.tools.py2fgen.wrappers import wrapper_dimension
 
 
 UNINITIALISED_ARRAYS = [
-    "mask_hdiff",
+    "mask_hdiff",  # optional diffusion init fields
     "zd_diffcoef",
     "zd_vertoffset",
     "zd_intcoef",
-    "hdef_ic",
+    "hdef_ic",  # optional diffusion output fields
     "div_ic",
     "dwdx",
     "dwdy",
@@ -90,7 +90,6 @@ class Func(Node):
 class CffiPlugin(Node):
     module_name: str
     plugin_name: str
-    imports: list[str]
     functions: list[Func]
 
 
@@ -253,11 +252,6 @@ logging.basicConfig(level=logging.{%- if _this_node.debug_mode -%}DEBUG{%- else 
 
 import numpy as np
 
-# embedded module imports
-{% for stmt in imports -%}
-{{ stmt }}
-{% endfor %}
-
 # embedded function imports
 {% for func in _this_node.functions -%}
 from {{ module_name }} import {{ func.name }}
@@ -279,7 +273,7 @@ def {{ func.name }}_wrapper(
 {{ arg.name }}{% if not loop.last or func.global_size_args %}, {% endif %}
 {%- endfor %}
 {%- for arg in func.global_size_args -%}
-{{ arg }}: gtx.int32{{ ", " if not loop.last else "" }}
+{{ arg }}{{ ", " if not loop.last else "" }}
 {%- endfor -%}
 ):
     try:

--- a/tools/src/icon4py/tools/py2fgen/utils.py
+++ b/tools/src/icon4py/tools/py2fgen/utils.py
@@ -27,7 +27,7 @@ def flatten_and_get_unique_elts(list_of_lists: list[list[str]]) -> list[str]:
     return sorted(set(item for sublist in list_of_lists for item in sublist))
 
 
-def get_local_test_grid(grid_folder: str):
+def get_local_test_grid(grid_folder: str) -> str:
     test_folder = "testdata"
     module_spec = importlib.util.find_spec("icon4py.tools")
 
@@ -43,7 +43,7 @@ def get_local_test_grid(grid_folder: str):
         )
 
 
-def get_icon_grid_loc():
+def get_icon_grid_loc() -> str:
     env_path = os.environ.get("ICON_GRID_LOC")
     if env_path is not None:
         return env_path
@@ -53,7 +53,7 @@ def get_icon_grid_loc():
         )
 
 
-def get_grid_filename():
+def get_grid_filename() -> str:
     env_path = os.environ.get("ICON_GRID_NAME")
     if env_path is not None:
         return env_path

--- a/tools/src/icon4py/tools/py2fgen/wrapper_utils.py
+++ b/tools/src/icon4py/tools/py2fgen/wrapper_utils.py
@@ -1,0 +1,121 @@
+# ICON4Py - ICON inspired code in Python and GT4Py
+#
+# Copyright (c) 2022-2024, ETH Zurich and MeteoSwiss
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+
+if TYPE_CHECKING:
+    import cffi
+
+try:
+    import cupy as cp  # type: ignore
+except ImportError:
+    cp = None
+
+
+def unpack(ffi: cffi.FFI, ptr, *sizes: int) -> np.typing.NDArray:  # type: ignore[no-untyped-def] # CData type not public?
+    """
+    Converts a C pointer into a NumPy array to directly manipulate memory allocated in Fortran.
+    This function is needed for operations requiring in-place modification of CPU data, enabling
+    changes made in Python to reflect immediately in the original Fortran memory space.
+
+    Args:
+        ffi (cffi.FFI): A CFFI FFI instance.
+        ptr (CData): A CFFI pointer to the beginning of the data array in CPU memory. This pointer
+                     should reference a contiguous block of memory whose total size matches the product
+                     of the specified dimensions.
+        *sizes (int): Variable length argument list specifying the dimensions of the array.
+                      These sizes determine the shape of the resulting NumPy array.
+
+    Returns:
+        np.ndarray: A NumPy array that provides a direct view of the data pointed to by `ptr`.
+                    This array shares the underlying data with the original Fortran code, allowing
+                    modifications made through the array to affect the original data.
+    """
+    length = math.prod(sizes)
+    c_type = ffi.getctype(ffi.typeof(ptr).item)
+
+    # Map C data types to NumPy dtypes
+    dtype_map: dict[str, np.dtype] = {
+        "int": np.dtype(np.int32),
+        "double": np.dtype(np.float64),
+    }
+    dtype = dtype_map.get(c_type, np.dtype(c_type))
+
+    # Create a NumPy array from the buffer, specifying the Fortran order
+    arr = np.frombuffer(ffi.buffer(ptr, length * ffi.sizeof(c_type)), dtype=dtype).reshape(  # type: ignore
+        sizes, order="F"
+    )
+    return arr
+
+
+def unpack_gpu(ffi: cffi.FFI, ptr, *sizes: int):  # type: ignore[no-untyped-def] # CData type not public?
+    """
+    Converts a C pointer into a CuPy array to directly manipulate memory allocated in Fortran.
+    This function is needed for operations that require in-place modification of GPU data,
+    enabling changes made in Python to reflect immediately in the original Fortran memory space.
+
+    Args:
+        ffi (cffi.FFI): A CFFI FFI instance.
+        ptr (cffi.CData): A CFFI pointer to GPU memory allocated by OpenACC, representing
+                          the starting address of the data. This pointer must correspond to
+                          a contiguous block of memory whose total size matches the product
+                          of the specified dimensions.
+        *sizes (int): Variable length argument list specifying the dimensions of the array.
+                      These sizes determine the shape of the resulting CuPy array.
+
+    Returns:
+        cp.ndarray: A CuPy array that provides a direct view of the data pointed to by `ptr`.
+                    This array shares the underlying data with the original Fortran code, allowing
+                    modifications made through the array to affect the original data.
+    """
+
+    if not sizes:
+        raise ValueError("Sizes must be provided to determine the array shape.")
+
+    length = math.prod(sizes)
+    c_type = ffi.getctype(ffi.typeof(ptr).item)
+
+    dtype_map = {
+        "int": cp.int32,
+        "double": cp.float64,
+    }
+    dtype = dtype_map.get(c_type, None)
+    if dtype is None:
+        raise ValueError(f"Unsupported C data type: {c_type}")
+
+    itemsize = ffi.sizeof(c_type)
+    total_size = length * itemsize
+
+    # cupy array from OpenACC device pointer
+    current_device = cp.cuda.Device()
+    ptr_val = int(ffi.cast("uintptr_t", ptr))
+    mem = cp.cuda.UnownedMemory(ptr_val, total_size, owner=ptr, device_id=current_device.id)
+    memptr = cp.cuda.MemoryPointer(mem, 0)
+    arr = cp.ndarray(shape=sizes, dtype=dtype, memptr=memptr, order="F")
+    return arr
+
+
+def int_array_to_bool_array(int_array: np.typing.NDArray) -> np.typing.NDArray:
+    """
+    Converts a NumPy array of integers to a boolean array.
+    In the input array, 0 represents False, and any non-zero value (1 or -1) represents True.
+
+    Args:
+        int_array: A NumPy array of integers.
+
+    Returns:
+        A NumPy array of booleans.
+    """
+    bool_array = int_array != 0
+    return bool_array

--- a/tools/src/icon4py/tools/py2fgen/wrappers/debug_utils.py
+++ b/tools/src/icon4py/tools/py2fgen/wrappers/debug_utils.py
@@ -34,7 +34,7 @@ def print_grid_decomp_info(
     num_cells: int,
     num_edges: int,
     num_verts: int,
-):
+) -> None:
     log.info("icon_grid:cell_start%s", icon_grid._start_indices[CellDim])
     log.info("icon_grid:cell_end:%s", icon_grid._end_indices[CellDim])
     log.info("icon_grid:vert_start:%s", icon_grid._start_indices[VertexDim])

--- a/tools/tests/py2fgen/test_cffi.py
+++ b/tools/tests/py2fgen/test_cffi.py
@@ -14,7 +14,8 @@ import numpy as np
 import pytest
 from cffi import FFI
 
-from icon4py.tools.py2fgen.plugin import generate_and_compile_cffi_plugin, unpack
+from icon4py.tools.py2fgen.plugin import generate_and_compile_cffi_plugin
+from icon4py.tools.py2fgen.wrapper_utils import unpack
 
 
 @pytest.fixture
@@ -34,7 +35,7 @@ def test_unpack_column_major(data, expected_result, ffi):
 
     rows, cols = expected_result.shape
 
-    result = unpack(ptr, rows, cols)
+    result = unpack(ffi, ptr, rows, cols)
 
     assert np.array_equal(result, expected_result)
 

--- a/tools/tests/py2fgen/test_cli.py
+++ b/tools/tests/py2fgen/test_cli.py
@@ -170,7 +170,7 @@ def test_py2fgen_python_error_propagation_to_fortran(
 @pytest.mark.parametrize(
     "function_name, plugin_name, test_name, run_backend, extra_flags",
     [
-        ("square", "square_plugin", "test_square", "GPU", ("-acc", "-Minfo=acc")),
+        ("square_from_function", "square_plugin", "test_square", "GPU", ("-acc", "-Minfo=acc")),
     ],
 )
 def test_py2fgen_compilation_and_execution_gpu(

--- a/tools/tests/py2fgen/test_cli.py
+++ b/tools/tests/py2fgen/test_cli.py
@@ -116,7 +116,7 @@ def compile_and_run_fortran(
             env.update(env_vars)
         fortran_result = run_fortran_executable(plugin_name, env)
         if expected_error_code == 0:
-            assert "passed" in fortran_result.stdout
+            assert "passed" in fortran_result.stdout, fortran_result.stderr
         else:
             assert "failed" in fortran_result.stdout
     except subprocess.CalledProcessError as e:
@@ -170,7 +170,13 @@ def test_py2fgen_python_error_propagation_to_fortran(
 @pytest.mark.parametrize(
     "function_name, plugin_name, test_name, run_backend, extra_flags",
     [
-        ("square_from_function", "square_plugin", "test_square", "GPU", ("-acc", "-Minfo=acc")),
+        (
+            "square_from_function",
+            "square_plugin",
+            "test_square",
+            "GPU",
+            ("-acc", "-Minfo=acc", "-DUSE_SQUARE_FROM_FUNCTION"),
+        ),
     ],
 )
 def test_py2fgen_compilation_and_execution_gpu(

--- a/tools/tests/py2fgen/test_cli.py
+++ b/tools/tests/py2fgen/test_cli.py
@@ -127,7 +127,6 @@ def compile_and_run_fortran(
     "run_backend, extra_flags",
     [
         ("CPU", ("-DUSE_SQUARE_FROM_FUNCTION",)),
-        ("CPU", ""),
     ],
 )
 def test_py2fgen_compilation_and_execution_square_cpu(
@@ -139,7 +138,7 @@ def test_py2fgen_compilation_and_execution_square_cpu(
     run_test_case(
         cli_runner,
         square_wrapper_module,
-        "square,square_from_function",
+        "square_from_function",
         "square_plugin",
         run_backend,
         samples_path,

--- a/tools/tests/py2fgen/test_codegen.py
+++ b/tools/tests/py2fgen/test_codegen.py
@@ -356,7 +356,6 @@ def bar_wrapper(one, two, n_Cell, n_K):
 
     return 0
     '''
-    print(interface)
     assert compare_ignore_whitespace(interface, expected)
 
 

--- a/tools/tests/py2fgen/test_codegen.py
+++ b/tools/tests/py2fgen/test_codegen.py
@@ -230,6 +230,7 @@ def test_python_wrapper(dummy_plugin):
     expected = '''
 # imports for generated wrapper code
 import logging
+
 import math
 from libtest_plugin import ffi
 import numpy as np
@@ -237,6 +238,7 @@ import cupy as cp
 from numpy.typing import NDArray
 from gt4py.next.iterator.embedded import np_as_located_field
 from icon4py.tools.py2fgen.settings import config
+
 xp = config.array_ns
 from icon4py.model.common import dimension as dims
 
@@ -251,7 +253,8 @@ import numpy as np
 from libtest import foo
 from libtest import bar
 
-def unpack_gpu(ptr, *sizes: int):
+
+def unpack_gpu(ptr, *sizes: int):  # type: ignore[no-untyped-def] # CData type not public?
     """
     Converts a C pointer into a CuPy array to directly manipulate memory allocated in Fortran.
     This function is needed for operations that require in-place modification of GPU data,
@@ -296,6 +299,7 @@ def unpack_gpu(ptr, *sizes: int):
     arr = cp.ndarray(shape=sizes, dtype=dtype, memptr=memptr, order="F")
     return arr
 
+
 def int_array_to_bool_array(int_array: NDArray) -> NDArray:
     """
     Converts a NumPy array of integers to a boolean array.
@@ -310,13 +314,17 @@ def int_array_to_bool_array(int_array: NDArray) -> NDArray:
     bool_array = int_array != 0
     return bool_array
 
+
 @ffi.def_extern()
 def foo_wrapper(one, two, n_Cell, n_K):
     try:
+
         # Unpack pointers into Ndarrays
+
         two = unpack_gpu(two, n_Cell, n_K)
 
         # Allocate GT4Py Fields
+
         two = np_as_located_field(dims.CellDim, dims.KDim)(two)
 
         foo(one, two)
@@ -327,13 +335,17 @@ def foo_wrapper(one, two, n_Cell, n_K):
 
     return 0
 
+
 @ffi.def_extern()
 def bar_wrapper(one, two, n_Cell, n_K):
     try:
+
         # Unpack pointers into Ndarrays
+
         one = unpack_gpu(one, n_Cell, n_K)
 
         # Allocate GT4Py Fields
+
         one = np_as_located_field(dims.CellDim, dims.KDim)(one)
 
         bar(one, two)
@@ -344,6 +356,7 @@ def bar_wrapper(one, two, n_Cell, n_K):
 
     return 0
     '''
+    print(interface)
     assert compare_ignore_whitespace(interface, expected)
 
 

--- a/tools/tests/py2fgen/test_codegen.py
+++ b/tools/tests/py2fgen/test_codegen.py
@@ -30,18 +30,14 @@ field_2d = FuncParameter(
     name="name",
     d_type=ScalarKind.FLOAT32,
     dimensions=[dims.CellDim, dims.KDim],
-    py_type_hint="Field[dims.CellDim, dims.KDim], float64]",
 )
 field_1d = FuncParameter(
     name="name",
     d_type=ScalarKind.FLOAT32,
     dimensions=[dims.KDim],
-    py_type_hint="Field[dims.KDim], float64]",
 )
 
-simple_type = FuncParameter(
-    name="name", d_type=ScalarKind.FLOAT32, dimensions=[], py_type_hint="gtx.int32"
-)
+simple_type = FuncParameter(name="name", d_type=ScalarKind.FLOAT32, dimensions=[])
 
 
 @pytest.mark.parametrize(
@@ -54,15 +50,13 @@ def test_as_target(param, expected):
 foo = Func(
     name="foo",
     args=[
-        FuncParameter(name="one", d_type=ScalarKind.INT32, dimensions=[], py_type_hint="gtx.int32"),
+        FuncParameter(name="one", d_type=ScalarKind.INT32, dimensions=[]),
         FuncParameter(
             name="two",
             d_type=ScalarKind.FLOAT64,
             dimensions=[dims.CellDim, dims.KDim],
-            py_type_hint="Field[dims.CellDim, dims.KDim], float64]",
         ),
     ],
-    is_gt4py_program=False,
 )
 
 bar = Func(
@@ -75,11 +69,9 @@ bar = Func(
                 dims.CellDim,
                 dims.KDim,
             ],
-            py_type_hint="Field[dims.CellDim, dims.KDim], float64]",
         ),
-        FuncParameter(name="two", d_type=ScalarKind.INT32, dimensions=[], py_type_hint="gtx.int32"),
+        FuncParameter(name="two", d_type=ScalarKind.INT32, dimensions=[]),
     ],
-    is_gt4py_program=False,
 )
 
 
@@ -330,7 +322,7 @@ def int_array_to_bool_array(int_array: NDArray) -> NDArray:
     return bool_array
 
 @ffi.def_extern()
-def foo_wrapper(one: gtx.int32, two: Field[dims.CellDim, dims.KDim], float64], n_Cell: gtx.int32, n_K: gtx.int32):
+def foo_wrapper(one, two, n_Cell: gtx.int32, n_K: gtx.int32):
     try:
         # Unpack pointers into Ndarrays
         two = unpack_gpu(two, n_Cell, n_K)
@@ -347,7 +339,7 @@ def foo_wrapper(one: gtx.int32, two: Field[dims.CellDim, dims.KDim], float64], n
     return 0
 
 @ffi.def_extern()
-def bar_wrapper(one: Field[dims.CellDim, dims.KDim], float64], two: gtx.int32, n_Cell: gtx.int32, n_K: gtx.int32):
+def bar_wrapper(one, two, n_Cell: gtx.int32, n_K: gtx.int32):
     try:
         # Unpack pointers into Ndarrays
         one = unpack_gpu(one, n_Cell, n_K)

--- a/tools/tests/py2fgen/test_codegen.py
+++ b/tools/tests/py2fgen/test_codegen.py
@@ -76,18 +76,14 @@ bar = Func(
 
 
 def test_cheader_generation_for_single_function():
-    plugin = CffiPlugin(
-        module_name="libtest", plugin_name="libtest_plugin", functions=[foo], imports=["import foo"]
-    )
+    plugin = CffiPlugin(module_name="libtest", plugin_name="libtest_plugin", functions=[foo])
 
     header = CHeaderGenerator.apply(plugin)
     assert header == "extern int foo_wrapper(int one, double* two, int n_Cell, int n_K);"
 
 
 def test_cheader_for_pointer_args():
-    plugin = CffiPlugin(
-        module_name="libtest", plugin_name="libtest_plugin", functions=[bar], imports=["import bar"]
-    )
+    plugin = CffiPlugin(module_name="libtest", plugin_name="libtest_plugin", functions=[bar])
 
     header = CHeaderGenerator.apply(plugin)
     assert header == "extern int bar_wrapper(float* one, int two, int n_Cell, int n_K);"
@@ -104,7 +100,6 @@ def dummy_plugin():
         module_name="libtest",
         plugin_name="libtest_plugin",
         functions=[foo, bar],
-        imports=["import foo_module_x\nimport bar_module_y"],
     )
 
 
@@ -246,17 +241,11 @@ xp = config.array_ns
 from icon4py.model.common import dimension as dims
 
 # logger setup
-log_format = '%(asctime)s.%(msecs)03d - %(levelname)s - %(message)s'
-logging.basicConfig(level=logging.ERROR,
-                    format=log_format,
-                    datefmt='%Y-%m-%d %H:%M:%S')
+log_format = "%(asctime)s.%(msecs)03d - %(levelname)s - %(message)s"
+logging.basicConfig(level=logging.ERROR, format=log_format, datefmt="%Y-%m-%d %H:%M:%S")
 logging.info(cp.show_config())
 
 import numpy as np
-
-# embedded module imports
-import foo_module_x
-import bar_module_y
 
 # embedded function imports
 from libtest import foo
@@ -322,7 +311,7 @@ def int_array_to_bool_array(int_array: NDArray) -> NDArray:
     return bool_array
 
 @ffi.def_extern()
-def foo_wrapper(one, two, n_Cell: gtx.int32, n_K: gtx.int32):
+def foo_wrapper(one, two, n_Cell, n_K):
     try:
         # Unpack pointers into Ndarrays
         two = unpack_gpu(two, n_Cell, n_K)
@@ -339,7 +328,7 @@ def foo_wrapper(one, two, n_Cell: gtx.int32, n_K: gtx.int32):
     return 0
 
 @ffi.def_extern()
-def bar_wrapper(one, two, n_Cell: gtx.int32, n_K: gtx.int32):
+def bar_wrapper(one, two, n_Cell, n_K):
     try:
         # Unpack pointers into Ndarrays
         one = unpack_gpu(one, n_Cell, n_K)

--- a/tools/tests/py2fgen/test_parsing.py
+++ b/tools/tests/py2fgen/test_parsing.py
@@ -8,9 +8,7 @@
 
 import ast
 
-import pytest
-
-from icon4py.tools.py2fgen.parsing import ImportStmtVisitor, TypeHintVisitor, parse
+from icon4py.tools.py2fgen.parsing import ImportStmtVisitor, parse
 from icon4py.tools.py2fgen.template import CffiPlugin
 
 
@@ -36,18 +34,3 @@ def test_import_visitor():
     extractor.visit(tree)
     expected_imports = ["import foo", "import bar"]
     assert extractor.import_statements == expected_imports
-
-
-def test_type_hint_visitor():
-    tree = ast.parse(source)
-    visitor = TypeHintVisitor()
-    visitor.visit(tree)
-    expected_type_hints = {"x": "gtx.Field[gtx.Dims[EdgeDim, KDim], float64]", "y": "int"}
-    assert visitor.type_hints == expected_type_hints
-
-
-def test_function_missing_type_hints():
-    tree = ast.parse(source.replace(": int", ""))
-    visitor = TypeHintVisitor()
-    with pytest.raises(TypeError):
-        visitor.visit(tree)

--- a/tools/tests/py2fgen/test_parsing.py
+++ b/tools/tests/py2fgen/test_parsing.py
@@ -6,9 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import ast
-
-from icon4py.tools.py2fgen.parsing import ImportStmtVisitor, parse
+from icon4py.tools.py2fgen.parsing import parse
 from icon4py.tools.py2fgen.template import CffiPlugin
 
 
@@ -26,11 +24,3 @@ def test_parse_functions_on_wrapper():
     functions = ["diffusion_init", "diffusion_run"]
     plugin = parse(module_path, functions, "diffusion_plugin")
     assert isinstance(plugin, CffiPlugin)
-
-
-def test_import_visitor():
-    tree = ast.parse(source)
-    extractor = ImportStmtVisitor()
-    extractor.visit(tree)
-    expected_imports = ["import foo", "import bar"]
-    assert extractor.import_statements == expected_imports


### PR DESCRIPTION
- Remove special handling for wrapping gtx.Program (if needed at some point, the cleaner way would be to first wrap the program and then use the standard py2fgen)
- Remove type annotations from the wrapper (they were wrong and required extra logic to extract them)
- Remove copying over the imports from the wrapped module to the wrapper, unclear why that was needed in the past
- Enable mypy on `icon4py.tools` and add type annotations
- Move `unpack` and `int_array_to_bool_array` to `wrapper_util` module and import from there (they are now required at runtime).