### PR TITLE
Reenable graupel tests

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -83,7 +83,7 @@ build_image_aarch64:
   variables:
     RUNNER: "ci-runner"
     SYSTEM_TAG: "${FIRECREST_SYSTEM}-gh200"
-    CSCS_ADDITIONAL_MOUNTS: '["/capstor/store/cscs/userlab/d126/icon4py/ci/testdata_002:$TEST_DATA_PATH"]'
+    CSCS_ADDITIONAL_MOUNTS: '["/capstor/store/cscs/userlab/d126/icon4py/ci/testdata_003:$TEST_DATA_PATH"]'
     HPC_SDK_PATH: "/opt/nvidia/hpc_sdk/Linux_${ARCH}/24.11"
     # Grace-Hopper gpu architecture is not enabled by default in CUDA build
     CUDAARCHS: "90"

--- a/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion_states.py
+++ b/model/atmosphere/diffusion/tests/diffusion_tests/test_diffusion_states.py
@@ -17,7 +17,7 @@ from icon4py.model.atmosphere.diffusion import diffusion_states
 @pytest.mark.datatest
 def test_verify_geofac_n2s_field_manipulation(interpolation_savepoint, icon_grid, backend):
     geofac_n2s = interpolation_savepoint.geofac_n2s().asnumpy()
