### PR TITLE
Write GT4Py timers in dycore_wrapper solve_nh_run

### DIFF
--- a/tools/src/icon4py/tools/py2fgen/wrappers/dycore_wrapper.py
+++ b/tools/src/icon4py/tools/py2fgen/wrappers/dycore_wrapper.py
@@ -416,6 +416,5 @@ def solve_nh_run(
     # dump gt4py timers
     if gtx_config.COLLECT_METRICS_LEVEL > 0:
         gtx_metrics.dump_json("gt4py_timers.json")
-        logger.info(gtx_metrics.dumps())
 
     max_vcfl_size1_array[0] = diagnostic_state_nh.max_vertical_cfl  # pass back to Fortran

--- a/tools/src/icon4py/tools/py2fgen/wrappers/dycore_wrapper.py
+++ b/tools/src/icon4py/tools/py2fgen/wrappers/dycore_wrapper.py
@@ -413,7 +413,7 @@ def solve_nh_run(
         at_last_substep=idyn_timestep == (ndyn_substeps_var - 1),
     )
 
-    # dump gt4py timers
+    # TODO(havogt): create separate bindings for writing the timers
     if gtx_config.COLLECT_METRICS_LEVEL > 0:
         gtx_metrics.dump_json("gt4py_timers.json")
 

--- a/tools/src/icon4py/tools/py2fgen/wrappers/dycore_wrapper.py
+++ b/tools/src/icon4py/tools/py2fgen/wrappers/dycore_wrapper.py
@@ -25,6 +25,7 @@ from typing import Annotated, TypeAlias
 import gt4py.next as gtx
 import gt4py.next.typing as gtx_typing
 import numpy as np
+from gt4py.next import config as gtx_config, metrics as gtx_metrics
 from gt4py.next.type_system import type_specifications as ts
 
 from icon4py.model.atmosphere.dycore import dycore_states, solve_nonhydro
@@ -411,5 +412,10 @@ def solve_nh_run(
         at_first_substep=idyn_timestep == 0,
         at_last_substep=idyn_timestep == (ndyn_substeps_var - 1),
     )
+
+    # dump gt4py timers
+    if gtx_config.COLLECT_METRICS_LEVEL > 0:
+        gtx_metrics.dump_json("gt4py_timers.json")
+        logger.info(gtx_metrics.dumps())
 
     max_vcfl_size1_array[0] = diagnostic_state_nh.max_vertical_cfl  # pass back to Fortran


### PR DESCRIPTION
This is a quick fix for writing the gt4py timers from the blueline. For a clean implementation we would create separate bindings for this call and write it once at the end of the simulation.