### PR TITLE
Muphys: configure `t` as inout field

### DIFF
--- a/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/driver/run_graupel_only.py
+++ b/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/driver/run_graupel_only.py
@@ -96,6 +96,7 @@ def main():
             "qr": inp.qr,
             "qs": inp.qs,
             "qg": inp.qg,
+            "t": inp.t,
         }
     else:
         references = None

--- a/model/atmosphere/subgrid_scale_physics/muphys/tests/muphys/integration_tests/test_graupel_only.py
+++ b/model/atmosphere/subgrid_scale_physics/muphys/tests/muphys/integration_tests/test_graupel_only.py
@@ -79,6 +79,7 @@ def test_graupel_only(
             "qr": inp.qr,
             "qs": inp.qs,
             "qg": inp.qg,
+            "t": inp.t,
         },
     )
 


### PR DESCRIPTION
It is possible to use the same `t` field for input and output of the graupel program. This allows us to use the same interface as other implementations in the muphys-ppp project.