### PR TITLE
Only compute rayleigh damping factors if dtime changes

### DIFF
--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/solve_nonhydro.py
@@ -1058,8 +1058,6 @@ class SolveNonhydro:
                 self.intermediate_fields.horizontal_gradient_of_normal_wind_divergence,
             )
 
-        self.rayleigh_damping_factor = self._get_rayleigh_damping_factor(dtime)
-
         self.run_predictor_step(
             diagnostic_state_nh=diagnostic_state_nh,
             prognostic_states=prognostic_states,
@@ -1230,7 +1228,7 @@ class SolveNonhydro:
             exner_tendency_due_to_slow_physics=diagnostic_state_nh.exner_tendency_due_to_slow_physics,
             rho_iau_increment=diagnostic_state_nh.rho_iau_increment,
             exner_iau_increment=diagnostic_state_nh.exner_iau_increment,
-            rayleigh_damping_factor=self.rayleigh_damping_factor,
+            rayleigh_damping_factor=self._get_rayleigh_damping_factor(dtime),
             dtime=dtime,
             at_first_substep=at_first_substep,
         )
@@ -1401,7 +1399,7 @@ class SolveNonhydro:
             exner_tendency_due_to_slow_physics=diagnostic_state_nh.exner_tendency_due_to_slow_physics,
             rho_iau_increment=diagnostic_state_nh.rho_iau_increment,
             exner_iau_increment=diagnostic_state_nh.exner_iau_increment,
-            rayleigh_damping_factor=self.rayleigh_damping_factor,
+            rayleigh_damping_factor=self._get_rayleigh_damping_factor(dtime),
             lprep_adv=lprep_adv,
             r_nsubsteps=r_nsubsteps,
             ndyn_substeps_var=float(ndyn_substeps_var),

--- a/model/atmosphere/dycore/tests/dycore/integration_tests/test_solve_nonhydro.py
+++ b/model/atmosphere/dycore/tests/dycore/integration_tests/test_solve_nonhydro.py
@@ -222,11 +222,6 @@ def test_nonhydro_predictor_step(
     if not at_first_substep:
         diagnostic_state_nh.normal_wind_advective_tendency.swap()
 
-    solve_nonhydro._compute_rayleigh_damping_factor(
-        rayleigh_damping_factor=solve_nonhydro.rayleigh_damping_factor,
-        dtime=dtime,
-    )
-
     solve_nonhydro.run_predictor_step(
         diagnostic_state_nh=diagnostic_state_nh,
         prognostic_states=prognostic_states,
@@ -576,11 +571,6 @@ def test_nonhydro_corrector_step(
         diagnostic_state_nh.vertical_wind_advective_tendency.swap()
     if not at_first_substep:
         diagnostic_state_nh.normal_wind_advective_tendency.swap()
-
-    solve_nonhydro._compute_rayleigh_damping_factor(
-        rayleigh_damping_factor=solve_nonhydro.rayleigh_damping_factor,
-        dtime=dtime,
-    )
 
     solve_nonhydro.run_corrector_step(
         diagnostic_state_nh=diagnostic_state_nh,


### PR DESCRIPTION
Only compute rayleigh damping factor if the dynamic substep ever changes.
Detect this by storing the substep length of the previous substep, if it differs from the current substep length, recompute rayleigh damping.