### PR TITLE
Restrict connectivities to actual sizes of the dimension

### DIFF
--- a/model/common/src/icon4py/model/common/grid/base.py
+++ b/model/common/src/icon4py/model/common/grid/base.py
@@ -185,11 +185,13 @@ class BaseGrid(ABC):
             neighbor_table = self._neighbor_tables[dim]
 
         if (dimension_size := self.size[from_dim]) <= neighbor_table.shape[0]:
-            # TODO(havogt): Introduce a layer that isolates ICON Fortran related hacks. 
+            # TODO(havogt): Introduce a layer that isolates ICON Fortran related hacks.
             # In Fortran, all connectivities have `nproma` size.
             # Here we are restricting the connectivity to the actual size as this is currently used
             # for sizing GT4Py temporaries.
-            _log.info(f"Restricting connectivity for {dim} to size of {from_dim} ({dimension_size}).")
+            _log.info(
+                f"Restricting connectivity for {dim} to size of {from_dim} ({dimension_size})."
+            )
             neighbor_table = neighbor_table[:dimension_size, :]
 
         connectivity = gtx.as_connectivity(
@@ -236,6 +238,7 @@ class BaseGrid(ABC):
             self._neighbor_tables[dim].shape,
             from_dim,
             to_dim,
+            self.size[from_dim],
             has_skip_values=False,
             array_ns=xp,
         )

--- a/model/common/src/icon4py/model/common/grid/utils.py
+++ b/model/common/src/icon4py/model/common/grid/utils.py
@@ -5,10 +5,14 @@
 #
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
+import logging
 from types import ModuleType
 
 import gt4py.next as gtx
 import numpy as np
+
+
+_log = logging.getLogger(__name__)
 
 
 def connectivity_for_1d_sparse_fields(
@@ -16,6 +20,7 @@ def connectivity_for_1d_sparse_fields(
     old_shape: tuple[int, ...],
     origin_axis: gtx.Dimension,
     neighbor_axis: gtx.Dimension,
+    neighbor_axis_size: int,
     has_skip_values: bool,
     array_ns: ModuleType = np,
 ):
@@ -25,6 +30,13 @@ def connectivity_for_1d_sparse_fields(
     ), 'Neighbor table\'s ("{}" to "{}") data type for 1d sparse fields must be gtx.int32. Instead it\'s "{}"'.format(
         origin_axis, neighbor_axis, table.dtype
     )
+    if neighbor_axis_size <= table.shape[0]:
+        # TODO centralize the restriction in base.py
+        _log.info(
+            f"Restricting connectivity for {dim} to size of {neighbor_axis} ({neighbor_axis_size})."
+        )
+        table = table[:neighbor_axis_size, :]
+
     return gtx.as_connectivity(
         [origin_axis, dim],
         neighbor_axis,


### PR DESCRIPTION
In Fortran, all connectivities have `nproma` size.
Here we are restricting the connectivity to the actual size as this is currently used for sizing GT4Py temporaries.