### PR TITLE
Fix typo in EDGE_TANGENT_Z definition

### DIFF
--- a/model/common/src/icon4py/model/common/grid/geometry_attributes.py
+++ b/model/common/src/icon4py/model/common/grid/geometry_attributes.py
@@ -266,7 +266,7 @@ attrs: dict[str, model.FieldMetaData] = {
         dtype=ta.wpfloat,
     ),
     EDGE_TANGENT_Z: dict(
-        standard_name=EDGE_NORMAL_Z,
+        standard_name=EDGE_TANGENT_Z,
         long_name=EDGE_TANGENT_Z,
         units="m",
         dims=(dims.EdgeDim,),


### PR DESCRIPTION
The standard_name was wrong. Should have no effect on correctness.

https://hackmd.io/1A31VydfR5KZd1SKRuYCMQ#51-Bugs