### PR TITLE
Fix typo in field names in driver_utils.py

### DIFF
--- a/model/standalone_driver/src/icon4py/model/standalone_driver/driver_utils.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/driver_utils.py
@@ -194,7 +194,7 @@ def initialize_granules(
         primal_normal_vert_x=geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_U),
         primal_normal_vert_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
         dual_normal_vert_x=geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_U),
-        dual_normal_vert_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
+        dual_normal_vert_y=geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_V),
         primal_normal_cell_x=geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_U),
         dual_normal_cell_x=geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_U),
         primal_normal_cell_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_V),


### PR DESCRIPTION
The wrong field was used to initialize dual_normal_vert_y.

The bug was found by GLM 5.1: https://hackmd.io/cuEsccnkTniYTn0ABCa7LQ?view#H6-dual_normal_vert_y-uses-wrong-geometry-attribute-normal-vs-tangent.

Note that I'm not changing the names of the members in EdgeParams to use u/v instead of x/y as initially discussed. The *_x/y suffixes are as in ICON fortran and the dual_normal_vert etc. names also come from ICON fortran. If we change x/y then the whole name should be changed in one go, so I'm leaving that unchanged right now.

This change does not change the comparison to ICON fortran serialized data.