### PR TITLE
CI: Remove CI_PROJECT_DIR from DOCKER_BUILD_ARGS

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -26,7 +26,7 @@ variables:
     DOCKERFILE: ci/docker/base.Dockerfile
     # change to 'always' if you want to rebuild, even if target tag exists already (if-not-exists is the default, i.e. we could also skip the variable)
     CSCS_REBUILD_POLICY: if-not-exists
-    DOCKER_BUILD_ARGS: '["ARCH=$ARCH", "HPC_SDK_VERSION=$HPC_SDK_VERSION", "HPC_SDK_NAME=$HPC_SDK_NAME", "PYVERSION=$PYVERSION", "CI_PROJECT_DIR=$CI_PROJECT_DIR"]'
+    DOCKER_BUILD_ARGS: '["ARCH=$ARCH", "HPC_SDK_VERSION=$HPC_SDK_VERSION", "HPC_SDK_NAME=$HPC_SDK_NAME", "PYVERSION=$PYVERSION"]'
 # build_baseimage_x86_64:
 #   extends: [.container-builder-cscs-zen2, .build_baseimage]
 #   variables:


### PR DESCRIPTION
The `CI_PROJECT_DIR` variable is passed to the docker build, which occasionally triggers an unnecessary rebuild. Since it is never used anywhere I removed it.