### PR TITLE
Fortran bindings: fix numpy allocation and cleanups

### DIFF
--- a/tools/src/icon4py/tools/py2fgen/wrappers/diffusion_wrapper.py
+++ b/tools/src/icon4py/tools/py2fgen/wrappers/diffusion_wrapper.py
@@ -99,6 +99,7 @@ def diffusion_init(
     )
     backend_name = actual_backend.name if hasattr(actual_backend, "name") else actual_backend
     logger.info(f"Using Backend {backend_name} with on_gpu={on_gpu}")
+    allocator = model_backends.get_allocator(actual_backend)
 
     # Diffusion parameters
     config = DiffusionConfig(
@@ -138,13 +139,14 @@ def diffusion_init(
     xp = wgtfac_c.array_ns
 
     if zd_cellidx is None:
-        # then l_zdiffu_t = .false. and these are all not initialized
-        zd_diffcoef = gtx.zeros(cell_k_domain, dtype=theta_ref_mc.dtype)
-        zd_intcoef = gtx.zeros(cell_c2e2c_k_domain, dtype=wgtfac_c.dtype)
-        zd_vertoffset = gtx.zeros(cell_c2e2c_k_domain, dtype=xp.int32)
+        # then zdiffu_t is False or the list on that rank is empty, then all of the following are not initialized
+        assert zd_vertidx is None and zd_intcoef is None and zd_diffcoef is None
+        zd_diffcoef = gtx.zeros(cell_k_domain, dtype=theta_ref_mc.dtype, allocator=allocator)
+        zd_intcoef = gtx.zeros(cell_c2e2c_k_domain, dtype=wgtfac_c.dtype, allocator=allocator)
+        zd_vertoffset = gtx.zeros(cell_c2e2c_k_domain, dtype=xp.int32, allocator=allocator)
     else:
         # transform lists to fields
-        #
+
         # only the first row is needed, the others are for C2E2C neighbors, but slicing in fortran causes issues
         zd_cellidx = zd_cellidx[0, :]
         # these are the three k offsets for the C2E2C neighbors
@@ -160,7 +162,7 @@ def diffusion_init(
                 data_alloc.adjust_fortran_indices(zd_vertidx),
             ),
             default_value=gtx.float64(0.0),
-            allocator=model_backends.get_allocator(actual_backend),
+            allocator=allocator,
         )
         zd_intcoef = data_alloc.list2field(
             domain=cell_c2e2c_k_domain,
@@ -171,7 +173,7 @@ def diffusion_init(
                 data_alloc.adjust_fortran_indices(zd_vertidx),
             ),
             default_value=gtx.float64(0.0),
-            allocator=model_backends.get_allocator(actual_backend),
+            allocator=allocator,
         )
         zd_vertoffset = data_alloc.list2field(
             domain=cell_c2e2c_k_domain,
@@ -182,7 +184,7 @@ def diffusion_init(
                 data_alloc.adjust_fortran_indices(zd_vertidx),
             ),
             default_value=gtx.int32(0),
-            allocator=model_backends.get_allocator(actual_backend),
+            allocator=allocator,
         )
 
     # Metric state
@@ -221,9 +223,7 @@ def diffusion_init(
             backend=actual_backend,
             exchange=grid_wrapper.grid_state.exchange_runtime,
         ),
-        dummy_field_factory=wrapper_common.cached_dummy_field_factory(
-            model_backends.get_allocator(actual_backend)
-        ),
+        dummy_field_factory=wrapper_common.cached_dummy_field_factory(allocator),
     )
 
 

--- a/tools/src/icon4py/tools/py2fgen/wrappers/dycore_wrapper.py
+++ b/tools/src/icon4py/tools/py2fgen/wrappers/dycore_wrapper.py
@@ -135,27 +135,22 @@ def solve_nh_init(
     )
     backend_name = actual_backend.name if hasattr(actual_backend, "name") else actual_backend
     logger.info(f"Using Backend {backend_name} with on_gpu={on_gpu}")
+    allocator = model_backends.get_allocator(actual_backend)
 
-    xp = rho_ref_me.array_ns
-    domain = rho_ref_me.domain
-    default_value = gtx.float64(0.0)
-    if (pg_edgeidx is None) or (pg_vertidx is None) or (pg_exdist is None):
-        # if any of the fields is missing, return a zero field with the correct shape
-        pg_exdist_dsl = gtx.as_field(
-            domain,
-            xp.full(domain.shape, fill_value=default_value, dtype=gtx.float64),
-            allocator=model_backends.get_allocator(actual_backend),
-        )
+    pg_exdist_domain = rho_ref_me.domain
+    if any(field is None for field in [pg_edgeidx, pg_vertidx, pg_exdist]):
+        assert all(field is None for field in [pg_edgeidx, pg_vertidx, pg_exdist])
+        pg_exdist_dsl = gtx.zeros(pg_exdist_domain, dtype=gtx.float64, allocator=allocator)
     else:
         pg_exdist_dsl = data_alloc.list2field(
-            domain=domain,
+            domain=pg_exdist_domain,
             values=pg_exdist,
             indices=(
                 data_alloc.adjust_fortran_indices(pg_edgeidx),
                 data_alloc.adjust_fortran_indices(pg_vertidx),
             ),
-            default_value=default_value,
-            allocator=model_backends.get_allocator(actual_backend),
+            default_value=gtx.float64(0.0),
+            allocator=allocator,
         )
 
     config = solve_nonhydro.NonHydrostaticConfig(
@@ -221,14 +216,10 @@ def solve_nh_init(
         }
     )
     wgtfacq_c = data_alloc.kflip_wgtfacq(
-        arr=wgtfacq_c.ndarray,
-        domain=cell_kflip_domain,
-        allocator=model_backends.get_allocator(actual_backend),
+        arr=wgtfacq_c.ndarray, domain=cell_kflip_domain, allocator=allocator
     )
     wgtfacq_e = data_alloc.kflip_wgtfacq(
-        arr=wgtfacq_e.ndarray,
-        domain=edge_kflip_domain,
-        allocator=model_backends.get_allocator(actual_backend),
+        arr=wgtfacq_e.ndarray, domain=edge_kflip_domain, allocator=allocator
     )
 
     metric_state_nonhydro = dycore_states.MetricStateNonHydro(
@@ -281,9 +272,7 @@ def solve_nh_init(
             backend=actual_backend,
             exchange=grid_wrapper.grid_state.exchange_runtime,
         ),
-        dummy_field_factory=wrapper_common.cached_dummy_field_factory(
-            model_backends.get_allocator(actual_backend)
-        ),
+        dummy_field_factory=wrapper_common.cached_dummy_field_factory(allocator),
     )
 
 


### PR DESCRIPTION
Allocate dummy fields for the correct device as they are still passed via the program interface, even if they are not used.