### PR TITLE
Fix grid download in CI and add torus grid

### DIFF
--- a/.github/validation_grid_utils.py
+++ b/.github/validation_grid_utils.py
@@ -53,7 +53,7 @@ def download_validation_grids() -> None:
     config.TEST_DATA_PATH = pathlib.Path.cwd() / definitions.DEFAULT_TEST_DATA_FOLDER
     for grid in VALIDATION_GRIDS:
         print(f"downloading and unpacking {grid.name}")
-        fname = grid_utils._download_grid_file(grid.name)
+        fname = grid_utils._download_grid_file(grid)
         print(f"done - downloaded {fname}")
 
 


### PR DESCRIPTION
- Download torus grid in CI (will be needed for torus tests in CI)
- Pass GridDescriptor instead of only name (string) to `_download_grid_file` so that grids are actually correctly downloaded (leftover from https://github.com/C2SM/icon4py/pull/862)