### PR TITLE
ci: use all available CUDA devices for parallel tests

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -87,6 +87,8 @@ build_image_aarch64:
     # Grace-Hopper gpu architecture is not enabled by default in CUDA build
     CUDAARCHS: "90"
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
-    PYTEST_XDIST_AUTO_NUM_WORKERS: 16
+    PYTEST_XDIST_AUTO_NUM_WORKERS: 16    
     GT4PY_BUILD_JOBS: 8
+    # Split CUDA_VISIBLE_DEVICES across pytest-xdist workers for parallel test runs
+    PYTEST_XDIST_SPLIT_CUDA_VISIBLE_DEVICES: "${CUDA_VISIBLE_DEVICES}"
     ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS: "cuda12"

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -87,8 +87,8 @@ build_image_aarch64:
     # Grace-Hopper gpu architecture is not enabled by default in CUDA build
     CUDAARCHS: "90"
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
-    PYTEST_XDIST_AUTO_NUM_WORKERS: 16    
+    PYTEST_XDIST_AUTO_NUM_WORKERS: 16
     GT4PY_BUILD_JOBS: 8
     # Split CUDA_VISIBLE_DEVICES across pytest-xdist workers for parallel test runs
-    PYTEST_XDIST_SPLIT_CUDA_VISIBLE_DEVICES: "${CUDA_VISIBLE_DEVICES}"
+    PYTEST_XDIST_SPLIT_CUDA_VISIBLE_DEVICES: "0,1,2,3"
     ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS: "cuda12"

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -63,7 +63,6 @@ build_image_aarch64:
     SLURM_NTASKS: 1
     SLURM_TIMELIMIT: '03:00:00'
     CRAY_CUDA_MPS: 1
-    NUM_PROCESSES: auto
     VIRTUALENV_SYSTEM_SITE_PACKAGES: 1
     TEST_DATA_PATH: "/icon4py/ci/testdata"
     ICON_GRID_LOC: "${TEST_DATA_PATH}/grids/mch_ch_r04b09_dsl"
@@ -88,6 +87,6 @@ build_image_aarch64:
     # Grace-Hopper gpu architecture is not enabled by default in CUDA build
     CUDAARCHS: "90"
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
-    NUM_PROCESSES: 16
+    PYTEST_XDIST_AUTO_NUM_WORKERS: 16
     GT4PY_BUILD_JOBS: 8
     ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS: "cuda12"

--- a/ci/default.yml
+++ b/ci/default.yml
@@ -4,6 +4,9 @@ include:
 .test_model_stencils:
   stage: test
   script:
+    - echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
+    - echo "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES"
+    - echo "PYTEST_XDIST_SPLIT_CUDA_VISIBLE_DEVICES=$PYTEST_XDIST_SPLIT_CUDA_VISIBLE_DEVICES"
     - nox -s "test_model-3.10(stencils, $COMPONENT)" -- --backend=$BACKEND --grid=$GRID
   parallel:
     matrix:

--- a/ci/default.yml
+++ b/ci/default.yml
@@ -4,9 +4,6 @@ include:
 .test_model_stencils:
   stage: test
   script:
-    - echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
-    - echo "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES"
-    - echo "PYTEST_XDIST_SPLIT_CUDA_VISIBLE_DEVICES=$PYTEST_XDIST_SPLIT_CUDA_VISIBLE_DEVICES"
     - nox -s "test_model-3.10(stencils, $COMPONENT)" -- --backend=$BACKEND --grid=$GRID
   parallel:
     matrix:

--- a/model/testing/src/icon4py/model/testing/pytest_config.py
+++ b/model/testing/src/icon4py/model/testing/pytest_config.py
@@ -103,6 +103,9 @@ def pytest_configure(config):
             assert worker_name.startswith("gw")
             worker_id = int(worker_name[2:])
             os.environ["CUDA_VISIBLE_DEVICES"] = cuda_devices[worker_id % len(cuda_devices)]
+            print(f"====== PYTEST_XDIST_SPLIT_CUDA_VISIBLE_DEVICES={cuda_devices_env} ======")
+            print(f'{worker_id=}{os.environ["CUDA_VISIBLE_DEVICES"]}')
+            print("======")
         except Exception:
             pass
 

