### PR TITLE
CI: remove boost dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ ICON4Py uses the [`uv`](https://docs.astral.sh/uv/) project manager for developm
 $ curl -LsSf https://astral.sh/uv/install.sh | sh 
 ```
 
-Finally, make sure **_boost >= 1.85.0_** is installed in your system, which is required by `gt4py` to compile generated C++ code. 
-
 ### ICON4Py Development Environment
 
 Once `uv` is installed in your system, it is enough to clone this repository and let `uv` handling the installation of the development environment. 

--- a/ci/docker/base.Dockerfile
+++ b/ci/docker/base.Dockerfile
@@ -65,16 +65,6 @@ ENV PATH=${HPC_SDK_PATH}/compilers/bin:${HPC_SDK_PATH}/comm_libs/mpi/bin:${PATH}
     MANPATH=${HPC_SDK_PATH}/compilers/man:${MANPATH} \
     LD_LIBRARY_PATH=${CUDA_PATH}/lib64:${HPC_SDK_PATH}/math_libs/lib64:${LD_LIBRARY_PATH}
 
-# Install Boost
-RUN wget --quiet https://archives.boost.io/release/1.85.0/source/boost_1_85_0.tar.gz && \
-    echo be0d91732d5b0cc6fbb275c7939974457e79b54d6f07ce2e3dfdd68bef883b0b boost_1_85_0.tar.gz > boost_hash.txt && \
-    sha256sum -c boost_hash.txt && \
-    tar xzf boost_1_85_0.tar.gz && \
-    mv boost_1_85_0/boost /usr/local/include/ && \
-    rm boost_1_85_0.tar.gz boost_hash.txt
-
-ENV BOOST_ROOT /usr/local/
-
 # Install pyenv and Python version specified by PYVERSION
 ARG PYVERSION
 RUN curl https://pyenv.run | bash


### PR DESCRIPTION
With gridtools-cpp 2.3.9 the relevant boost dependencies are bundled, therefore GT4Py does not depend on user-installed boost anymore.

Removes the boost installation from CI.

See the GT4Py PR https://github.com/GridTools/gt4py/pull/1971