### PR TITLE
Fix Deprecation/SyntaxWarning from invalid escape sequence in regex

### DIFF
--- a/model/testing/src/icon4py/model/testing/datatest_utils.py
+++ b/model/testing/src/icon4py/model/testing/datatest_utils.py
@@ -104,7 +104,7 @@ def get_global_grid_params(experiment: str) -> tuple[int, int]:
         return 0, 2
 
     try:
-        root, level = map(int, re.search("[Rr](\d+)[Bb](\d+)", experiment).groups())  # type:ignore[union-attr]
+        root, level = map(int, re.search(r"[Rr](\d+)[Bb](\d+)", experiment).groups())  # type:ignore[union-attr]
         return root, level
     except AttributeError as err:
         raise ValueError(


### PR DESCRIPTION
`\d` is an invalid escape sequence in a regular string. Change the string to a raw string (where there are no escape sequences) to fix the warning.