### PR TITLE
CI: Fix for nox environment variables

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -65,7 +65,6 @@ build_image_aarch64:
   timeout: 8h
   image: $CSCS_REGISTRY_PATH/public/$ARCH/icon4py/icon4py-ci:$CI_COMMIT_SHA-$PYVERSION
   before_script:
-    - env | grep ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS
     - cd /icon4py
     - ls "${TEST_DATA_PATH}"
   variables:

--- a/noxfile.py
+++ b/noxfile.py
@@ -109,7 +109,7 @@ def _install_session_venv(
 ) -> None:
     """Install session packages using uv."""
     #TODO(egparedes): remove this workaround once `backend` parameter is added to sessions
-    if (env_extras := session.env.get("ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS", "")):
+    if (env_extras := os.environ.get("ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS", "")):
         extras = [*extras, *re.split(r'\W+', env_extras)]
     env = dict(os.environ.items()) | {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
     session.run_install(


### PR DESCRIPTION
Read icon4py variable from OS environment, not nox environment. This became necessary after the nox version was upgraded. Refer to nox PR https://github.com/wntrblm/nox/pull/874