### PR TITLE
[BUG FIX] fourth_order_divdamp_scaling_coeff

### DIFF
--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
@@ -1289,7 +1289,7 @@ class SolveNonhydro:
             interpolated_fourth_order_divdamp_factor=self.interpolated_fourth_order_divdamp_factor,
             fourth_order_divdamp_scaling_coeff=self.fourth_order_divdamp_scaling_coeff,
             reduced_fourth_order_divdamp_coeff_at_nest_boundary=self.reduced_fourth_order_divdamp_coeff_at_nest_boundary,
-            second_order_divdamp_factor=second_order_divdamp_scaling_coeff,
+            second_order_divdamp_factor=second_order_divdamp_factor,
         )
 
         log.debug("corrector run velocity advection")


### PR DESCRIPTION
`second_order_divdamp_scaling_coeff` is wrongly passed to `calculate_divdamp_fields` in the `run_corrector_step` in the dycore.
It should be `second_order_divdamp_factor`. This is fixed in this PR.
