### PR TITLE
Remove jabw init savepoint

### DIFF
--- a/model/driver/tests/initial_condition_tests/test_jablonowski_williamson.py
+++ b/model/driver/tests/initial_condition_tests/test_jablonowski_williamson.py
@@ -8,6 +8,8 @@
 
 import pytest
 
+from icon4py.model.common import dimension as dims
+from icon4py.model.common.utils import data_allocation as data_alloc
 from icon4py.model.driver.test_cases import jablonowski_williamson as jabw
 from icon4py.model.testing import datatest_utils as dt_utils, helpers
 
@@ -30,6 +32,7 @@ def test_jabw_initial_condition(
 ):
     edge_geometry = grid_savepoint.construct_edge_geometry()
     cell_geometry = grid_savepoint.construct_cell_geometry()
+    default_surface_pressure = data_alloc.constant_field(icon_grid, 1e5, dims.CellDim)
 
     (
         diffusion_diagnostic_state,
@@ -81,7 +84,7 @@ def test_jabw_initial_condition(
 
     assert helpers.dallclose(
         diagnostic_state.surface_pressure.asnumpy(),
-        data_provider.from_savepoint_jabw_init().pressure_sfc().asnumpy(),
+        default_surface_pressure.asnumpy(),
     )
 
     assert helpers.dallclose(

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1364,50 +1364,6 @@ class IconNHFinalExitSavepoint(IconSavepoint):
         return self._get_field("x_exner", dims.CellDim, dims.KDim)
 
 
-class IconJabwInitSavepoint(IconSavepoint):
-    def exner(self):
-        return self._get_field("exner_init", dims.CellDim, dims.KDim)
-
-    def rho(self):
-        return self._get_field("rho_init", dims.CellDim, dims.KDim)
-
-    def w(self):
-        return self._get_field("w_init", dims.CellDim, dims.KDim)
-
-    def theta_v(self):
-        return self._get_field("theta_v_init", dims.CellDim, dims.KDim)
-
-    def pressure(self):
-        return self._get_field("pressure_init", dims.CellDim, dims.KDim)
-
-    def pressure_sfc(self):
-        return self._get_field("pressure_surface", dims.CellDim)
-
-    def temperature(self):
-        return self._get_field("temperature_init", dims.CellDim, dims.KDim)
-
-    def vn(self):
-        return self._get_field("vn_init", dims.EdgeDim, dims.KDim)
-
-    def eta0(self):
-        return self.serializer.read("eta0", self.savepoint)[0]
-
-    def etat(self):
-        return self.serializer.read("etat", self.savepoint)[0]
-
-    def gamma(self):
-        return self.serializer.read("gamma", self.savepoint)[0]
-
-    def dtemp(self):
-        return self.serializer.read("dtemp", self.savepoint)[0]
-
-    def lat_perturbation_center(self):
-        return self.serializer.read("latC", self.savepoint)[0]
-
-    def lon_perturbation_center(self):
-        return self.serializer.read("lonC", self.savepoint)[0]
-
-
 class IconJabwFinalSavepoint(IconSavepoint):
     def exner(self):
         return self._get_field("exner_final", dims.CellDim, dims.KDim)
@@ -1965,12 +1921,6 @@ class IconSerialDataProvider:
             self.serializer.savepoint["solve_nonhydro_step"].date[date].jstep[jstep].as_savepoint()
         )
         return IconNHFinalExitSavepoint(
-            savepoint, self.serializer, size=self.grid_size, backend=self.backend
-        )
-
-    def from_savepoint_jabw_init(self) -> IconJabwInitSavepoint:
-        savepoint = self.serializer.savepoint["icon-jabw-init"].id[1].as_savepoint()
-        return IconJabwInitSavepoint(
             savepoint, self.serializer, size=self.grid_size, backend=self.backend
         )
 


### PR DESCRIPTION
(Cleanup) This savepoint only contains 
 - constant values (`PARAMETER`s from `mo_nh_jabw_exp.f90`) 
 - fields that are initialized with a constant value (surface pressure) or zero

There is no need to keep it in the serialization and read it in via serialbox.
