### PR TITLE
Use only one test worker in CI

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -88,6 +88,6 @@ build_image_aarch64:
     # Grace-Hopper gpu architecture is not enabled by default in CUDA build
     CUDAARCHS: "90"
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
-    NUM_PROCESSES: 16
+    NUM_PROCESSES: 1
     GT4PY_BUILD_JOBS: 8
     ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS: "cuda12"


### PR DESCRIPTION
Testing if this is faster (or not slower) in all CI jobs compared to 16 workers.