### PR TITLE
CI: cleanup base_image gitlab config

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -37,10 +37,6 @@ build_baseimage_aarch64:
   variables:
     HPC_SDK_VERSION: 24.11
     HPC_SDK_NAME: "nvhpc_2024_2411_Linux_${ARCH}_cuda_12.6"
-    # TODO(edopao): use santis config until a gh200 machine is available in a kubernetes cluster
-    # CI-Ext is awaiting task to be done: https://jira.cscs.ch/browse/SD-60293
-    F7T_URL: 'https://api.cscs.ch/cw/firecrest/v1'
-    FIRECREST_SYSTEM: 'santis'
 
 .build_image:
   stage: image
@@ -55,11 +51,6 @@ build_baseimage_aarch64:
 build_image_aarch64:
   extends: [.container-builder-cscs-gh200, .build_image]
   needs: [build_baseimage_aarch64]
-  variables:
-    # TODO(edopao): use santis config until a gh200 machine is available in a kubernetes cluster
-    # CI-Ext is awaiting task to be done: https://jira.cscs.ch/browse/SD-60293
-    F7T_URL: 'https://api.cscs.ch/cw/firecrest/v1'
-    FIRECREST_SYSTEM: 'santis'
 
 .test_template:
   timeout: 8h


### PR DESCRIPTION
This cleanup is made possible by the change in CI-Ext: switched the container-builder from the compute nodes on the clusters to the build-farm.