### PR TITLE
Disabled DaCe `LoopBlocking` by Default

### DIFF
--- a/model/common/src/icon4py/model/common/model_backends.py
+++ b/model/common/src/icon4py/model/common/model_backends.py
@@ -93,7 +93,9 @@ try:
         """
         on_gpu = device == GPU
         if (blocking_dim is None) ^ (blocking_size is None):
-            raise ValueError("Undefined behavior for `blocking_dim`={blocking_dim} `blocking_size`={blocking_size}.")
+            raise ValueError(
+                f"Undefined behavior for `blocking_dim`={blocking_dim} `blocking_size`={blocking_size}."
+            )
 
         return make_dace_backend(
             auto_optimize=auto_optimize,


### PR DESCRIPTION
We noticed that in some cases loop blocking was applied which had negative impact on performance.
It was also realized that controlling its usage in general was hard and it was thus decided to disable it and later reenable it on a per stencil basis.