### PR TITLE
Fix cupy cfl reduction performance by raveling the array

### DIFF
--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity_advection.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/velocity_advection.py
@@ -279,11 +279,13 @@ class VelocityAdvection:
             skip_compute_predictor_vertical_advection=skip_compute_predictor_vertical_advection,
         )
 
+        # Reductions should be performed on flat, contiguous arrays for best cupy performance
+        # as otherwise cupy won't use cub optimized kernels.
         max_vertical_cfl = float(
             self.vertical_cfl.array_ns.max(
                 self.vertical_cfl.ndarray[
                     self._start_cell_lateral_boundary_level_4 : self._end_cell_halo, :
-                ]
+                ].ravel(order="K")
             )
         )
         diagnostic_state.max_vertical_cfl = max(max_vertical_cfl, diagnostic_state.max_vertical_cfl)


### PR DESCRIPTION
On the mch-ch1_medium experiment
- this is 4% faster on the full timestep compared to the version without `ravel`;
- within fluctuations there is no difference between no reduction and this version.