### PR TITLE
Remove pytest-deadfixtures from test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ test = [
   "pytest-benchmark>=5.0.0",
   "pytest-cache>=1.0",
   "pytest-cov>=5.0.0",
-  "pytest-deadfixtures>=2.2.1",
   "pytest-factoryboy>=2.6.1",
   "pytest-mpi>=0.6",
   "pytest-unused-fixtures>=0.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -173,8 +173,8 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "platformdirs" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-7-icon4py-cuda11' and extra == 'extra-7-icon4py-cuda12')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-7-icon4py-cuda11' and extra == 'extra-7-icon4py-cuda12')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/0d/cc2fb42b8c50d80143221515dd7e4766995bd07c56c9a3ed30baf080b6dc/black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875", size = 645813, upload-time = "2024-10-07T19:20:50.361Z" }
 wheels = [
@@ -562,7 +562,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-7-icon4py-cuda11' and extra == 'extra-7-icon4py-cuda12')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121, upload-time = "2023-08-17T17:29:11.868Z" }
 wheels = [
@@ -917,7 +917,7 @@ dependencies = [
     { name = "numpy" },
     { name = "packaging" },
     { name = "ply" },
-    { name = "pyreadline", marker = "sys_platform == 'win32'" },
+    { name = "pyreadline", marker = "sys_platform == 'win32' or (extra == 'extra-7-icon4py-cuda11' and extra == 'extra-7-icon4py-cuda12')" },
     { name = "pyyaml" },
     { name = "sympy" },
 ]
@@ -1578,7 +1578,6 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cache" },
     { name = "pytest-cov" },
-    { name = "pytest-deadfixtures" },
     { name = "pytest-factoryboy" },
     { name = "pytest-mpi" },
     { name = "pytest-unused-fixtures" },
@@ -1624,7 +1623,6 @@ test = [
     { name = "pytest-benchmark" },
     { name = "pytest-cache" },
     { name = "pytest-cov" },
-    { name = "pytest-deadfixtures" },
     { name = "pytest-factoryboy" },
     { name = "pytest-mpi" },
     { name = "pytest-unused-fixtures" },
@@ -1678,7 +1676,6 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=5.0.0" },
     { name = "pytest-cache", specifier = ">=1.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
-    { name = "pytest-deadfixtures", specifier = ">=2.2.1" },
     { name = "pytest-factoryboy", specifier = ">=2.6.1" },
     { name = "pytest-mpi", specifier = ">=0.6" },
     { name = "pytest-unused-fixtures", specifier = ">=0.2.0" },
@@ -1724,7 +1721,6 @@ test = [
     { name = "pytest-benchmark", specifier = ">=5.0.0" },
     { name = "pytest-cache", specifier = ">=1.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
-    { name = "pytest-deadfixtures", specifier = ">=2.2.1" },
     { name = "pytest-factoryboy", specifier = ">=2.6.1" },
     { name = "pytest-mpi", specifier = ">=0.6" },
     { name = "pytest-unused-fixtures", specifier = ">=0.2.0" },
@@ -3517,18 +3513,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-deadfixtures"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/d5/0472e7dd4c5794cd720f8add3ba59b35e45c1bb7482e04b6d6e60ff4eed0/pytest-deadfixtures-2.2.1.tar.gz", hash = "sha256:ca15938a4e8330993ccec9c6c847383d88b3cd574729530647dc6b492daa9c1e", size = 6616, upload-time = "2020-07-23T11:58:09.465Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/c7/d8c3fa6d2de6814c92161fcce984a7d38a63186590a66238e7b749f7fe37/pytest_deadfixtures-2.2.1-py2.py3-none-any.whl", hash = "sha256:db71533f2d9456227084e00a1231e732973e299ccb7c37ab92e95032ab6c083e", size = 5059, upload-time = "2020-07-23T11:58:11.538Z" },
-]
-
-[[package]]
 name = "pytest-factoryboy"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3943,7 +3927,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "setuptools" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-7-icon4py-cuda11' and extra == 'extra-7-icon4py-cuda12')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4f/a4/00a9ac1b555294710d4a68d2ce8dfdf39d72aa4d769a7395d05218d88a42/setuptools_scm-8.1.0.tar.gz", hash = "sha256:42dea1b65771cba93b7a515d65a65d8246e560768a66b9106a592c8e7f26c8a7", size = 76465, upload-time = "2024-05-06T15:07:56.934Z" }
 wheels = [
@@ -4568,7 +4552,7 @@ version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-7-icon4py-cuda11' and extra == 'extra-7-icon4py-cuda12')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/9b/941647e9e3616b5da7bbc4601ed9920f44a886704100fa8151406c07c149/versioningit-3.1.2.tar.gz", hash = "sha256:4db83ed99f56b07d83940bee3445ca46ca120d13b6b304cdb5fb44e5aa4edec0", size = 213047, upload-time = "2024-07-20T12:41:07.927Z" }
 wheels = [


### PR DESCRIPTION
It seems the plugin will cache fixtures forever (even fixtures with function scope), which will eventually lead to out of memory.