### PR TITLE
explicitly set  gpu s per node for slurm

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -61,6 +61,7 @@ build_image_aarch64:
   variables:
     SLURM_JOB_NUM_NODES: 1
     SLURM_NTASKS: 1
+    SLURM_GPUS_PER_NODE: 4
     SLURM_TIMELIMIT: '01:30:00'
     CSCS_CUDA_MPS: 1
     NUM_PROCESSES: auto


### PR DESCRIPTION
CI: explicitly set number of GPUs in slurm request,  like also (https://github.com/GridTools/gt4py/pull/2133)
This setting is now required on Santis vCluster, after the vCluster
configuration has been updated with sharing capability.