### PR TITLE
Update distributed CI testdata path

### DIFF
--- a/ci/distributed.yml
+++ b/ci/distributed.yml
@@ -65,7 +65,7 @@ build_distributed_cpu:
     TEST_DATA_PATH: "/icon4py/testdata"
     ICON4PY_ENABLE_GRID_DOWNLOAD: false
     ICON4PY_ENABLE_TESTDATA_DOWNLOAD: false
-    CSCS_ADDITIONAL_MOUNTS: '["/capstor/store/cscs/userlab/d126/icon4py/ci/testdata_003:$TEST_DATA_PATH"]'
+    CSCS_ADDITIONAL_MOUNTS: '["/capstor/store/cscs/userlab/cwci02/icon4py/ci/testdata:$TEST_DATA_PATH"]'
 
 .test_distributed_aarch64:
   stage: test


### PR DESCRIPTION
Use the cwci02 path instead of the old d126 path. #692 was created before the path was changed, and I didn't think to update it to cwci02 while working on it.