### PR TITLE
update gt4py version in standalone driver

### DIFF
--- a/model/standalone_driver/pyproject.toml
+++ b/model/standalone_driver/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   # external dependencies
   "typer>=0.20.0",
   "devtools>=0.12",
-  "gt4py==1.1.0",
+  "gt4py==1.1.2",
   "packaging>=20.0",
   "numpy>=1.23.3"
 ]


### PR DESCRIPTION
(FIX) uplift gt4py version in standalone driver to the one used in the other packages

I assume that was merged with the old version by accident... at least I had troubles building something yesterday... 