### PR TITLE
Test fixes for  metrics fields

### DIFF
--- a/model/common/tests/common/metrics/unit_tests/test_metric_fields.py
+++ b/model/common/tests/common/metrics/unit_tests/test_metric_fields.py
@@ -398,7 +398,7 @@ def test_compute_pressure_gradient_downward_extrapolation_mask_distance(
         k_lev=k.ndarray,
         array_ns=xp,
     )
-
+    # TODO (nfarabullini): fix type ignore
     flat_idx = gtx.as_field((dims.EdgeDim,), data=flat_idx_max, allocator=backend)  # type: ignore [arg-type]
     mf.compute_pressure_gradient_downward_extrapolation_mask_distance.with_backend(backend)(
         z_mc=z_mc,


### PR DESCRIPTION
Fix and remove obsolete test in `test_metric_fields.py`, only run in extra test suite.