### PR TITLE
Change atol in stencil tests from 0.0 to 1e-14

### DIFF
--- a/model/testing/src/icon4py/model/testing/helpers.py
+++ b/model/testing/src/icon4py/model/testing/helpers.py
@@ -138,6 +138,8 @@ def _test_validation(
         np.testing.assert_allclose(
             input_data[name].asnumpy()[gtslice],
             reference_outputs[name][refslice],
+            rtol=1e-7,
+            atol=1e-14,
             equal_nan=True,
             err_msg=f"Validation failed for '{name}'",
         )


### PR DESCRIPTION
In dace pipeline the stencil tests fail sometimes on the absolute tolerance check, see the latest two daily runs:

https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/5125340235196978/2255149825504671/-/jobs/9746137104
```
FAILED tests/dycore_stencil_tests/test_compute_contravariant_correction_of_w.py::TestComputeContravariantCorrectionOfW::test_TestComputeContravariantCorrectionOfW - AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0
Validation failed for 'w_concorr_c'
Mismatched elements: 1 / 1358240 (7.36e-05%)
Max absolute difference: 1.77635684e-15
Max relative difference: 2.34534177e-07
```

https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/5125340235196978/2255149825504671/-/jobs/9759297570
```
FAILED tests/advection_stencil_tests/test_prepare_numerical_quadrature_list_for_cubic_reconstruction.py::TestPrepareNumericalQuadratureListForCubicReconstruction::test_TestPrepareNumericalQuadratureListForCubicReconstruction - AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0
Validation failed for 'p_quad_vector_sum_5'
Mismatched elements: 1 / 2051270 (4.88e-05%)
Max absolute difference: 3.38813179e-21
Max relative difference: 1.248705e-07
```

This PR introduces an `atol=1e-14` in stencil tests.