### PR TITLE
Fix `MetricsFieldsFactory` construction in `standalone_driver`

### DIFF
--- a/model/standalone_driver/src/icon4py/model/standalone_driver/driver_utils.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/driver_utils.py
@@ -144,6 +144,8 @@ def create_static_field_factories(
         rayleigh_coeff=0.1,
         exner_expol=0.333,
         vwind_offctr=0.2,
+        thslp_zdiffu=0.02,
+        thhgtd_zdiffu=125.0,
     )
 
     return driver_states.StaticFieldFactories(


### PR DESCRIPTION
#1045 added two more config options to the constructor which were not added to the standalone driver.