-    interpolation_state = interpolation_state = diffusion_states.DiffusionInterpolationState(
+    interpolation_state = diffusion_states.DiffusionInterpolationState(
         e_bln_c_s=data_alloc.flatten_first_two_dims(
             dims.CEDim,
             field=interpolation_savepoint.e_bln_c_s(),

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
@@ -404,7 +404,10 @@ class NonHydrostaticConfig:
             raise NotImplementedError("divdamp_order can only be 24")
 
         if self.divdamp_type == DivergenceDampingType.TWO_DIMENSIONAL:
-            raise NotImplementedError("`DivergenceDampingType.TWO_DIMENSIONAL` (2) is not yet implemented")
+            raise NotImplementedError(
+                "`DivergenceDampingType.TWO_DIMENSIONAL` (2) is not yet implemented"
+            )
+
 
 class NonHydrostaticParams:
     """Calculates derived quantities depending on the NonHydrostaticConfig."""

--- a/model/atmosphere/dycore/tests/dycore_stencil_tests/test_compute_advection_in_horizontal_momentum_equation.py
+++ b/model/atmosphere/dycore/tests/dycore_stencil_tests/test_compute_advection_in_horizontal_momentum_equation.py
@@ -64,7 +64,9 @@ class TestFusedVelocityAdvectionStencilsHMomentum(test_helpers.StencilTest):
         normal_wind_advective_tendency_cp = normal_wind_advective_tendency.copy()
         k = np.arange(nlev)
 
-        upward_vorticity_at_vertices = mo_math_divrot_rot_vertex_ri_dsl_numpy(connectivities, vn, geofac_rot)
+        upward_vorticity_at_vertices = mo_math_divrot_rot_vertex_ri_dsl_numpy(
+            connectivities, vn, geofac_rot
+        )
 
         normal_wind_advective_tendency = compute_advective_normal_wind_tendency_numpy(
             connectivities,
@@ -79,7 +81,7 @@ class TestFusedVelocityAdvectionStencilsHMomentum(test_helpers.StencilTest):
             vn_on_half_levels,
             ddqz_z_full_e,
         )
-        
+
         condition = (np.maximum(3, nrdmax - 2) - 1 <= k) & (k < nlev - 4)
         normal_wind_advective_tendency_extra_diffu = (
             add_extra_diffusion_for_normal_wind_tendency_approaching_cfl_numpy(

--- a/model/atmosphere/dycore/tests/dycore_tests/conftest.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/conftest.py
@@ -35,7 +35,6 @@ from icon4py.model.testing.datatest_fixtures import (  # noqa F401
     savepoint_nonhydro_step_final,
     savepoint_velocity_exit,
     savepoint_velocity_init,
-    savepoint_compute_edge_diagnostics_for_velocity_advection_init,
     savepoint_compute_edge_diagnostics_for_velocity_advection_exit,
     savepoint_compute_cell_diagnostics_for_velocity_advection_init,
     savepoint_compute_cell_diagnostics_for_velocity_advection_exit,

--- a/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
@@ -456,7 +456,6 @@ def test_velocity_corrector_step(
 def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
     icon_grid,
     grid_savepoint,
-    savepoint_compute_edge_diagnostics_for_velocity_advection_init,
     savepoint_compute_edge_diagnostics_for_velocity_advection_exit,
     interpolation_savepoint,
     metrics_savepoint,
@@ -471,25 +470,25 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
     edge_domain = h_grid.domain(dims.EdgeDim)
 
     tangential_wind_on_half_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_vt_ie()
+        savepoint_velocity_init.z_vt_ie()
     )
-    tangential_wind = savepoint_compute_edge_diagnostics_for_velocity_advection_init.vt()
-    vn_on_half_levels = savepoint_compute_edge_diagnostics_for_velocity_advection_init.vn_ie()
+    tangential_wind = savepoint_velocity_init.vt()
+    vn_on_half_levels = savepoint_velocity_init.vn_ie()
     horizontal_kinetic_energy_at_edges_on_model_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_kin_hor_e()
+        savepoint_velocity_init.z_kin_hor_e()
     )
     horizontal_advection_of_w_at_edges_on_half_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_v_grad_w()
+        data_alloc.zero_field(icon_grid, dims.EdgeDim, dims.KDim, backend=backend)
     )
-    vn = savepoint_compute_edge_diagnostics_for_velocity_advection_init.vn()
-    w = savepoint_compute_edge_diagnostics_for_velocity_advection_init.w()
+    vn = savepoint_velocity_init.vn()
+    w = savepoint_velocity_init.w()
 
     rbf_vec_coeff_e = interpolation_savepoint.rbf_vec_coeff_e()
     wgtfac_e = metrics_savepoint.wgtfac_e()
     ddxn_z_full = metrics_savepoint.ddxn_z_full()
     ddxt_z_full = metrics_savepoint.ddxt_z_full()
     contravariant_correction_at_edges_on_model_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_w_concorr_me()
+        savepoint_velocity_init.z_w_concorr_me()
     )
     wgtfacq_e = metrics_savepoint.wgtfacq_e_dsl(icon_grid.num_levels)
     nflatlev = grid_savepoint.nflatlev()
@@ -499,7 +498,7 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
     tangent_orientation = grid_savepoint.tangent_orientation()
 
     skip_compute_predictor_vertical_advection = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.lvn_only()
+        savepoint_velocity_init.vn_only()
     )
     # TODO(havogt): we need a test where skip_compute_predictor_vertical_advection is True!
 
@@ -595,7 +594,6 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
 def test_compute_edge_diagnostics_for_velocity_advection_in_corrector_step(
     icon_grid,
     grid_savepoint,
-    savepoint_compute_edge_diagnostics_for_velocity_advection_init,
     savepoint_compute_edge_diagnostics_for_velocity_advection_exit,
     interpolation_savepoint,
     metrics_savepoint,
@@ -610,13 +608,11 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_corrector_step(
     edge_domain = h_grid.domain(dims.EdgeDim)
 
     tangential_wind_on_half_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_vt_ie()
+        savepoint_velocity_init.z_vt_ie()
     )
-    vn_on_half_levels = savepoint_compute_edge_diagnostics_for_velocity_advection_init.vn_ie()
-    horizontal_advection_of_w_at_edges_on_half_levels = (
-        savepoint_compute_edge_diagnostics_for_velocity_advection_init.z_v_grad_w()
-    )
-    w = savepoint_compute_edge_diagnostics_for_velocity_advection_init.w()
+    vn_on_half_levels = savepoint_velocity_init.vn_ie()
+    horizontal_advection_of_w_at_edges_on_half_levels = data_alloc.zero_field(icon_grid, dims.EdgeDim, dims.KDim, backend=backend)
+    w = savepoint_velocity_init.w()
 
     c_intp = interpolation_savepoint.c_intp()
     inv_dual_edge_length = grid_savepoint.inv_dual_edge_length()

--- a/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
@@ -910,7 +910,7 @@ def test_compute_advection_in_vertical_momentum_equation(
     )
     ddt_w_adv_ref = savepoint_compute_advection_in_vertical_momentum_equation_exit.ddt_w_adv()
 
-    nrdmax = grid_savepoint.nrdmax()[0]
+    nrdmax = grid_savepoint.nrdmax()
 
     dtime = 5.0
     cell_domain = h_grid.domain(dims.CellDim)
@@ -1035,7 +1035,7 @@ def test_compute_advection_in_horizontal_momentum_equation(
     end_edge_local = icon_grid.end_index(edge_domain(h_grid.Zone.LOCAL))
 
     d_time = savepoint_velocity_init.get_metadata("dtime").get("dtime")
-    nrdmax = grid_savepoint.nrdmax()[0]
+    nrdmax = grid_savepoint.nrdmax()
 
     ddt_vn_apc_ref = savepoint_compute_advection_in_horizontal_momentum_equation_exit.ddt_vn_apc()
 

--- a/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
+++ b/model/atmosphere/dycore/tests/dycore_tests/test_velocity_advection.py
@@ -469,16 +469,12 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
 ):
     edge_domain = h_grid.domain(dims.EdgeDim)
 
-    tangential_wind_on_half_levels = (
-        savepoint_velocity_init.z_vt_ie()
-    )
+    tangential_wind_on_half_levels = savepoint_velocity_init.z_vt_ie()
     tangential_wind = savepoint_velocity_init.vt()
     vn_on_half_levels = savepoint_velocity_init.vn_ie()
-    horizontal_kinetic_energy_at_edges_on_model_levels = (
-        savepoint_velocity_init.z_kin_hor_e()
-    )
-    horizontal_advection_of_w_at_edges_on_half_levels = (
-        data_alloc.zero_field(icon_grid, dims.EdgeDim, dims.KDim, backend=backend)
+    horizontal_kinetic_energy_at_edges_on_model_levels = savepoint_velocity_init.z_kin_hor_e()
+    horizontal_advection_of_w_at_edges_on_half_levels = data_alloc.zero_field(
+        icon_grid, dims.EdgeDim, dims.KDim, backend=backend
     )
     vn = savepoint_velocity_init.vn()
     w = savepoint_velocity_init.w()
@@ -487,9 +483,7 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
     wgtfac_e = metrics_savepoint.wgtfac_e()
     ddxn_z_full = metrics_savepoint.ddxn_z_full()
     ddxt_z_full = metrics_savepoint.ddxt_z_full()
-    contravariant_correction_at_edges_on_model_levels = (
-        savepoint_velocity_init.z_w_concorr_me()
-    )
+    contravariant_correction_at_edges_on_model_levels = savepoint_velocity_init.z_w_concorr_me()
     wgtfacq_e = metrics_savepoint.wgtfacq_e_dsl(icon_grid.num_levels)
     nflatlev = grid_savepoint.nflatlev()
     c_intp = interpolation_savepoint.c_intp()
@@ -497,9 +491,7 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_predictor_step(
     inv_primal_edge_length = grid_savepoint.inverse_primal_edge_lengths()
     tangent_orientation = grid_savepoint.tangent_orientation()
 
-    skip_compute_predictor_vertical_advection = (
-        savepoint_velocity_init.vn_only()
-    )
+    skip_compute_predictor_vertical_advection = savepoint_velocity_init.vn_only()
     # TODO(havogt): we need a test where skip_compute_predictor_vertical_advection is True!
 
     horizontal_start = icon_grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5))
@@ -607,11 +599,11 @@ def test_compute_edge_diagnostics_for_velocity_advection_in_corrector_step(
 ):
     edge_domain = h_grid.domain(dims.EdgeDim)
 
-    tangential_wind_on_half_levels = (
-        savepoint_velocity_init.z_vt_ie()
-    )
+    tangential_wind_on_half_levels = savepoint_velocity_init.z_vt_ie()
     vn_on_half_levels = savepoint_velocity_init.vn_ie()
-    horizontal_advection_of_w_at_edges_on_half_levels = data_alloc.zero_field(icon_grid, dims.EdgeDim, dims.KDim, backend=backend)
+    horizontal_advection_of_w_at_edges_on_half_levels = data_alloc.zero_field(
+        icon_grid, dims.EdgeDim, dims.KDim, backend=backend
+    )
     w = savepoint_velocity_init.w()
 
     c_intp = interpolation_savepoint.c_intp()

--- a/model/atmosphere/subgrid_scale_physics/microphysics/tests/microphysics_tests/test_saturation_adjustment.py
+++ b/model/atmosphere/subgrid_scale_physics/microphysics/tests/microphysics_tests/test_saturation_adjustment.py
@@ -8,7 +8,9 @@
 
 import pytest
 
-from icon4py.model.atmosphere.subgrid_scale_physics.microphysics import saturation_adjustment
+from icon4py.model.atmosphere.subgrid_scale_physics.microphysics import (
+    saturation_adjustment as satad,
+)
 from icon4py.model.common import dimension as dims
 from icon4py.model.common.grid import vertical as v_grid
 from icon4py.model.common.states import (
@@ -20,17 +22,22 @@ from icon4py.model.common.utils import data_allocation as data_alloc
 from icon4py.model.testing import datatest_utils as dt_utils, helpers
 
 
-@pytest.skip("FIXME: Need to update data for Weisman Klemp", allow_module_level=True)
 @pytest.mark.parametrize(
-    "experiment, model_top_height, damping_height, stretch_factor, date",
+    "experiment, model_top_height, damping_height, stretch_factor",
     [
-        (dt_utils.WEISMAN_KLEMP_EXPERIMENT, 30000.0, 8000.0, 0.85, "48"),
-        (dt_utils.WEISMAN_KLEMP_EXPERIMENT, 30000.0, 8000.0, 0.85, "52"),
-        (dt_utils.WEISMAN_KLEMP_EXPERIMENT, 30000.0, 8000.0, 0.85, "56"),
+        (dt_utils.WEISMAN_KLEMP_EXPERIMENT, 30000.0, 8000.0, 0.85),
     ],
 )
-def test_saturation_adjustment_in_gscp_call(
+@pytest.mark.parametrize(
+    "date", ["2008-09-01T01:59:48.000", "2008-09-01T01:59:52.000", "2008-09-01T01:59:56.000"]
+)
+@pytest.mark.parametrize(
+    "location, diagnose_values", [("nwp-gscp-interface", False), ("interface-nwp", True)]
+)
+def test_saturation_adjustement(
     experiment,
+    location,
+    diagnose_values,
     model_top_height,
     damping_height,
     stretch_factor,
@@ -42,21 +49,15 @@ def test_saturation_adjustment_in_gscp_call(
     lowest_layer_thickness,
     backend,
 ):
-    entry_microphysics_savepoint = data_provider.from_savepoint_weisman_klemp_graupel_entry(
-        date=date
-    )
-    gscp_satad_entry_savepoint = data_provider.from_savepoint_weisman_klemp_gscp_satad_entry(
-        date=date
-    )
-    gscp_satad_exit_savepoint = data_provider.from_savepoint_weisman_klemp_gscp_satad_exit(
-        date=date
-    )
+    satad_init = data_provider.from_savepoint_satad_init(location=location, date=date)
+    satad_exit = data_provider.from_savepoint_satad_exit(location=location, date=date)
 
-    gscp_satad_config = saturation_adjustment.SaturationAdjustmentConfig(
-        tolerance=gscp_satad_entry_savepoint.tolerance(),
-        max_iter=gscp_satad_entry_savepoint.maxiter(),
-        diagnose_variables_from_new_temperature=False,
+    config = satad.SaturationAdjustmentConfig(
+        tolerance=1e-3,
+        max_iter=10,
+        diagnose_variables_from_new_temperature=diagnose_values,
     )
+    dtime = 2.0
 
     vertical_config = v_grid.VerticalGridConfig(icon_grid.num_levels)
     vertical_params = v_grid.VerticalGrid(
@@ -66,233 +67,111 @@ def test_saturation_adjustment_in_gscp_call(
         _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp(),
     )
 
-    metric_state = saturation_adjustment.MetricStateSaturationAdjustment(
+    metric_state = satad.MetricStateSaturationAdjustment(
         ddqz_z_full=metrics_savepoint.ddqz_z_full()
     )
 
-    gscp_saturation_adjustment_granule = saturation_adjustment.SaturationAdjustment(
-        config=gscp_satad_config,
+    saturation_adjustment = satad.SaturationAdjustment(
+        config=config,
         grid=icon_grid,
         metric_state=metric_state,
         vertical_params=vertical_params,
         backend=backend,
     )
-
     tracer_state = tracers.TracerState(
-        qv=gscp_satad_entry_savepoint.qv(),
-        qc=gscp_satad_entry_savepoint.qc(),
-        qr=None,
-        qi=None,
-        qs=None,
-        qg=None,
+        qv=satad_init.qv(),
+        qc=satad_init.qc(),
+        qr=satad_init.qr(),
+        qi=satad_init.qi(),
+        qs=satad_init.qs(),
+        qg=satad_init.qg(),
     )
     prognostic_state = prognostics.PrognosticState(
-        rho=gscp_satad_entry_savepoint.rho(),
-        vn=None,
-        w=None,
-        exner=None,
-        theta_v=None,
+        rho=satad_init.rho(),
+        vn=data_alloc.zero_field(icon_grid, dims.EdgeDim, dims.KDim, dtype=float),
+        w=data_alloc.zero_field(icon_grid, dims.CellDim, dims.KDim, dtype=float),
+        exner=satad_init.exner(),
+        theta_v=data_alloc.zero_field(icon_grid, dims.CellDim, dims.KDim, dtype=float),
     )
     diagnostic_state = diagnostics.DiagnosticState(
-        temperature=gscp_satad_entry_savepoint.temperature(),
-        virtual_temperature=None,
-        pressure=data_alloc.zero_field(icon_grid, dims.CellDim, dims.KDim, dtype=float),
-        pressure_ifc=data_alloc.zero_field(
-            icon_grid, dims.CellDim, dims.KDim, dtype=float, extend={dims.KDim: 1}
-        ),
-        u=None,
-        v=None,
+        temperature=satad_init.temperature(),
+        virtual_temperature=satad_init.virtual_temperature(),
+        pressure=satad_init.pressure(),
+        pressure_ifc=satad_init.pressure_ifc(),
+        u=data_alloc.zero_field(icon_grid, dims.CellDim, dims.KDim, dtype=float),
+        v=data_alloc.zero_field(icon_grid, dims.CellDim, dims.KDim, dtype=float),
     )
 
-    dtime = entry_microphysics_savepoint.dt_microphysics()
-    gscp_saturation_adjustment_granule.run(
+    # WHEN
+    # run saturation adjustment
+    saturation_adjustment.run(
         dtime=dtime,
         prognostic_state=prognostic_state,
         diagnostic_state=diagnostic_state,
         tracer_state=tracer_state,
     )
 
-    updated_qv = (
-        tracer_state.qv.ndarray + gscp_saturation_adjustment_granule.qv_tendency.ndarray * dtime
-    )
-    updated_qc = (
-        tracer_state.qc.ndarray + gscp_saturation_adjustment_granule.qc_tendency.ndarray * dtime
-    )
+    # apply tendencies
+
+    updated_qv = tracer_state.qv.asnumpy() + saturation_adjustment.qv_tendency.asnumpy() * dtime
+    updated_qc = tracer_state.qc.asnumpy() + saturation_adjustment.qc_tendency.asnumpy() * dtime
     updated_temperature = (
-        diagnostic_state.temperature.ndarray
-        + gscp_saturation_adjustment_granule.temperature_tendency.ndarray * dtime
-    )
-
-    assert helpers.dallclose(
-        updated_qv,
-        gscp_satad_exit_savepoint.qv().ndarray,
-        atol=1.0e-13,
-    )
-    assert helpers.dallclose(
-        updated_qc,
-        gscp_satad_exit_savepoint.qc().ndarray,
-        atol=1.0e-13,
-    )
-    assert helpers.dallclose(
-        updated_temperature,
-        gscp_satad_exit_savepoint.temperature().ndarray,
-        atol=1.0e-13,
-    )
-
-
-@pytest.mark.parametrize(
-    "experiment, model_top_height, damping_height, stretch_factor, date",
-    [
-        (dt_utils.WEISMAN_KLEMP_EXPERIMENT, 30000.0, 8000.0, 0.85, "48"),
-        (dt_utils.WEISMAN_KLEMP_EXPERIMENT, 30000.0, 8000.0, 0.85, "52"),
-        (dt_utils.WEISMAN_KLEMP_EXPERIMENT, 30000.0, 8000.0, 0.85, "56"),
-    ],
-)
-def test_saturation_adjustment_in_physics_interface_call(
-    experiment,
-    model_top_height,
-    damping_height,
-    stretch_factor,
-    date,
-    data_provider,
-    grid_savepoint,
-    metrics_savepoint,
-    icon_grid,
-    lowest_layer_thickness,
-    backend,
-):
-    entry_microphysics_savepoint = data_provider.from_savepoint_weisman_klemp_graupel_entry(
-        date=date
-    )
-    nwp_interface_satad_entry_savepoint = (
-        data_provider.from_savepoint_weisman_klemp_interface_satad_entry(date=date)
-    )
-    nwp_interface_satad_exit_savepoint = (
-        data_provider.from_savepoint_weisman_klemp_interface_satad_exit(date=date)
-    )
-    nwp_interface_satad_diag_exit_savepoint = (
-        data_provider.from_savepoint_weisman_klemp_interface_diag_after_satad_exit(date=date)
-    )
-
-    nwp_interface_config = saturation_adjustment.SaturationAdjustmentConfig(
-        tolerance=nwp_interface_satad_entry_savepoint.tolerance(),
-        max_iter=nwp_interface_satad_entry_savepoint.maxiter(),
-        diagnose_variables_from_new_temperature=True,
-    )
-
-    vertical_config = v_grid.VerticalGridConfig(icon_grid.num_levels)
-    vertical_params = v_grid.VerticalGrid(
-        config=vertical_config,
-        vct_a=grid_savepoint.vct_a(),
-        vct_b=grid_savepoint.vct_b(),
-        _min_index_flat_horizontal_grad_pressure=grid_savepoint.nflat_gradp(),
-    )
-
-    metric_state = saturation_adjustment.MetricStateSaturationAdjustment(
-        ddqz_z_full=metrics_savepoint.ddqz_z_full()
-    )
-
-    nwp_interface_saturation_adjustment_granule = saturation_adjustment.SaturationAdjustment(
-        config=nwp_interface_config,
-        grid=icon_grid,
-        metric_state=metric_state,
-        vertical_params=vertical_params,
-        backend=backend,
-    )
-
-    tracer_state = tracers.TracerState(
-        qv=nwp_interface_satad_entry_savepoint.qv(),
-        qc=nwp_interface_satad_entry_savepoint.qc(),
-        qr=nwp_interface_satad_exit_savepoint.qr(),
-        qi=nwp_interface_satad_exit_savepoint.qi(),
-        qs=nwp_interface_satad_exit_savepoint.qs(),
-        qg=nwp_interface_satad_exit_savepoint.qg(),
-    )
-    prognostic_state = prognostics.PrognosticState(
-        rho=nwp_interface_satad_entry_savepoint.rho(),
-        vn=None,
-        w=None,
-        exner=nwp_interface_satad_exit_savepoint.exner(),
-        theta_v=None,
-    )
-    diagnostic_state = diagnostics.DiagnosticState(
-        temperature=nwp_interface_satad_entry_savepoint.temperature(),
-        virtual_temperature=nwp_interface_satad_exit_savepoint.virtual_temperature(),
-        pressure=nwp_interface_satad_exit_savepoint.pressure(),
-        pressure_ifc=nwp_interface_satad_exit_savepoint.pressure_ifc(),
-        u=None,
-        v=None,
-    )
-
-    dtime = entry_microphysics_savepoint.dt_microphysics()
-    nwp_interface_saturation_adjustment_granule.run(
-        dtime=dtime,
-        prognostic_state=prognostic_state,
-        diagnostic_state=diagnostic_state,
-        tracer_state=tracer_state,
-    )
-
-    updated_qv = (
-        tracer_state.qv.ndarray
-        + nwp_interface_saturation_adjustment_granule.qv_tendency.ndarray * dtime
-    )
-    updated_qc = (
-        tracer_state.qc.ndarray
-        + nwp_interface_saturation_adjustment_granule.qc_tendency.ndarray * dtime
-    )
-    updated_temperature = (
-        diagnostic_state.temperature.ndarray
-        + nwp_interface_saturation_adjustment_granule.temperature_tendency.ndarray * dtime
-    )
-    updated_virtual_temperature = (
-        diagnostic_state.virtual_temperature.ndarray
-        + nwp_interface_saturation_adjustment_granule.virtual_temperature_tendency.ndarray * dtime
+        diagnostic_state.temperature.asnumpy()
+        + saturation_adjustment.temperature_tendency.asnumpy() * dtime
     )
     updated_exner = (
-        prognostic_state.exner.ndarray
-        + nwp_interface_saturation_adjustment_granule.exner_tendency.ndarray * dtime
+        prognostic_state.exner.asnumpy() + saturation_adjustment.exner_tendency.asnumpy() * dtime
     )
-    updated_pressure = (
-        diagnostic_state.pressure.ndarray
-        + nwp_interface_saturation_adjustment_granule.pressure_tendency.ndarray * dtime
-    )
-    updated_pressure_ifc = (
-        diagnostic_state.pressure_ifc.ndarray
-        + nwp_interface_saturation_adjustment_granule.pressure_ifc_tendency.ndarray * dtime
-    )
+    if diagnose_values:
+        pressure = (
+            diagnostic_state.pressure.asnumpy()
+            + saturation_adjustment.pressure_tendency.asnumpy() * dtime
+        )
+        pressure_ifc = (
+            diagnostic_state.pressure_ifc.asnumpy()
+            + saturation_adjustment.pressure_ifc_tendency.asnumpy() * dtime
+        )
+        virtual_temperature = (
+            diagnostic_state.virtual_temperature.asnumpy()
+            + saturation_adjustment.virtual_temperature_tendency.asnumpy() * dtime
+        )
+    else:
+        pressure = diagnostic_state.pressure.asnumpy()
+        pressure_ifc = diagnostic_state.pressure_ifc.asnumpy()
+        virtual_temperature = diagnostic_state.virtual_temperature.asnumpy()
 
     assert helpers.dallclose(
         updated_qv,
-        nwp_interface_satad_exit_savepoint.qv().ndarray,
+        satad_exit.qv().asnumpy(),
         atol=1.0e-13,
     )
     assert helpers.dallclose(
         updated_qc,
-        nwp_interface_satad_exit_savepoint.qc().ndarray,
+        satad_exit.qc().asnumpy(),
         atol=1.0e-13,
     )
     assert helpers.dallclose(
         updated_temperature,
-        nwp_interface_satad_exit_savepoint.temperature().ndarray,
+        satad_exit.temperature().asnumpy(),
         atol=1.0e-13,
     )
     assert helpers.dallclose(
-        updated_virtual_temperature,
-        nwp_interface_satad_diag_exit_savepoint.virtual_temperature().ndarray,
+        virtual_temperature,
+        satad_exit.virtual_temperature().asnumpy(),
         atol=1.0e-13,
     )
     assert helpers.dallclose(
         updated_exner,
-        nwp_interface_satad_diag_exit_savepoint.exner().ndarray,
+        satad_exit.exner().asnumpy(),
         atol=1.0e-13,
     )
     assert helpers.dallclose(
-        updated_pressure,
-        nwp_interface_satad_diag_exit_savepoint.pressure().ndarray,
+        pressure,
+        satad_exit.pressure().asnumpy(),
         atol=1.0e-13,
     )
     assert helpers.dallclose(
-        updated_pressure_ifc,
-        nwp_interface_satad_diag_exit_savepoint.pressure_ifc().ndarray,
+        pressure_ifc,
+        satad_exit.pressure_ifc().asnumpy(),
         atol=1.0e-13,
     )

--- a/model/common/src/icon4py/model/common/utils/__init__.py
+++ b/model/common/src/icon4py/model/common/utils/__init__.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-from . import data_allocation
 from ._common import (
     DoubleBuffering,
     Pair,

--- a/model/common/src/icon4py/model/common/utils/__init__.py
+++ b/model/common/src/icon4py/model/common/utils/__init__.py
@@ -28,6 +28,5 @@ __all__ = [
     # Functions
     "chainable",
     # Modules
-    "data_allocation",
     "serialbox",
 ]

--- a/model/common/tests/diagnostic_calculations_tests/test_diagnostic_calculations.py
+++ b/model/common/tests/diagnostic_calculations_tests/test_diagnostic_calculations.py
@@ -38,9 +38,9 @@ def test_diagnose_temperature(
     diagnostic_reference_savepoint = data_provider.from_savepoint_diagnostics_initial()
     temperature_ref = diagnostic_reference_savepoint.temperature().asnumpy()
     virtual_temperature_ref = diagnostic_reference_savepoint.virtual_temperature().asnumpy()
-    initial_prognostic_savepoint = data_provider.from_savepoint_jabw_exit()
-    exner = initial_prognostic_savepoint.exner()
-    theta_v = initial_prognostic_savepoint.theta_v()
+    initial_prognostic_savepoint = data_provider.from_savepoint_prognostics_initial()
+    exner = initial_prognostic_savepoint.exner_now()
+    theta_v = initial_prognostic_savepoint.theta_v_now()
 
     temperature = data_alloc.zero_field(
         icon_grid, dims.CellDim, dims.KDim, dtype=float, backend=backend
@@ -100,7 +100,7 @@ def test_diagnose_meridional_and_zonal_winds(
     icon_grid,
     backend,
 ):
-    prognostics_init_savepoint = data_provider.from_savepoint_jabw_exit()
+    prognostics_init_savepoint = data_provider.from_savepoint_prognostics_initial()
     vn = prognostics_init_savepoint.vn()
     rbv_vec_coeff_c1 = interpolation_savepoint.rbf_vec_coeff_c1()
     rbv_vec_coeff_c2 = interpolation_savepoint.rbf_vec_coeff_c2()
@@ -157,8 +157,8 @@ def test_diagnose_surface_pressure(
 ):
     initial_diagnostic_savepoint = data_provider.from_savepoint_diagnostics_initial()
     surface_pressure_ref = initial_diagnostic_savepoint.pressure_sfc().asnumpy()
-    initial_prognostic_savepoint = data_provider.from_savepoint_jabw_exit()
-    exner = initial_prognostic_savepoint.exner()
+    initial_prognostic_savepoint = data_provider.from_savepoint_prognostics_initial()
+    exner = initial_prognostic_savepoint.exner_now()
     virtual_temperature = initial_diagnostic_savepoint.virtual_temperature()
     ddqz_z_full = metrics_savepoint.ddqz_z_full()
 

--- a/model/common/tests/diagnostic_calculations_tests/test_diagnostic_calculations.py
+++ b/model/common/tests/diagnostic_calculations_tests/test_diagnostic_calculations.py
@@ -101,7 +101,7 @@ def test_diagnose_meridional_and_zonal_winds(
     backend,
 ):
     prognostics_init_savepoint = data_provider.from_savepoint_prognostics_initial()
-    vn = prognostics_init_savepoint.vn()
+    vn = prognostics_init_savepoint.vn_now()
     rbv_vec_coeff_c1 = interpolation_savepoint.rbf_vec_coeff_c1()
     rbv_vec_coeff_c2 = interpolation_savepoint.rbf_vec_coeff_c2()
 

--- a/model/common/tests/metric_tests/test_metric_fields.py
+++ b/model/common/tests/metric_tests/test_metric_fields.py
@@ -184,7 +184,7 @@ def test_compute_rayleigh_w(icon_grid, experiment, metrics_savepoint, grid_savep
         vct_a_1=vct_a_1,
         pi_const=math.pi,
         vertical_start=0,
-        vertical_end=grid_savepoint.nrdmax().item() + 1,
+        vertical_end=gtx.int32(grid_savepoint.nrdmax() + 1),
         offset_provider={},
     )
 

--- a/model/driver/tests/initial_condition_tests/test_jablonowski_williamson.py
+++ b/model/driver/tests/initial_condition_tests/test_jablonowski_williamson.py
@@ -52,35 +52,35 @@ def test_jabw_initial_condition(
     )
 
     # note that w is not verified because we decided to force w to zero in python framework after discussion
-    prognostics_reference_savepoint = data_provider.from_savepoint_jabw_exit()
+    jabw_exit_savepoint = data_provider.from_savepoint_jabw_exit()
     assert helpers.dallclose(
         prognostic_state_now.rho.asnumpy(),
-        prognostics_reference_savepoint.rho().asnumpy(),
+        jabw_exit_savepoint.rho().asnumpy(),
     )
 
     assert helpers.dallclose(
         prognostic_state_now.exner.asnumpy(),
-        prognostics_reference_savepoint.exner().asnumpy(),
+        jabw_exit_savepoint.exner().asnumpy(),
     )
 
     assert helpers.dallclose(
         prognostic_state_now.theta_v.asnumpy(),
-        prognostics_reference_savepoint.theta_v().asnumpy(),
+        jabw_exit_savepoint.theta_v().asnumpy(),
     )
 
     assert helpers.dallclose(
         prognostic_state_now.vn.asnumpy(),
-        prognostics_reference_savepoint.vn().asnumpy(),
+        jabw_exit_savepoint.vn().asnumpy(),
     )
 
     assert helpers.dallclose(
         diagnostic_state.pressure.asnumpy(),
-        prognostics_reference_savepoint.pressure().asnumpy(),
+        jabw_exit_savepoint.pressure().asnumpy(),
     )
 
     assert helpers.dallclose(
         diagnostic_state.temperature.asnumpy(),
-        prognostics_reference_savepoint.temperature().asnumpy(),
+        jabw_exit_savepoint.temperature().asnumpy(),
     )
 
     assert helpers.dallclose(

--- a/model/testing/src/icon4py/model/testing/datatest_fixtures.py
+++ b/model/testing/src/icon4py/model/testing/datatest_fixtures.py
@@ -188,7 +188,7 @@ def savepoint_velocity_init(data_provider, step_date_init, istep_init, substep_i
         istep=istep_init, date=step_date_init, substep=substep_init
     )
 
-
+# TODO (halungge) remove fixture (and class) in a followup PR, once data is updated
 @pytest.fixture
 def savepoint_compute_edge_diagnostics_for_velocity_advection_init(
     data_provider, step_date_init, istep_init, substep_init
@@ -319,7 +319,6 @@ def savepoint_compute_cell_diagnostics_for_velocity_advection_exit(
     return data_provider.from_savepoint_compute_cell_diagnostics_for_velocity_advection_exit(
         istep=istep_init, date=step_date_exit, substep_init=substep_init
     )
-
 
 @pytest.fixture
 def savepoint_compute_advection_in_vertical_momentum_equation_exit(

--- a/model/testing/src/icon4py/model/testing/datatest_fixtures.py
+++ b/model/testing/src/icon4py/model/testing/datatest_fixtures.py
@@ -188,6 +188,7 @@ def savepoint_velocity_init(data_provider, step_date_init, istep_init, substep_i
         istep=istep_init, date=step_date_init, substep=substep_init
     )
 
+
 # TODO (halungge) remove fixture (and class) in a followup PR, once data is updated
 @pytest.fixture
 def savepoint_compute_edge_diagnostics_for_velocity_advection_init(
@@ -319,6 +320,7 @@ def savepoint_compute_cell_diagnostics_for_velocity_advection_exit(
     return data_provider.from_savepoint_compute_cell_diagnostics_for_velocity_advection_exit(
         istep=istep_init, date=step_date_exit, substep_init=substep_init
     )
+
 
 @pytest.fixture
 def savepoint_compute_advection_in_vertical_momentum_equation_exit(

--- a/model/testing/src/icon4py/model/testing/datatest_fixtures.py
+++ b/model/testing/src/icon4py/model/testing/datatest_fixtures.py
@@ -189,24 +189,6 @@ def savepoint_velocity_init(data_provider, step_date_init, istep_init, substep_i
     )
 
 
-# TODO (halungge) remove fixture (and class) in a followup PR, once data is updated
-@pytest.fixture
-def savepoint_compute_edge_diagnostics_for_velocity_advection_init(
-    data_provider, step_date_init, istep_init, substep_init
-):  # F811
-    """
-    Load data from ICON savepoint at start of velocity_advection module for edge diagnostics.
-
-     metadata to select a unique savepoint:
-    - date: <iso_string> of the simulation timestep
-    - istep: one of 1 ~ predictor, 2 ~ corrector of dycore integration scheme
-    - substep: dynamical substep
-    """
-    return data_provider.from_savepoint_compute_edge_diagnostics_for_velocity_advection_init(
-        istep=istep_init, date=step_date_init, substep_init=substep_init
-    )
-
-
 @pytest.fixture
 def savepoint_compute_cell_diagnostics_for_velocity_advection_init(
     data_provider, step_date_init, istep_init, substep_init

--- a/model/testing/src/icon4py/model/testing/datatest_utils.py
+++ b/model/testing/src/icon4py/model/testing/datatest_utils.py
@@ -28,11 +28,11 @@ WEISMAN_KLEMP_EXPERIMENT = "weisman_klemp_torus"
 MC_CH_R04B09_DSL_GRID_URI = "https://polybox.ethz.ch/index.php/s/hD232znfEPBh4Oh/download"
 R02B04_GLOBAL_GRID_URI = "https://polybox.ethz.ch/index.php/s/AKAO6ImQdIatnkB/download"
 TORUS_100X116_1000M_GRID_URI = "https://polybox.ethz.ch/index.php/s/yqvotFss9i1OKzs/download"
+TORUS_50000x5000_RES500 = "https://polybox.ethz.ch/index.php/s/eclzK00TM9nnLtE/download"
 GRID_URIS = {
     REGIONAL_EXPERIMENT: MC_CH_R04B09_DSL_GRID_URI,
     R02B04_GLOBAL: R02B04_GLOBAL_GRID_URI,
-    # TODO (Chia Rui): check if we can use the grid for gauss3d and get a good quality data for testing microphysics
-    WEISMAN_KLEMP_EXPERIMENT: TORUS_100X116_1000M_GRID_URI,
+    WEISMAN_KLEMP_EXPERIMENT: TORUS_50000x5000_RES500,
 }
 
 GRID_IDS = {
@@ -40,7 +40,7 @@ GRID_IDS = {
     REGIONAL_EXPERIMENT: uuid.UUID("f2e06839-694a-cca1-a3d5-028e0ff326e0"),
     JABW_EXPERIMENT: uuid.UUID("af122aca-1dd2-11b2-a7f8-c7bf6bc21eba"),
     GAUSS3D_EXPERIMENT: uuid.UUID("80ae276e-ec54-11ee-bf58-e36354187f08"),
-    WEISMAN_KLEMP_EXPERIMENT: uuid.UUID("24fe2406-8066-11e8-bc5b-f3dc5af69303"),
+    WEISMAN_KLEMP_EXPERIMENT: uuid.UUID("80ae276e-ec54-11ee-bf58-e36354187f08"),
 }
 
 
@@ -68,7 +68,7 @@ DATA_URIS = {
 DATA_URIS_APE = {1: "https://polybox.ethz.ch/index.php/s/2n2WpTgZFlTCTHu/download"}
 DATA_URIS_JABW = {1: "https://polybox.ethz.ch/index.php/s/5W3Z2K6pyo0egzo/download"}
 DATA_URIS_GAUSS3D = {1: "https://polybox.ethz.ch/index.php/s/ZuqDIREPVits9r0/download"}
-DATA_URIS_WK = {1: "https://polybox.ethz.ch/index.php/s/91DEUGmAkBgrXO6/download"}
+DATA_URIS_WK = {1: "https://polybox.ethz.ch/index.php/s/ByLnyii7MMRHJbK/download"}
 
 
 def get_global_grid_params(experiment: str) -> tuple[int, int]:

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1579,7 +1579,6 @@ class IconPrognosticsInitSavepoint(IconSavepoint):
         return self._get_field("theta_v_now", dims.CellDim, dims.KDim)
 
 
-
 class IconGraupelEntrySavepoint(IconSavepoint):
     def temperature(self):
         return self._get_field("ser_in_graupel_temperature", dims.CellDim, dims.KDim)

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1527,7 +1527,6 @@ class IconDiagnosticsInitSavepoint(IconSavepoint):
         return self._get_field("v", dims.CellDim, dims.KDim)
 
 
-
 class IconPrognosticsInitSavepoint(IconSavepoint):
     def exner_now(self):
         return self._get_field("exner_now", dims.CellDim, dims.KDim)

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -398,7 +398,7 @@ class IconGridSavepoint(IconSavepoint):
         return self._get_connectivity_array("c2v", dims.CellDim)
 
     def nrdmax(self):
-        return self._read_int32_shift1("nrdmax")
+        return gtx.int32(self._read_int32_shift1("nrdmax").item())
 
     def refin_ctrl(self, dim: gtx.Dimension):
         field_name = "refin_ctl"

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -321,10 +321,10 @@ class IconGridSavepoint(IconSavepoint):
         return self._read_int32_shift1("e_start_index")
 
     def nflatlev(self):
-        return self._read_int32_shift1("nflatlev")
+        return self._read_int32_shift1("nflatlev").item()
 
     def nflat_gradp(self):
-        return self._read_int32_shift1("nflat_gradp")
+        return self._read_int32_shift1("nflat_gradp").item()
 
     def edge_end_index(self):
         # don't need to subtract 1, because FORTRAN slices  are inclusive [from:to] so the being
@@ -355,7 +355,7 @@ class IconGridSavepoint(IconSavepoint):
                 : self.sizes[target_dim], :
             ]
         else:
-            connectivity = np.squeeze(self._read_int32(name, offset=1)[: self.sizes[target_dim], :])
+            connectivity = self._read_int32(name, offset=1)[: self.sizes[target_dim], :]
         self.log.debug(f" connectivity {name} : {connectivity.shape}")
         return connectivity
 
@@ -404,9 +404,7 @@ class IconGridSavepoint(IconSavepoint):
         field_name = "refin_ctl"
         return gtx.as_field(
             (dim,),
-            np.squeeze(
-                self._read_field_for_dim(field_name, self._read_int32, dim)[: self.num(dim)], 1
-            ),
+            self._read_field_for_dim(field_name, self._read_int32, dim)[: self.num(dim)],
             allocator=self.backend,
         )
 
@@ -430,7 +428,7 @@ class IconGridSavepoint(IconSavepoint):
     def owner_mask(self, dim: gtx.Dimension):
         field_name = "owner_mask"
         mask = self._read_field_for_dim(field_name, self._read_bool, dim)
-        return np.squeeze(mask)
+        return mask
 
     def global_index(self, dim: gtx.Dimension):
         field_name = "glb_index"

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1297,35 +1297,6 @@ class IconVelocityInitSavepoint(IconSavepoint):
         return self._get_field("w_concorr_c", dims.CellDim, dims.KDim)
 
 
-class VelocityInitEdgeDiagnosticsSavepoint(IconSavepoint):
-    def lvn_only(self) -> bool:
-        return bool(self.serializer.read("vn_only", self.savepoint)[0])
-
-    def vn(self):
-        return self._get_field("vn", dims.EdgeDim, dims.KDim)
-
-    def vn_ie(self):
-        return self._get_field("vn_ie", dims.EdgeDim, dims.KDim)
-
-    def vt(self):
-        return self._get_field("vt", dims.EdgeDim, dims.KDim)
-
-    def w(self):
-        return self._get_field("w", dims.CellDim, dims.KDim)
-
-    def z_kin_hor_e(self):
-        return self._get_field("z_kin_hor_e", dims.EdgeDim, dims.KDim)
-
-    def z_v_grad_w(self):
-        return self._get_field("z_v_grad_w", dims.EdgeDim, dims.KDim)
-
-    def z_vt_ie(self):
-        return self._get_field("z_vt_ie", dims.EdgeDim, dims.KDim)
-
-    def z_w_concorr_me(self):
-        return self._get_field("z_w_concorr_me", dims.EdgeDim, dims.KDim)
-
-
 class VelocityAdvectionCellDiagnosticsInitSavepoint(IconSavepoint):
     def z_kin_hor_e(self):
         return self._get_field("z_kin_hor_e", dims.EdgeDim, dims.KDim)
@@ -1999,21 +1970,6 @@ class IconSerialDataProvider:
             .as_savepoint()
         )
         return IconVelocityInitSavepoint(
-            savepoint, self.serializer, size=self.grid_size, backend=self.backend
-        )
-
-    # TODO (halungge) remove function and class in a followup PR, once data is updated
-    def from_savepoint_compute_edge_diagnostics_for_velocity_advection_init(
-        self, istep: int, date: str, substep_init: int
-    ) -> VelocityInitEdgeDiagnosticsSavepoint:
-        savepoint = (
-            self.serializer.savepoint["velocity-tendencies-init"]
-            .istep[istep]
-            .date[date]
-            .dyn_timestep[substep_init]
-            .as_savepoint()
-        )
-        return VelocityInitEdgeDiagnosticsSavepoint(
             savepoint, self.serializer, size=self.grid_size, backend=self.backend
         )
 

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1963,7 +1963,7 @@ class IconSerialDataProvider:
             savepoint, self.serializer, size=self.grid_size, backend=self.backend
         )
 
-    def from_savepoint_satad_exit(self, location, date: str) -> IconSatadExitSavepoint:
+    def from_savepoint_satad_exit(self, location:str, date: str) -> IconSatadExitSavepoint:
         savepoint = (
             self.serializer.savepoint["satad-exit"].date[date].location[location].as_savepoint()
         )

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1552,13 +1552,13 @@ class IconPrognosticsInitSavepoint(IconSavepoint):
 
 class IconGraupelEntrySavepoint(IconSavepoint):
     def temperature(self):
-        return self._get_field("ser_in_graupel_temperature", dims.CellDim, dims.KDim)
+        return self._get_field("temperature", dims.CellDim, dims.KDim)
 
     def pres(self):
-        return self._get_field("ser_in_graupel_pres", dims.CellDim, dims.KDim)
+        return self._get_field("pressure", dims.CellDim, dims.KDim)
 
     def rho(self):
-        return self._get_field("ser_in_graupel_rho", dims.CellDim, dims.KDim)
+        return self._get_field("rho", dims.CellDim, dims.KDim)
 
     def qv(self):
         return self._get_field("ser_in_graupel_qv", dims.CellDim, dims.KDim)
@@ -1584,33 +1584,14 @@ class IconGraupelEntrySavepoint(IconSavepoint):
     def dt_microphysics(self):
         return self.serializer.read("ser_in_graupel_dt", self.savepoint)[0]
 
-    def qc0(self):
-        return self.serializer.read("ser_in_graupel_qc0", self.savepoint)[0]
-
-    def qi0(self):
-        return self.serializer.read("ser_in_graupel_qi0", self.savepoint)[0]
-
+   
+    
     def kstart_moist(self):
         return self.serializer.read("ser_in_graupel_kstart_moist", self.savepoint)[0]
 
-    def l_cv(self):
-        return self.serializer.read("ser_in_graupel_l_cv", self.savepoint)[0]
-
-    def ithermo_water(self):
-        return self.serializer.read("ser_in_graupel_ithermo_water", self.savepoint)[0]
-
-    def ldiag_ttend(self):
-        return self.serializer.read("ser_in_graupel_ldiag_ttend", self.savepoint)[0]
-
-    def ldiag_qtend(self):
-        return self.serializer.read("ser_in_graupel_ldiag_qtend", self.savepoint)[0]
-
-    def istart_idx(self):
-        return self.serializer.read("ser_in_graupel_istart", self.savepoint)[0]
-
-    def iend_idx(self):
-        return self.serializer.read("ser_in_graupel_iend", self.savepoint)[0]
-
+    
+    
+    
 
 class IconGraupelExitSavepoint(IconSavepoint):
     def temperature(self):

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -351,7 +351,7 @@ class IconGridSavepoint(IconSavepoint):
 
     def _get_connectivity_array(self, name: str, target_dim: gtx.Dimension, reverse: bool = False):
         if reverse:
-            connectivity = np.transpose(np.squeeze(self._read_int32(name, offset=1)))[
+            connectivity = np.transpose(self._read_int32(name, offset=1))[
                 : self.sizes[target_dim], :
             ]
         else:

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -344,7 +344,7 @@ class IconGridSavepoint(IconSavepoint):
                 : self.sizes[target_dim], :
             ]
         else:
-            connectivity = self._read_int32(name, offset=1)[: self.sizes[target_dim], :]
+            connectivity = np.squeeze(self._read_int32(name, offset=1)[: self.sizes[target_dim], :])
         self.log.debug(f" connectivity {name} : {connectivity.shape}")
         return connectivity
 
@@ -1578,20 +1578,6 @@ class IconPrognosticsInitSavepoint(IconSavepoint):
     def theta_v_now(self):
         return self._get_field("theta_v_now", dims.CellDim, dims.KDim)
 
-    def pressure_ifc(self):
-        return self._get_field("pressure_ifc", dims.CellDim, dims.KDim)
-
-    def pressure_sfc(self):
-        return self._get_field("pressure_sfc", dims.CellDim)
-
-    def virtual_temperature(self):
-        return self._get_field("virtual_temperature", dims.CellDim, dims.KDim)
-
-    def zonal_wind(self):
-        return self._get_field("u", dims.CellDim, dims.KDim)
-
-    def meridional_wind(self):
-        return self._get_field("v", dims.CellDim, dims.KDim)
 
 
 class IconGraupelEntrySavepoint(IconSavepoint):
@@ -2021,7 +2007,7 @@ class IconSerialDataProvider:
         self, istep: int, date: str, substep_init: int
     ) -> VelocityInitEdgeDiagnosticsSavepoint:
         savepoint = (
-            self.serializer.savepoint["velocity-tendencies-1to7-init"]
+            self.serializer.savepoint["velocity-tendencies-init"]
             .istep[istep]
             .date[date]
             .dyn_timestep[substep_init]

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1535,6 +1535,9 @@ class IconPrognosticsInitSavepoint(IconSavepoint):
     def rho_now(self):
         return self._get_field("rho_now", dims.CellDim, dims.KDim)
 
+    def vn_now(self):
+        return self._get_field("vn_now", dims.EdgeDim, dims.KDim)
+
     def theta_v_now(self):
         return self._get_field("theta_v_now", dims.CellDim, dims.KDim)
 

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -133,7 +133,7 @@ class IconSavepoint:
         return self._read(name, offset=0, dtype=bool)
 
     def _read(self, name: str, offset=0, dtype=int):
-        return (self.serializer.read(name, self.savepoint) - offset).astype(dtype)
+        return np.squeeze(self.serializer.read(name, self.savepoint) - offset).astype(dtype)
 
 
 class IconGridSavepoint(IconSavepoint):
@@ -321,10 +321,10 @@ class IconGridSavepoint(IconSavepoint):
         return self._read_int32_shift1("e_start_index")
 
     def nflatlev(self):
-        return self._read_int32_shift1("nflatlev")[0]
+        return self._read_int32_shift1("nflatlev")
 
     def nflat_gradp(self):
-        return self._read_int32_shift1("nflat_gradp")[0]
+        return self._read_int32_shift1("nflat_gradp")
 
     def edge_end_index(self):
         # don't need to subtract 1, because FORTRAN slices  are inclusive [from:to] so the being

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -2002,6 +2002,7 @@ class IconSerialDataProvider:
             savepoint, self.serializer, size=self.grid_size, backend=self.backend
         )
 
+    # TODO (halungge) remove function and class in a followup PR, once data is updated
     def from_savepoint_compute_edge_diagnostics_for_velocity_advection_init(
         self, istep: int, date: str, substep_init: int
     ) -> VelocityInitEdgeDiagnosticsSavepoint:

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1527,7 +1527,7 @@ class IconDiagnosticsInitSavepoint(IconSavepoint):
         return self._get_field("v", dims.CellDim, dims.KDim)
 
 
-# TODO remove now and new
+
 class IconPrognosticsInitSavepoint(IconSavepoint):
     def exner_now(self):
         return self._get_field("exner_now", dims.CellDim, dims.KDim)

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1963,7 +1963,7 @@ class IconSerialDataProvider:
             savepoint, self.serializer, size=self.grid_size, backend=self.backend
         )
 
-    def from_savepoint_satad_exit(self, location:str, date: str) -> IconSatadExitSavepoint:
+    def from_savepoint_satad_exit(self, location: str, date: str) -> IconSatadExitSavepoint:
         savepoint = (
             self.serializer.savepoint["satad-exit"].date[date].location[location].as_savepoint()
         )


### PR DESCRIPTION
Re enables the tests for saturation adjustment which were skipped during the refactoring to the data serialization in icon-exclaim.

Includes changes from this [PR 711](https://github.com/C2SM/icon4py/pull/711) and uses serialized data generated by ICON exclaim [PR 310](https://github.com/C2SM/icon-exclaim/pull/310)