### PR TITLE
fix serialisation: https://github.com/C2SM/icon-exclaim/pull/374

### DIFF
--- a/model/atmosphere/dycore/tests/dycore/integration_tests/test_velocity_advection.py
+++ b/model/atmosphere/dycore/tests/dycore/integration_tests/test_velocity_advection.py
@@ -25,7 +25,7 @@ from icon4py.model.atmosphere.dycore.stencils.compute_advection_in_vertical_mome
 from icon4py.model.atmosphere.dycore.stencils.compute_derived_horizontal_winds_and_ke_and_contravariant_correction import (
     compute_derived_horizontal_winds_and_ke_and_contravariant_correction,
 )
-from icon4py.model.common import dimension as dims, utils as common_utils
+from icon4py.model.common import dimension as dims, utils as common_utils, type_alias as ta
 from icon4py.model.common.grid import (
     horizontal as h_grid,
     states as grid_states,
@@ -603,7 +603,7 @@ def test_compute_contravariant_correction_and_advection_in_vertical_momentum_equ
     horizontal_advection_of_w_at_edges_on_half_levels = savepoint_velocity_exit.z_v_grad_w()
     vertical_wind_advective_tendency = savepoint_velocity_init.ddt_w_adv_pc(istep_init - 1)
     contravariant_corrected_w_at_cells_on_model_levels = savepoint_velocity_init.z_w_con_c_full()
-    vertical_cfl = savepoint_velocity_init.vcfl_dsl()
+    vertical_cfl = data_alloc.zero_field(icon_grid, dims.CellDim, dims.KDim, dtype=ta.vpfloat)
     skip_compute_predictor_vertical_advection = savepoint_velocity_init.lvn_only()
 
     coeff1_dwdz = metrics_savepoint.coeff1_dwdz()
@@ -747,7 +747,7 @@ def test_compute_advection_in_vertical_momentum_equation(
     vn_on_half_levels = savepoint_velocity_exit.vn_ie()
     vertical_wind_advective_tendency = savepoint_velocity_init.ddt_w_adv_pc(istep_init - 1)
     contravariant_corrected_w_at_cells_on_model_levels = savepoint_velocity_init.z_w_con_c_full()
-    vertical_cfl = savepoint_velocity_init.vcfl_dsl()
+    vertical_cfl = data_alloc.zero_field(icon_grid, dims.CellDim, dims.KDim, dtype=ta.vpfloat)
 
     coeff1_dwdz = metrics_savepoint.coeff1_dwdz()
     coeff2_dwdz = metrics_savepoint.coeff2_dwdz()

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -1159,7 +1159,7 @@ class NonHydroInitEdgeDiagnosticsUpdateVnSavepoint(IconSavepoint):
         return self._get_field("bdy_divdamp", dims.KDim)
 
     def z_hydro_corr(self):
-        return self._get_field("z_hydro_corr", dims.EdgeDim, dims.KDim)
+        return self._get_field("z_hydro_corr", dims.EdgeDim)
 
     def z_graddiv2_vn(self):
         return self._get_field("z_graddiv2_vn", dims.EdgeDim, dims.KDim)
@@ -1565,9 +1565,6 @@ class IconVelocityInitSavepoint(IconSavepoint):
 
     def z_w_con_c_full(self):
         return self._get_field("z_w_con_c_full", dims.CellDim, dims.KDim)
-
-    def vcfl_dsl(self):
-        return self._get_field("vcfl_dsl", dims.CellDim, dims.KDim)
 
 
 class IconVelocityExitSavepoint(IconSavepoint):


### PR DESCRIPTION
Adapt to serialization in icon-exclaim.

Icon-exclaim [PR-374] (https://github.com/C2SM/icon-exclaim/pull/374) changes serialization data after removal of liskov. 
This PR does the corresponding changes in icon4py: 

- reduce dimension of z_hydro_corr to only horizontal
- remove vcfl_dsl