--- a/model/testing/src/icon4py/model/testing/pytest_config.py
+++ b/model/testing/src/icon4py/model/testing/pytest_config.py
@@ -95,17 +95,16 @@ def pytest_configure(config):
 
     # Split CUDA_VISIBLE_DEVICES across pytest-xdist workers
     # Each worker will get a different CUDA device
-    worker_name = os.environ.get("PYTEST_XDIST_WORKER", "master")
-    if worker_name.startswith("gw"):
+    if cuda_devices_env := os.environ.get("PYTEST_XDIST_SPLIT_CUDA_VISIBLE_DEVICES", None):
         try:
-            worker_id = int(worker_name[2:])
-        except ValueError:
-            worker_id = None
-        if worker_id is not None and (
-            cuda_devices_env := os.environ.get("PYTEST_XDIST_SPLIT_CUDA_VISIBLE_DEVICES", None)
-        ):
             cuda_devices = [d.strip() for d in cuda_devices_env.strip().split(",")]
+            assert cuda_devices
+            worker_name = os.environ.get("PYTEST_XDIST_WORKER", "master")
+            assert worker_name.startswith("gw")
+            worker_id = int(worker_name[2:])
             os.environ["CUDA_VISIBLE_DEVICES"] = cuda_devices[worker_id % len(cuda_devices)]
+        except Exception:
+            pass
 
 
 def pytest_addoption(parser):

--- a/noxfile.py
+++ b/noxfile.py
@@ -167,7 +167,8 @@ def test_tools(session: nox.Session, datatest: bool) -> None:
     with session.chdir("tools"):
         session.run(
             *f"pytest -sv --benchmark-disable -n auto {'--datatest-only' if datatest else '--datatest-skip'}".split(),
-            *session.posargs
+            *session.posargs,
+            env={**os.environ}
         )
 
 # -- utils --
@@ -181,7 +182,7 @@ def _install_session_venv(
     #TODO(egparedes): remove this workaround once `backend` parameter is added to sessions
     if (env_extras := os.environ.get("ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS", "")):
         extras = [*extras, *re.split(r'\W+', env_extras)]
-    env = dict(os.environ.items()) | {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
+    env = os.environ | {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
     session.run_install(
         "uv",
         "sync",

--- a/noxfile.py
+++ b/noxfile.py
@@ -141,7 +141,9 @@ def test_model(session: nox.Session, selection: ModelTestsSubset, subpackage: Mo
             *pytest_args,
             *session.posargs,
             success_codes=[0, NO_TESTS_COLLECTED_EXIT_CODE],
+            env={**os.environ}
         )
+
 
 # @nox.session(python=["3.10", "3.11"])
 # @nox.parametrize("selection", MODEL_TEST_SELECTION)

--- a/noxfile.py
+++ b/noxfile.py
@@ -137,7 +137,7 @@ def test_model(session: nox.Session, selection: ModelTestsSubset, subpackage: Mo
     pytest_args = _selection_to_pytest_args(selection)
     with session.chdir(f"model/{subpackage}"):
         session.run(
-            *f"pytest -sv --benchmark-disable -n {os.environ.get('NUM_PROCESSES', 'auto')}".split(),
+            *f"pytest -sv --benchmark-disable -n auto".split(),
             *pytest_args,
             *session.posargs,
             success_codes=[0, NO_TESTS_COLLECTED_EXIT_CODE],
@@ -164,7 +164,7 @@ def test_tools(session: nox.Session, datatest: bool) -> None:
 
     with session.chdir("tools"):
         session.run(
-            *f"pytest -sv --benchmark-disable -n {os.environ.get('NUM_PROCESSES', 'auto')} {'--datatest-only' if datatest else '--datatest-skip'}".split(),
+            *f"pytest -sv --benchmark-disable -n auto {'--datatest-only' if datatest else '--datatest-skip'}".split(),
             *session.posargs
         )
 


### PR DESCRIPTION
Enhance pytest and CSCS-CI configuration settings to use all CUDA devices during parallel tests runs.
It works by adding code in the `pytest_configure()` hook, which is executed by every pytest worker, to set the environment variable `CUDA_VISIBLE_DEVICES` to a different device for each worker id. The list of available devices needs to be explicitly defined in the custom `PYTEST_XDIST_SPLIT_CUDA_VISIBLE_DEVICES` environment variable as a comma separated list.

Additionally, replace the custom `NUM_PROCESSES` env variable by the standard `PYTEST_XDIST_AUTO_NUM_WORKER` to control the number or pytest-xdist workers.

