### PR TITLE
Fix return types in RBF interpolation functions

### DIFF
--- a/model/common/src/icon4py/model/common/interpolation/rbf_interpolation.py
+++ b/model/common/src/icon4py/model/common/interpolation/rbf_interpolation.py
@@ -227,7 +227,7 @@ def _compute_rbf_interpolation_coeffs(
     scale_factor: ta.wpfloat,
     horizontal_start: gtx.int32,
     array_ns: ModuleType = np,
-) -> tuple[data_alloc.NDArray, data_alloc.NDArray]:
+) -> list[data_alloc.NDArray]:
     rbf_offset_shape_full = rbf_offset.shape
     rbf_offset = rbf_offset[horizontal_start:]
     num_elements = rbf_offset.shape[0]
@@ -346,7 +346,7 @@ def _compute_rbf_interpolation_coeffs(
             rbf_vec_coeff_np[j][i + horizontal_start, valid_neighbors] = sla.cho_solve(
                 z_diag_np, rhs_np[j][i, valid_neighbors]
             )
-    rbf_vec_coeff = tuple([array_ns.asarray(x) for x in rbf_vec_coeff_np])
+    rbf_vec_coeff = [array_ns.asarray(x) for x in rbf_vec_coeff_np]
 
     # Normalize coefficients
     for j in range(num_zonal_meridional_components):
@@ -399,7 +399,7 @@ def compute_rbf_interpolation_coeffs_cell(
         array_ns=array_ns,
     )
     assert len(coeffs) == 2
-    return coeffs
+    return tuple(coeffs)
 
 
 def compute_rbf_interpolation_coeffs_edge(
@@ -483,4 +483,4 @@ def compute_rbf_interpolation_coeffs_vertex(
         array_ns=array_ns,
     )
     assert len(coeffs) == 2
-    return coeffs
+    return tuple(coeffs)


### PR DESCRIPTION
https://github.com/C2SM/icon4py/pull/871 made a partial fix, but the types still ended up slightly inconsistent. The generic `_compute_rbf_interpolation_coeffs` returns a dynamically sized list of ndarrays, as it depends on a dynamically sized list as input. The return type was incorrectly specified as a two-element tuple (it can be one or two elements long). #871 correctly made sure the cell/vertex-specific functions return a tuple, but with `_compute_rbf_interpolation_coeffs` returning a list, they return values should be explicitly converted in those functions instead.