### PR TITLE
fix: cache ghex pattern on buffer and dimension

### DIFF
--- a/model/common/src/icon4py/model/common/decomposition/mpi_decomposition.py
+++ b/model/common/src/icon4py/model/common/decomposition/mpi_decomposition.py
@@ -216,20 +216,21 @@ class GHexMultiNodeExchange:
     def _get_applied_pattern(self, dim: gtx.Dimension, f: gtx.Field) -> str:
         # TODO(havogt): the cache is never cleared, consider using functools.lru_cache in a bigger refactoring.
         assert hasattr(f, "__gt_buffer_info__")
-        buffer_key = f.__gt_buffer_info__.hash_key
+        # dimension and buffer_info uniquely identifies the exchange pattern
+        key = (dim, f.__gt_buffer_info__.hash_key)
         try:
-            return self._applied_patterns_cache[(dim, buffer_key)]
+            return self._applied_patterns_cache[key]
         except KeyError:
             assert dim in f.domain.dims
             array = self._slice_field_based_on_dim(f, dim)
-            self._applied_patterns_cache[(dim, buffer_key)] = self._patterns[dim](
+            self._applied_patterns_cache[key] = self._patterns[dim](
                 make_field_descriptor(
                     self._domain_descriptors[dim],
                     array,
                     arch=Architecture.CPU if isinstance(f, np.ndarray) else Architecture.GPU,
                 )
             )
-            return self._applied_patterns_cache[(dim, buffer_key)]
+            return self._applied_patterns_cache[key]
 
     def exchange(self, dim: gtx.Dimension, *fields: gtx.Field) -> MultiNodeResult:
         """


### PR DESCRIPTION
In #915 I claimed that the dimension does not have be part of the key as I thought the buffer uniquely identifies the exchange pattern. However if a field gets de-allocated and the same buffer gets re-allocated for a field with different dimension (which can only happen if all dimensions have the same length (`nproma`)) then the caching is broken.

This case can only happen in blueline verification mode (where fields are allocated/deallocated in the timeloop).