### PR TITLE
Cleanup deploy docs action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - cleanup_deploy_docs_action
-    workflow_dispatch:
 
 
 jobs:
@@ -13,10 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libboost-all-dev
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,7 +23,8 @@ jobs:
               python-version: "3.10"
       - name: Build documentation
         run: |
-            uv run --directory model/atmosphere/dycore/docs/ --only-dev  make html
+            cd model/atmosphere/dycore/docs/
+            uv run --project ../../../../ --only-dev make html
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build documentation
         run: |
             cd model/atmosphere/dycore/docs/
-            uv run --project ../../../../ --only-dev make html
+            uv run --project ../../../../ make html
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,23 +14,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libboost-all-dev
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.10"
-          cache: 'pip'
-          cache-dependency-path: |
-            **/pyproject.toml
-            uv.lock
-      - name: Install all icon4py namespace packages
-        run: |
-          uv sync --extra all
+              version: "0.6.16"
+              enable-cache: true
+              cache-dependency-glob: "uv.lock"
+              python-version: "3.10"
       - name: Build documentation
         run: |
-          source .venv/bin/activate
-          cd model/atmosphere/dycore/docs
-          make html
+            uv run --directory model/atmosphere/dycore/docs/ --only-dev  make html
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    workflow_dispatch:
+
 
 jobs:
   deploy-docs:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - cleanup_deploy_docs_action
     workflow_dispatch:
 
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
               version: "0.6.16"
               enable-cache: true


### PR DESCRIPTION
simplify the github action for the docs deployment: the install python actions used in this workflow has been failing for some time. This PR switches to using `uv` for running `sphinx` as we do in other actions.