### PR TITLE
Remove xfails in distributed metrics tests

### DIFF
--- a/model/common/tests/common/metrics/mpi_tests/test_parallel_metrics.py
+++ b/model/common/tests/common/metrics/mpi_tests/test_parallel_metrics.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
 
 @pytest.mark.datatest
 @pytest.mark.mpi
-@pytest.mark.uses_concat_where
 @pytest.mark.parametrize("processor_props", [True], indirect=True)
 @pytest.mark.parametrize(
     "attrs_name, metrics_name",
@@ -68,8 +67,8 @@ def test_distributed_metrics_attrs(
     metrics_name: str,
     experiment: test_defs.Experiment,
 ) -> None:
-    if attrs_name == attrs.COEFF_GRADEKIN:
-        pytest.xfail("Wrong results")
+    if test_utils.is_embedded(backend) and metrics_name == "ddqz_z_half":
+        pytest.xfail("Embedded backend does not support concat_where")
 
     parallel_helpers.check_comm_size(processor_props)
     parallel_helpers.log_process_properties(processor_props)


### PR DESCRIPTION
`COEFF_GRADEKIN` has fixed itself so removing the xfail. I also tried it locally with #1013 and the GAUSS3D test case also passes for with `COEFF_GRADEKIN`.

I've also reduced the embedded backend xfail to the one field that actually fails.