### PR TITLE
edits to parametrize skip_compute_predictor_vertical_advection

### DIFF
--- a/model/atmosphere/dycore/tests/dycore/stencil_tests/test_compute_derived_horizontal_winds_and_ke_and_contravariant_correction.py
+++ b/model/atmosphere/dycore/tests/dycore/stencil_tests/test_compute_derived_horizontal_winds_and_ke_and_contravariant_correction.py
@@ -184,6 +184,18 @@ class TestComputeDerivedHorizontalWindsAndKEAndHorizontalAdvectionofWAndContrava
         vertical_start: int,
         vertical_end: int,
     ) -> dict:
+        initial_tangential_wind = tangential_wind.copy()
+        initial_tangential_wind_on_half_levels = tangential_wind_on_half_levels.copy()
+        initial_vn_on_half_levels = vn_on_half_levels.copy()
+        initial_horizontal_kinetic_energy_at_edges_on_model_levels = (
+            horizontal_kinetic_energy_at_edges_on_model_levels.copy()
+        )
+        initial_contravariant_correction_at_edges_on_model_levels = (
+            contravariant_correction_at_edges_on_model_levels.copy()
+        )
+        initial_horizontal_advection_of_w_at_edges_on_half_levels = (
+            horizontal_advection_of_w_at_edges_on_half_levels.copy()
+        )
         (
             tangential_wind,
             tangential_wind_on_half_levels,
@@ -214,6 +226,40 @@ class TestComputeDerivedHorizontalWindsAndKEAndHorizontalAdvectionofWAndContrava
             nflatlev=nflatlev,
             nlevp1=nflatlev,
             horizontal_start=horizontal_start,
+        )
+
+        tangential_wind[:horizontal_start, :] = initial_tangential_wind[:horizontal_start, :]
+        tangential_wind[horizontal_end:, :] = initial_tangential_wind[horizontal_end:, :]
+
+        tangential_wind_on_half_levels[:horizontal_start, :] = (
+            initial_tangential_wind_on_half_levels[:horizontal_start, :]
+        )
+        tangential_wind_on_half_levels[horizontal_end:, :] = initial_tangential_wind_on_half_levels[
+            horizontal_end:, :
+        ]
+
+        vn_on_half_levels[:horizontal_start, :] = initial_vn_on_half_levels[:horizontal_start, :]
+        vn_on_half_levels[horizontal_end:, :] = initial_vn_on_half_levels[horizontal_end:, :]
+
+        horizontal_kinetic_energy_at_edges_on_model_levels[:horizontal_start, :] = (
+            initial_horizontal_kinetic_energy_at_edges_on_model_levels[:horizontal_start, :]
+        )
+        horizontal_kinetic_energy_at_edges_on_model_levels[horizontal_end:, :] = (
+            initial_horizontal_kinetic_energy_at_edges_on_model_levels[horizontal_end:, :]
+        )
+
+        contravariant_correction_at_edges_on_model_levels[:horizontal_start, :] = (
+            initial_contravariant_correction_at_edges_on_model_levels[:horizontal_start, :]
+        )
+        contravariant_correction_at_edges_on_model_levels[horizontal_end:, :] = (
+            initial_contravariant_correction_at_edges_on_model_levels[horizontal_end:, :]
+        )
+
+        horizontal_advection_of_w_at_edges_on_half_levels[:horizontal_start, :] = (
+            initial_horizontal_advection_of_w_at_edges_on_half_levels[:horizontal_start, :]
+        )
+        horizontal_advection_of_w_at_edges_on_half_levels[horizontal_end:, :] = (
+            initial_horizontal_advection_of_w_at_edges_on_half_levels[horizontal_end:, :]
         )
 
         return dict(
@@ -258,7 +304,7 @@ class TestComputeDerivedHorizontalWindsAndKEAndHorizontalAdvectionofWAndContrava
         c_intp = data_alloc.random_field(grid, dims.VertexDim, dims.V2CDim)
 
         nlev = grid.num_levels
-        nflatlev = grid.num_levels + 1
+        nflatlev = 11
 
         skip_compute_predictor_vertical_advection = request.param[
             "skip_compute_predictor_vertical_advection"

--- a/model/atmosphere/dycore/tests/dycore/stencil_tests/test_compute_derived_horizontal_winds_and_ke_and_contravariant_correction.py
+++ b/model/atmosphere/dycore/tests/dycore/stencil_tests/test_compute_derived_horizontal_winds_and_ke_and_contravariant_correction.py
@@ -304,10 +304,8 @@ class TestComputeDerivedHorizontalWindsAndKEAndHorizontalAdvectionofWAndContrava
             "skip_compute_predictor_vertical_advection"
         ]
 
-        edge_domain = h_grid.domain(dims.EdgeDim)
-        # For the ICON grid we use the proper domain bounds (otherwise we will run into non-protected skip values)
-        horizontal_start = grid.start_index(edge_domain(h_grid.Zone.LATERAL_BOUNDARY_LEVEL_5))
-        horizontal_end = grid.end_index(edge_domain(h_grid.Zone.HALO_LEVEL_2))
+        horizontal_start = 0
+        horizontal_end = grid.num_edges
         vertical_start = 0
         vertical_end = nlev + 1
 

--- a/model/atmosphere/dycore/tests/dycore/stencil_tests/test_interpolate_vn_to_half_levels_and_compute_kinetic_energy_on_edges.py
+++ b/model/atmosphere/dycore/tests/dycore/stencil_tests/test_interpolate_vn_to_half_levels_and_compute_kinetic_energy_on_edges.py
@@ -27,7 +27,7 @@ def interpolate_vn_to_half_levels_and_compute_kinetic_energy_on_edges_vn_ie_nump
 ) -> np.ndarray:
     vn_ie_k_minus_1 = np.roll(vn, shift=1, axis=1)
     vn_ie = wgtfac_e * vn + (1.0 - wgtfac_e) * vn_ie_k_minus_1
-    vn_ie[:, 0] = 0
+    vn_ie[:, 0] = vn[:, 0]
     return vn_ie
 
 
@@ -35,7 +35,6 @@ def interpolate_vn_to_half_levels_and_compute_kinetic_energy_on_edges_z_kin_hor_
     vn: np.ndarray, vt: np.ndarray
 ) -> np.ndarray:
     z_kin_hor_e = 0.5 * (vn * vn + vt * vt)
-    z_kin_hor_e[:, 0] = 0
     return z_kin_hor_e
 
 

--- a/model/atmosphere/dycore/tests/dycore/stencil_tests/test_interpolate_vt_to_interface_edges.py
+++ b/model/atmosphere/dycore/tests/dycore/stencil_tests/test_interpolate_vt_to_interface_edges.py
@@ -26,7 +26,7 @@ def interpolate_vt_to_interface_edges_numpy(
 ) -> np.ndarray:
     vt_k_minus_1 = np.roll(vt, shift=1, axis=1)
     z_vt_ie = wgtfac_e * vt + (1.0 - wgtfac_e) * vt_k_minus_1
-    z_vt_ie[:, 0] = 0
+    z_vt_ie[:, 0] = vt[:, 0]
     return z_vt_ie
 
 


### PR DESCRIPTION
stencils:
 - `compute_advective_vertical_wind_tendency_and_apply_diffusion`
 -  `compute_derived_horizontal_winds_and_ke_and_contravariant_correction`
 
did not include the right option for `skip_compute_predictor_vertical_advection` and subsequent changes