### PR TITLE
Fix cupy/numpy usage in metis decomposition

### DIFF
--- a/model/common/src/icon4py/model/common/decomposition/decomposer.py
+++ b/model/common/src/icon4py/model/common/decomposition/decomposer.py
@@ -67,7 +67,7 @@ class MetisDecomposer(Decomposer):
         # which avoids Python-side iteration and copies in pymetis._prepare_graph.
         #
         # xadj is an array [0, 3, 6, 9, ...] where xadj[i] is the start index of
-        # vertex i's neighbors, xadj[i+1] is the end index. Each cell always has
+        # cell i's neighbors, xadj[i+1] is the end index. Each cell always has
         # 3 neighbor cells (in global/torus grids).
         _, partition_index = pymetis.part_graph(
             nparts=num_partitions,

--- a/model/common/src/icon4py/model/common/decomposition/decomposer.py
+++ b/model/common/src/icon4py/model/common/decomposition/decomposer.py
@@ -9,6 +9,7 @@
 from typing import Protocol, runtime_checkable
 
 import gt4py.next as gtx
+import numpy as np
 
 from icon4py.model.common.utils import data_allocation as data_alloc
 
@@ -31,11 +32,6 @@ class Decomposer(Protocol):
 class MetisDecomposer(Decomposer):
     """
     A simple decomposer using METIS for partitioning a grid topology.
-
-    We use the simple pythonic interface to pymetis: just passing the adjacency matrix, which for ICON is
-    the full grid C2E2C neigbhor table.
-    if more control is needed (for example by using weights we need to switch to the C like interface)
-    https://documen.tician.de/pymetis/functionality.html
     """
 
     def __call__(
@@ -56,13 +52,27 @@ class MetisDecomposer(Decomposer):
 
         import pymetis  # type: ignore [import-untyped]
 
+        adjacency_matrix = data_alloc.as_numpy(adjacency_matrix)
+
         # Invalid indices are not allowed here. Metis will segfault or fail if
         # there are any invalid indices in the adjacency matrix.
         assert (adjacency_matrix >= 0).all()
 
         # The partitioning is done on all ranks, and this assumes that the
         # partitioning is deterministic.
-        _, partition_index = pymetis.part_graph(nparts=num_partitions, adjacency=adjacency_matrix)
+        #
+        # Passes the adjacency matrix in CSR format (xadj/adjncy) to pymetis,
+        # which avoids Python-side iteration and copies in pymetis._prepare_graph.
+        #
+        # xadj is an array [0, 3, 6, 9, ...] where xadj[i] is the start index of
+        # vertex i's neighbors, xadj[i+1] is the end index. Each cell always has
+        # 3 neighbor cells (in global/torus grids).
+        _, partition_index = pymetis.part_graph(
+            nparts=num_partitions,
+            xadj=np.arange(adjacency_matrix.shape[0] + 1, dtype=np.int32)
+            * adjacency_matrix.shape[1],
+            adjncy=adjacency_matrix.ravel(),
+        )
         return data_alloc.array_namespace(adjacency_matrix).array(partition_index)
 
 

--- a/model/common/src/icon4py/model/common/decomposition/decomposer.py
+++ b/model/common/src/icon4py/model/common/decomposition/decomposer.py
@@ -52,11 +52,13 @@ class MetisDecomposer(Decomposer):
 
         import pymetis  # type: ignore [import-untyped]
 
-        adjacency_matrix = data_alloc.as_numpy(adjacency_matrix)
-
         # Invalid indices are not allowed here. Metis will segfault or fail if
         # there are any invalid indices in the adjacency matrix.
         assert (adjacency_matrix >= 0).all()
+
+        # Explicitly move to CPU before passing to Metis, Metis only runs on
+        # CPU.
+        adjacency_matrix_np = data_alloc.as_numpy(adjacency_matrix)
 
         # The partitioning is done on all ranks, and this assumes that the
         # partitioning is deterministic.
@@ -69,9 +71,9 @@ class MetisDecomposer(Decomposer):
         # 3 neighbor cells (in global/torus grids).
         _, partition_index = pymetis.part_graph(
             nparts=num_partitions,
-            xadj=np.arange(adjacency_matrix.shape[0] + 1, dtype=np.int32)
-            * adjacency_matrix.shape[1],
-            adjncy=adjacency_matrix.ravel(),
+            xadj=np.arange(adjacency_matrix_np.shape[0] + 1, dtype=np.int32)
+            * adjacency_matrix_np.shape[1],
+            adjncy=adjacency_matrix_np.ravel(),
         )
         return data_alloc.array_namespace(adjacency_matrix).array(partition_index)
 

--- a/model/common/src/icon4py/model/common/decomposition/decomposer.py
+++ b/model/common/src/icon4py/model/common/decomposition/decomposer.py
@@ -66,9 +66,13 @@ class MetisDecomposer(Decomposer):
         # Passes the adjacency matrix in CSR format (xadj/adjncy) to pymetis,
         # which avoids Python-side iteration and copies in pymetis._prepare_graph.
         #
-        # xadj is an array [0, 3, 6, 9, ...] where xadj[i] is the start index of
-        # cell i's neighbors, xadj[i+1] is the end index. Each cell always has
-        # 3 neighbor cells (in global/torus grids).
+        # adjncy is flattened array of the cell neighbors. The first three
+        # entries contain the neighbors of cell 0, the next three neighbors of
+        # cell 1, and so on. xadj contains the indices where the ith cell's
+        # neighbors start in adjncy. Since we only support global/torus grids at
+        # the moment, every cell always has three neighbors. xadj will always be
+        # [0, 3, 6, 9, ...] because the first cell's neighbors are at indices 0
+        # to 2, the second cell's neighbors are at indices 3 to 5, and so on.
         _, partition_index = pymetis.part_graph(
             nparts=num_partitions,
             xadj=np.arange(adjacency_matrix_np.shape[0] + 1, dtype=np.int32)


### PR DESCRIPTION
A big slowdown in metis decomposition with GPU backends comes from metis restructuring the c2e2c adjacency matrix that we pass into a format for internal use. If I understand correctly, pymetis happens to work with cupy arrays because of this indexing: https://github.com/inducer/pymetis/blob/1db6cd1d189ddda75b80cb24125c0e9de88d79d8/pymetis/__init__.py#L358. This accesses a single element from the cupy array which is brought back to the host as a scalar.

This is of course extremely slow with cupy arrays. This PR makes sure we only pass numpy arrays to pymetis.

Additionally, this changes the call to pymetis to use the lower level interface where pymetis doesn't have to transform the adjacency matrix to a format used by metis. We can do this a lot faster because, at the moment, we only support global and torus grids, which always have full connectivity (three neighbors for every cell). With this assumption we can do the setup a lot faster than what pymetis can do with weaker assumptions. When we support limited area grids we'll have to revisit this setup, but even if we use the adjacency matrix interface the major speedup comes from the cupy/numpy fix.

I did a small test using the standalone benchmark script in https://gist.github.com/msimberg/84ad8195688d3edca08c8ef839e3a0f8. It compares:
- passing a cupy array directly to pymetis
- converting to numpy
- converting to a list (this is what pymetis really wants, but it works with arrays as well)
- using the low level API

On one GH200 module it outputs the following for a random 1000000 vertex graph:

| array_lib  |  n_cells | nparts | method                   | total (ms) | prep (ms) |
|------------|----------|--------|--------------------------|------------|-----------|
| cupy       |  1000000 |      4 | adjacency=xp (no conv)   |  117225.73 |         - |
| cupy       |  1000000 |      4 | adjacency=ndarray        |    4538.66 |    0.0842 |
| cupy       |  1000000 |      4 | adjacency=list           |    2687.75 |  374.5756 |
| cupy       |  1000000 |      4 | xadj/adjncy (CSR)        |    2380.84 |    0.4656 |

The graph is random (not a real icon grid), but is likely representative enough to conclude: the implicit cupy array access is expensive.

Just for completeness, using numpy for everything the timings are:

| array_lib  |  n_cells | nparts | method                   | total (ms) | prep (ms) |
|------------|----------|--------|--------------------------|------------|-----------|
| numpy      |  1000000 |      4 | adjacency=xp (no conv)   |    4418.93 |         - |
| numpy      |  1000000 |      4 | adjacency=ndarray        |    4551.28 |    0.0001 |
| numpy      |  1000000 |      4 | adjacency=list           |    2742.63 |  353.4515 |
| numpy      |  1000000 |      4 | xadj/adjncy (CSR)        |    2375.42 |    0.3910 |

So the slowdown is not just from the `no conv` path running first or similar.