### PR TITLE
Fixes for serialize icon4py verification icon exclaim

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -83,7 +83,7 @@ build_image_aarch64:
   variables:
     RUNNER: "ci-runner"
     SYSTEM_TAG: "${FIRECREST_SYSTEM}-gh200"
-    CSCS_ADDITIONAL_MOUNTS: '["/capstor/store/cscs/userlab/d126/icon4py/ci/testdata_002:$TEST_DATA_PATH"]'
+    CSCS_ADDITIONAL_MOUNTS: '["/capstor/store/cscs/userlab/d126/icon4py/ci/testdata_003:$TEST_DATA_PATH"]'
     HPC_SDK_PATH: "/opt/nvidia/hpc_sdk/Linux_${ARCH}/24.11"
     # Grace-Hopper gpu architecture is not enabled by default in CUDA build
     CUDAARCHS: "90"

--- a/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion_states.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion_states.py
@@ -17,7 +17,7 @@ from icon4py.model.atmosphere.diffusion import diffusion_states
 @pytest.mark.datatest
 def test_verify_geofac_n2s_field_manipulation(interpolation_savepoint, icon_grid, backend):
     geofac_n2s = interpolation_savepoint.geofac_n2s().asnumpy()
-    interpolation_state = interpolation_state = diffusion_states.DiffusionInterpolationState(
+    interpolation_state = diffusion_states.DiffusionInterpolationState(
         e_bln_c_s=data_alloc.flatten_first_two_dims(
             dims.CEDim,
             field=interpolation_savepoint.e_bln_c_s(),

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
@@ -404,7 +404,10 @@ class NonHydrostaticConfig:
             raise NotImplementedError("divdamp_order can only be 24")
 
         if self.divdamp_type == DivergenceDampingType.TWO_DIMENSIONAL:
-            raise NotImplementedError("`DivergenceDampingType.TWO_DIMENSIONAL` (2) is not yet implemented")
+            raise NotImplementedError(
+                "`DivergenceDampingType.TWO_DIMENSIONAL` (2) is not yet implemented"
+            )
+
 
 class NonHydrostaticParams:
     """Calculates derived quantities depending on the NonHydrostaticConfig."""

--- a/model/atmosphere/dycore/tests/dycore_stencil_tests/test_compute_advection_in_horizontal_momentum_equation.py
+++ b/model/atmosphere/dycore/tests/dycore_stencil_tests/test_compute_advection_in_horizontal_momentum_equation.py
@@ -64,7 +64,9 @@ class TestFusedVelocityAdvectionStencilsHMomentum(test_helpers.StencilTest):
         normal_wind_advective_tendency_cp = normal_wind_advective_tendency.copy()
         k = np.arange(nlev)
 
-        upward_vorticity_at_vertices = mo_math_divrot_rot_vertex_ri_dsl_numpy(connectivities, vn, geofac_rot)
+        upward_vorticity_at_vertices = mo_math_divrot_rot_vertex_ri_dsl_numpy(
+            connectivities, vn, geofac_rot
+        )
 
         normal_wind_advective_tendency = compute_advective_normal_wind_tendency_numpy(
             connectivities,
@@ -79,7 +81,7 @@ class TestFusedVelocityAdvectionStencilsHMomentum(test_helpers.StencilTest):
             vn_on_half_levels,
             ddqz_z_full_e,
         )
-        
+
         condition = (np.maximum(3, nrdmax - 2) - 1 <= k) & (k < nlev - 4)
         normal_wind_advective_tendency_extra_diffu = (
             add_extra_diffusion_for_normal_wind_tendency_approaching_cfl_numpy(

--- a/model/atmosphere/dycore/tests/dycore_tests/conftest.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/conftest.py
@@ -35,7 +35,6 @@ from icon4py.model.testing.datatest_fixtures import (  # noqa F401
     savepoint_nonhydro_step_final,
     savepoint_velocity_exit,
     savepoint_velocity_init,
-    savepoint_compute_edge_diagnostics_for_velocity_advection_init,
     savepoint_compute_edge_diagnostics_for_velocity_advection_exit,
     savepoint_compute_cell_diagnostics_for_velocity_advection_init,
     savepoint_compute_cell_diagnostics_for_velocity_advection_exit,

--- a/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
@@ -456,7 +456,6 @@ def test_velocity_corrector_step(
 def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
     icon_grid,
     grid_savepoint,
-    savepoint_compute_edge_diagnostics_for_velocity_advection_init,
     savepoint_compute_edge_diagnostics_for_velocity_advection_exit,
     interpolation_savepoint,
     metrics_savepoint,
@@ -471,25 +470,25 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
     edge_domain = h_grid.domain(dims.EdgeDim)
 
     tangential_wind_on_half_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_vt_ie()
+        savepoint_velocity_init.z_vt_ie()
     )
-    tangential_wind = savepoint_compute_edge_diagnostics_for_velocity_advection_init.vt()
-    vn_on_half_levels = savepoint_compute_edge_diagnostics_for_velocity_advection_init.vn_ie()
+    tangential_wind = savepoint_velocity_init.vt()
+    vn_on_half_levels = savepoint_velocity_init.vn_ie()
     horizontal_kinetic_energy_at_edges_on_model_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_kin_hor_e()
+        savepoint_velocity_init.z_kin_hor_e()
     )
     horizontal_advection_of_w_at_edges_on_half_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_v_grad_w()
+        data_alloc.zero_field(icon_grid, dims.EdgeDim, dims.KDim, backend=backend)
     )
-    vn = savepoint_compute_edge_diagnostics_for_velocity_advection_init.vn()
-    w = savepoint_compute_edge_diagnostics_for_velocity_advection_init.w()
+    vn = savepoint_velocity_init.vn()
+    w = savepoint_velocity_init.w()
 
     rbf_vec_coeff_e = interpolation_savepoint.rbf_vec_coeff_e()
     wgtfac_e = metrics_savepoint.wgtfac_e()
     ddxn_z_full = metrics_savepoint.ddxn_z_full()
     ddxt_z_full = metrics_savepoint.ddxt_z_full()
     contravariant_correction_at_edges_on_model_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_w_concorr_me()
+        savepoint_velocity_init.z_w_concorr_me()
     )
     wgtfacq_e = metrics_savepoint.wgtfacq_e_dsl(icon_grid.num_levels)
     nflatlev = grid_savepoint.nflatlev()
@@ -499,7 +498,7 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
     tangent_orientation = grid_savepoint.tangent_orientation()
 
     skip_compute_predictor_vertical_advection = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.lvn_only()
+        savepoint_velocity_init.vn_only()
     )
     # TODO(havogt): we need a test where skip_compute_predictor_vertical_advection is True!
 
@@ -595,7 +594,6 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
 def test_compute_edge_diagnostics_for_velocity_advection_in_corrector_step(
     icon_grid,
     grid_savepoint,
-    savepoint_compute_edge_diagnostics_for_velocity_advection_init,
     savepoint_compute_edge_diagnostics_for_velocity_advection_exit,
     interpolation_savepoint,
     metrics_savepoint,
@@ -610,13 +608,11 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_corrector_step(
     edge_domain = h_grid.domain(dims.EdgeDim)
 
     tangential_wind_on_half_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_vt_ie()
+        savepoint_velocity_init.z_vt_ie()
     )
-    vn_on_half_levels = savepoint_compute_edge_diagnostics_for_velocity_advection_init.vn_ie()
-    horizontal_advection_of_w_at_edges_on_half_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_v_grad_w()
-    )
-    w = savepoint_compute_edge_diagnostics_for_velocity_advection_init.w()
+    vn_on_half_levels = savepoint_velocity_init.vn_ie()
+    horizontal_advection_of_w_at_edges_on_half_levels = data_alloc.zero_field(icon_grid, dims.EdgeDim, dims.KDim, backend=backend)
+    w = savepoint_velocity_init.w()
 
     c_intp = interpolation_savepoint.c_intp()
     inv_dual_edge_length = grid_savepoint.inv_dual_edge_length()

--- a/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
@@ -469,16 +469,12 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
 ):
     edge_domain = h_grid.domain(dims.EdgeDim)
 
-    tangential_wind_on_half_levels = (
-        savepoint_velocity_init.z_vt_ie()
-    )
+    tangential_wind_on_half_levels = savepoint_velocity_init.z_vt_ie()
     tangential_wind = savepoint_velocity_init.vt()
     vn_on_half_levels = savepoint_velocity_init.vn_ie()
-    horizontal_kinetic_energy_at_edges_on_model_levels = (
-        savepoint_velocity_init.z_kin_hor_e()
-    )
-    horizontal_advection_of_w_at_edges_on_half_levels = (
-        data_alloc.zero_field(icon_grid, dims.EdgeDim, dims.KDim, backend=backend)
+    horizontal_kinetic_energy_at_edges_on_model_levels = savepoint_velocity_init.z_kin_hor_e()
+    horizontal_advection_of_w_at_edges_on_half_levels = data_alloc.zero_field(
+        icon_grid, dims.EdgeDim, dims.KDim, backend=backend
     )
     vn = savepoint_velocity_init.vn()
     w = savepoint_velocity_init.w()
@@ -487,9 +483,7 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
     wgtfac_e = metrics_savepoint.wgtfac_e()
     ddxn_z_full = metrics_savepoint.ddxn_z_full()
     ddxt_z_full = metrics_savepoint.ddxt_z_full()
-    contravariant_correction_at_edges_on_model_levels = (
-        savepoint_velocity_init.z_w_concorr_me()
-    )
+    contravariant_correction_at_edges_on_model_levels = savepoint_velocity_init.z_w_concorr_me()
     wgtfacq_e = metrics_savepoint.wgtfacq_e_dsl(icon_grid.num_levels)
     nflatlev = grid_savepoint.nflatlev()
     c_intp = interpolation_savepoint.c_intp()
@@ -497,9 +491,7 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
     inv_primal_edge_length = grid_savepoint.inverse_primal_edge_lengths()
     tangent_orientation = grid_savepoint.tangent_orientation()
 
-    skip_compute_predictor_vertical_advection = (
-        savepoint_velocity_init.vn_only()
-    )
+    skip_compute_predictor_vertical_advection = savepoint_velocity_init.vn_only()
     # TODO(havogt): we need a test where skip_compute_predictor_vertical_advection is True!
 
     horizontal_start = icon_grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5))
