### PR TITLE
Run CI test reminder workflow on `pull_request_target` events

### DIFF
--- a/.github/workflows/mandatory_and_optional_test_reminder.yml
+++ b/.github/workflows/mandatory_and_optional_test_reminder.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   test:


### PR DESCRIPTION
This ensures it runs in the context of the target branch (main icon4py repository) and has sufficient permissions to write the comment on a PR even when the PR comes from a fork.