### PR TITLE
Fix concat_where range syntax

### DIFF
--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_cell_diagnostics_for_dycore.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/stencils/compute_cell_diagnostics_for_dycore.py
@@ -111,7 +111,8 @@ def _compute_perturbed_quantities_and_interpolation(
     exner_at_cells_on_half_levels = (
         concat_where(
             (
-                (start_cell_lateral_boundary_level_3 <= dims.CellDim) & (dims.CellDim < end_cell_halo)
+                (start_cell_lateral_boundary_level_3 <= dims.CellDim)
+                & (dims.CellDim < end_cell_halo)
                 & (maximum(1, nflatlev) <= dims.KDim)
             ),
             _interpolate_cell_field_to_half_levels_vp(


### PR DESCRIPTION
The latest gt4py will not allow the range syntax `start <= dim < end`, instead we should use `(start <= dim) & (dim  < end)`.