### PR TITLE
disable NotImplementedError check for itype_sher=1

### DIFF
--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/diffusion.py
@@ -260,10 +260,12 @@ class DiffusionConfig:
 
         if self.shear_type not in (
             TurbulenceShearForcingType.VERTICAL_OF_HORIZONTAL_WIND,
+            TurbulenceShearForcingType.VERTICAL_HORIZONTAL_OF_HORIZONTAL_WIND,
             TurbulenceShearForcingType.VERTICAL_HORIZONTAL_OF_HORIZONTAL_VERTICAL_WIND,
         ):
             raise NotImplementedError(
                 f"Turbulence Shear only {TurbulenceShearForcingType.VERTICAL_OF_HORIZONTAL_WIND} "
+                f"and {TurbulenceShearForcingType.VERTICAL_HORIZONTAL_OF_HORIZONTAL_WIND} "
                 f"and {TurbulenceShearForcingType.VERTICAL_HORIZONTAL_OF_HORIZONTAL_VERTICAL_WIND} "
                 f"implemented"
             )


### PR DESCRIPTION
Disable the `NotImplementError` when `itype_sher` is set to 1 (`VERTICAL_HORIZONTAL_OF_HORIZONTAL_WIND` in icon4py) because we already have the stencil ported when `itype_sher>=1`.
In the diffusion granule, four variables `div_ic`, `hdef_ic`, `dwdx`, and `dwdy` are related to the turbulence. Whether they are computed is based on the value of `itype_sher`. When `itype_sher>=1`, `div_ic` and `hdef_ic` are computed in the stencil `calculate_diagnostic_quantities_for_turbulence`. When `itype_sher==2`, `dwdx` and `dwdy` are computed in the stencil `apply_diffusion_to_w_and_compute_horizontal_gradients_for_turbulence`. Both stencils have already been ported to icon4py. So, `itype_sher==1` should be supported.