@@ -607,11 +599,11 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_corrector_step(
 ):
     edge_domain = h_grid.domain(dims.EdgeDim)
 
-    tangential_wind_on_half_levels = (
-        savepoint_velocity_init.z_vt_ie()
-    )
+    tangential_wind_on_half_levels = savepoint_velocity_init.z_vt_ie()
     vn_on_half_levels = savepoint_velocity_init.vn_ie()
-    horizontal_advection_of_w_at_edges_on_half_levels = data_alloc.zero_field(icon_grid, dims.EdgeDim, dims.KDim, backend=backend)
+    horizontal_advection_of_w_at_edges_on_half_levels = data_alloc.zero_field(
+        icon_grid, dims.EdgeDim, dims.KDim, backend=backend
+    )
     w = savepoint_velocity_init.w()
 
     c_intp = interpolation_savepoint.c_intp()

--- a/model/common/src/icon4py/model/common/utils/__init__.py
+++ b/model/common/src/icon4py/model/common/utils/__init__.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-from . import data_allocation
 from ._common import (
     DoubleBuffering,
     Pair,

--- a/model/testing/src/icon4py/model/testing/datatest_fixtures.py
+++ b/model/testing/src/icon4py/model/testing/datatest_fixtures.py
@@ -188,7 +188,7 @@ def savepoint_velocity_init(data_provider, step_date_init, istep_init, substep_i
         istep=istep_init, date=step_date_init, substep=substep_init
     )
 
-
+# TODO (halungge) remove fixture (and class) in a followup PR, once data is updated
 @pytest.fixture
 def savepoint_compute_edge_diagnostics_for_velocity_advection_init(
     data_provider, step_date_init, istep_init, substep_init
@@ -319,7 +319,6 @@ def savepoint_compute_cell_diagnostics_for_velocity_advection_exit(
     return data_provider.from_savepoint_compute_cell_diagnostics_for_velocity_advection_exit(
         istep=istep_init, date=step_date_exit, substep_init=substep_init
     )
-
 
 @pytest.fixture
 def savepoint_compute_advection_in_vertical_momentum_equation_exit(

--- a/model/testing/src/icon4py/model/testing/datatest_fixtures.py
+++ b/model/testing/src/icon4py/model/testing/datatest_fixtures.py
@@ -188,6 +188,7 @@ def savepoint_velocity_init(data_provider, step_date_init, istep_init, substep_i
         istep=istep_init, date=step_date_init, substep=substep_init
     )
 
+
 # TODO (halungge) remove fixture (and class) in a followup PR, once data is updated
 @pytest.fixture
 def savepoint_compute_edge_diagnostics_for_velocity_advection_init(
@@ -319,6 +320,7 @@ def savepoint_compute_cell_diagnostics_for_velocity_advection_exit(
     return data_provider.from_savepoint_compute_cell_diagnostics_for_velocity_advection_exit(
         istep=istep_init, date=step_date_exit, substep_init=substep_init
     )
+
 
 @pytest.fixture
 def savepoint_compute_advection_in_vertical_momentum_equation_exit(

--- a/model/testing/src/icon4py/model/testing/datatest_fixtures.py
+++ b/model/testing/src/icon4py/model/testing/datatest_fixtures.py
@@ -189,24 +189,6 @@ def savepoint_velocity_init(data_provider, step_date_init, istep_init, substep_i
     )
 
 
-# TODO (halungge) remove fixture (and class) in a followup PR, once data is updated
-@pytest.fixture
-def savepoint_compute_edge_diagnostics_for_velocity_advection_init(
-    data_provider, step_date_init, istep_init, substep_init
-):  # F811
-    """
-    Load data from ICON savepoint at start of velocity_advection module for edge diagnostics.
-
-     metadata to select a unique savepoint:
-    - date: <iso_string> of the simulation timestep
-    - istep: one of 1 ~ predictor, 2 ~ corrector of dycore integration scheme
-    - substep: dynamical substep
-    """
-    return data_provider.from_savepoint_compute_edge_diagnostics_for_velocity_advection_init(
-        istep=istep_init, date=step_date_init, substep_init=substep_init
-    )
-
-
 @pytest.fixture
 def savepoint_compute_cell_diagnostics_for_velocity_advection_init(
     data_provider, step_date_init, istep_init, substep_init

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1579,7 +1579,6 @@ class IconPrognosticsInitSavepoint(IconSavepoint):
         return self._get_field("theta_v_now", dims.CellDim, dims.KDim)
 
 
-
 class IconGraupelEntrySavepoint(IconSavepoint):
     def temperature(self):
         return self._get_field("ser_in_graupel_temperature", dims.CellDim, dims.KDim)

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1297,35 +1297,6 @@ class IconVelocityInitSavepoint(IconSavepoint):
         return self._get_field("w_concorr_c", dims.CellDim, dims.KDim)
 
 
-class VelocityInitEdgeDiagnosticsSavepoint(IconSavepoint):
-    def lvn_only(self) -> bool:
-        return bool(self.serializer.read("vn_only", self.savepoint)[0])
-
-    def vn(self):
-        return self._get_field("vn", dims.EdgeDim, dims.KDim)
-
-    def vn_ie(self):
-        return self._get_field("vn_ie", dims.EdgeDim, dims.KDim)
-
-    def vt(self):
-        return self._get_field("vt", dims.EdgeDim, dims.KDim)
-
-    def w(self):
-        return self._get_field("w", dims.CellDim, dims.KDim)
-
-    def z_kin_hor_e(self):
-        return self._get_field("z_kin_hor_e", dims.EdgeDim, dims.KDim)
-
-    def z_v_grad_w(self):
-        return self._get_field("z_v_grad_w", dims.EdgeDim, dims.KDim)
-
-    def z_vt_ie(self):
-        return self._get_field("z_vt_ie", dims.EdgeDim, dims.KDim)
-
-    def z_w_concorr_me(self):
-        return self._get_field("z_w_concorr_me", dims.EdgeDim, dims.KDim)
-
-
 class VelocityAdvectionCellDiagnosticsInitSavepoint(IconSavepoint):
     def z_kin_hor_e(self):
         return self._get_field("z_kin_hor_e", dims.EdgeDim, dims.KDim)
@@ -1999,21 +1970,6 @@ class IconSerialDataProvider:
             .as_savepoint()
         )
         return IconVelocityInitSavepoint(
-            savepoint, self.serializer, size=self.grid_size, backend=self.backend
-        )
-
-    # TODO (halungge) remove function and class in a followup PR, once data is updated
-    def from_savepoint_compute_edge_diagnostics_for_velocity_advection_init(
-        self, istep: int, date: str, substep_init: int
-    ) -> VelocityInitEdgeDiagnosticsSavepoint:
-        savepoint = (
-            self.serializer.savepoint["velocity-tendencies-init"]
-            .istep[istep]
-            .date[date]
-            .dyn_timestep[substep_init]
-            .as_savepoint()
-        )
-        return VelocityInitEdgeDiagnosticsSavepoint(
             savepoint, self.serializer, size=self.grid_size, backend=self.backend
         )
 

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -344,7 +344,7 @@ class IconGridSavepoint(IconSavepoint):
                 : self.sizes[target_dim], :
             ]
         else:
-            connectivity = self._read_int32(name, offset=1)[: self.sizes[target_dim], :]
+            connectivity = np.squeeze(self._read_int32(name, offset=1)[: self.sizes[target_dim], :])
         self.log.debug(f" connectivity {name} : {connectivity.shape}")
         return connectivity
 
@@ -1578,20 +1578,6 @@ class IconPrognosticsInitSavepoint(IconSavepoint):
     def theta_v_now(self):
         return self._get_field("theta_v_now", dims.CellDim, dims.KDim)
 
-    def pressure_ifc(self):
-        return self._get_field("pressure_ifc", dims.CellDim, dims.KDim)
-
-    def pressure_sfc(self):
-        return self._get_field("pressure_sfc", dims.CellDim)
-
-    def virtual_temperature(self):
-        return self._get_field("virtual_temperature", dims.CellDim, dims.KDim)
-
-    def zonal_wind(self):
-        return self._get_field("u", dims.CellDim, dims.KDim)
-
-    def meridional_wind(self):
-        return self._get_field("v", dims.CellDim, dims.KDim)
 
 
 class IconGraupelEntrySavepoint(IconSavepoint):
@@ -2021,7 +2007,7 @@ class IconSerialDataProvider:
         self, istep: int, date: str, substep_init: int
     ) -> VelocityInitEdgeDiagnosticsSavepoint:
         savepoint = (
-            self.serializer.savepoint["velocity-tendencies-1to7-init"]
+            self.serializer.savepoint["velocity-tendencies-init"]
             .istep[istep]
             .date[date]
             .dyn_timestep[substep_init]

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -2002,6 +2002,7 @@ class IconSerialDataProvider:
             savepoint, self.serializer, size=self.grid_size, backend=self.backend
         )
 
+    # TODO (halungge) remove function and class in a followup PR, once data is updated
     def from_savepoint_compute_edge_diagnostics_for_velocity_advection_init(
         self, istep: int, date: str, substep_init: int
     ) -> VelocityInitEdgeDiagnosticsSavepoint:


### PR DESCRIPTION
Cleanups for the datatests:
- in the new dataset the special `velocity-tendencies-1to7` savepoint will be removed, the `velocity-tendencies-init` is used instead. 
- deletes unused functions from `IconPrognosticsInitSavepoint` which are not backed by data in the savepoint.
- an missing `squeeze` is added in  `serialbox.py::_get_connectivity_array` to allow for 4d data (empty block dimension)