### PR TITLE
fix computation of dz for float32 input files

### DIFF
--- a/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/driver/common.py
+++ b/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/driver/common.py
@@ -94,7 +94,10 @@ class GraupelInput:
 
     @classmethod
     def load(
-        cls, filename: pathlib.Path | str, allocator: gtx_typing.FieldBufferAllocationUtil
+        cls,
+        filename: pathlib.Path | str,
+        allocator: gtx_typing.FieldBufferAllocationUtil,
+        dtype=np.float64,
     ) -> None:
         with netCDF4.Dataset(filename, mode="r") as ncfile:
             try:
@@ -104,11 +107,9 @@ class GraupelInput:
 
             nlev = len(ncfile.dimensions["height"])
 
-            dz = _calc_dz(ncfile.variables["zg"])
+            dz = _calc_dz(np.asarray(ncfile.variables["zg"]).astype(dtype))
 
-            field_from_nc = functools.partial(
-                _as_field_from_nc, ncfile, allocator, dtype=np.float64
-            )
+            field_from_nc = functools.partial(_as_field_from_nc, ncfile, allocator, dtype=dtype)
             return cls(
                 ncells=ncells,
                 nlev=nlev,

--- a/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/implementations/graupel.py
+++ b/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/implementations/graupel.py
@@ -90,7 +90,7 @@ def precip_qx_level_update(
     current_level_activated = previous_level_q.activated | mask
     rho_x = q * rho
     flx_eff = (rho_x / zeta) + 2.0 * previous_level_q.p
-    #   Inlined calculation using _fall_speed_scalar
+    # Inlined calculation using _fall_speed_scalar
     flx_partial = minimum(rho_x * vc * prefactor * power((rho_x + offset), exponent), flx_eff)
 
     rhox_prev = (previous_level_q.x + q) * 0.5 * previous_level_rho
@@ -500,9 +500,9 @@ def _precipitation_effects(
     t = precip_state.t_state.t
     eflx = precip_state.t_state.eflx
 
-    pflx_tot = ps + pi + pg
+    pflx_tot = ps + pi + pg + pr
 
-    return qr, qs, qi, qg, t, pflx_tot + pr, pr, ps, pi, pg, eflx / dt
+    return qr, qs, qi, qg, t, pflx_tot, pr, ps, pi, pg, eflx / dt
 
 
 @gtx.field_operator

--- a/model/atmosphere/subgrid_scale_physics/muphys/tests/muphys/integration_tests/test_full_muphys.py
+++ b/model/atmosphere/subgrid_scale_physics/muphys/tests/muphys/integration_tests/test_full_muphys.py
@@ -28,7 +28,6 @@ class Experiments:
         name="mini",
         type=utils.ExperimentType.FULL_MUPHYS,
         uri="https://polybox.ethz.ch/index.php/s/rQBXS7niXBBZay9/download/mini.tar.gz",
-        dtype=np.float32,
     )
     # Note: don't use the 'tiny' experiment from graupel_only,
     # as it is not sensitive to saturation adjustment
@@ -38,19 +37,16 @@ class Experiments:
         name="r2b04",
         type=utils.ExperimentType.FULL_MUPHYS,
         uri="https://polybox.ethz.ch/index.php/s/5oNtcQFDcCaNxHH/download/r2b04.tar.gz",
-        dtype=np.float32,
     )
     R2B04_MAXFRAC: Final = utils.MuphysExperiment(
         name="r2b04_maxfrac",
         type=utils.ExperimentType.FULL_MUPHYS,
         uri="https://polybox.ethz.ch/index.php/s/mBeAWAQQHSKTkF7/download/r2b04_maxfrac.tar.gz",
-        dtype=np.float32,
     )
     R2B05: Final = utils.MuphysExperiment(
         name="r2b05",
         type=utils.ExperimentType.FULL_MUPHYS,
         uri="https://polybox.ethz.ch/index.php/s/mBrpE3iBoeek5wc/download/r2b05.tar.gz",
-        dtype=np.float32,
     )
 
 
@@ -113,10 +109,8 @@ def test_full_muphys(
         filename=experiment.reference_file, allocator=model_backends.get_allocator(backend_like)
     )
 
-    # TODO check tolerances
-    rtol = 1e-14 if experiment.dtype == np.float64 else 1e-7
-    atol = 1e-16 if experiment.dtype == np.float64 else 1e-8
-    # TODO we run the float32 input experiments with float64
+    rtol = 1e-14
+    atol = 1e-16
 
     np.testing.assert_allclose(ref.qv.asnumpy(), out.qv.asnumpy(), atol=atol, rtol=rtol)
     np.testing.assert_allclose(ref.qc.asnumpy(), out.qc.asnumpy(), atol=atol, rtol=rtol)

--- a/model/atmosphere/subgrid_scale_physics/muphys/tests/muphys/integration_tests/test_graupel_only.py
+++ b/model/atmosphere/subgrid_scale_physics/muphys/tests/muphys/integration_tests/test_graupel_only.py
@@ -28,19 +28,16 @@ class Experiments:
         name="mini",
         type=utils.ExperimentType.GRAUPEL_ONLY,
         uri="https://polybox.ethz.ch/index.php/s/55oHBDxS2SiqAGN/download/mini.tar.gz",
-        dtype=np.float32,
     )
     TINY: Final = utils.MuphysExperiment(
         name="tiny",
         type=utils.ExperimentType.GRAUPEL_ONLY,
         uri="https://polybox.ethz.ch/index.php/s/5Ceop3iaWkbc7gf/download/tiny.tar.gz",
-        dtype=np.float64,
     )
     R2B05: Final = utils.MuphysExperiment(
         name="R2B05",
         type=utils.ExperimentType.GRAUPEL_ONLY,
         uri="https://polybox.ethz.ch/index.php/s/RBib8rFSEd7Eomo/download/R2B05.tar.gz",
-        dtype=np.float32,
     )
 
 
@@ -91,10 +88,8 @@ def test_graupel_only(
         filename=experiment.reference_file, allocator=model_backends.get_allocator(backend_like)
     )
 
-    # TODO check tolerances
-    rtol = 1e-14 if experiment.dtype == np.float64 else 1e-7
-    atol = 1e-16 if experiment.dtype == np.float64 else 1e-8
-    # TODO we run the float32 input experiments with float64
+    rtol = 1e-14
+    atol = 1e-16
 
     np.testing.assert_allclose(ref.qv.asnumpy(), out.qv.asnumpy(), atol=atol, rtol=rtol)
     np.testing.assert_allclose(ref.qc.asnumpy(), out.qc.asnumpy(), atol=atol, rtol=rtol)

--- a/model/atmosphere/subgrid_scale_physics/muphys/tests/muphys/integration_tests/utils.py
+++ b/model/atmosphere/subgrid_scale_physics/muphys/tests/muphys/integration_tests/utils.py
@@ -12,7 +12,6 @@ import dataclasses
 import enum
 import pathlib
 
-import numpy as np
 import pytest
 
 from icon4py.model.testing import data_handling, definitions as testing_defs
@@ -37,7 +36,6 @@ class MuphysExperiment:
     name: str
     type: ExperimentType
     uri: str
-    dtype: np.dtype
     dt: float = 30.0
     qnc: float = 100.0
 


### PR DESCRIPTION
`dz` was computed in the precision of the input file, therefore graupel did not verify to f64 precision for f32 input files.