### PR TITLE
Fix dead assertions in pytest.raises blocks

### DIFF
--- a/model/common/tests/common/grid/unit_tests/test_geometry.py
+++ b/model/common/tests/common/grid/unit_tests/test_geometry.py
@@ -48,10 +48,8 @@ def test_geometry_raises_for_unknown_field(
     backend: gtx_typing.Backend, experiment: definitions.Experiment
 ) -> None:
     geometry = grid_utils.get_grid_geometry(backend, experiment)
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="Field 'foo' not provided by the source"):
         geometry.get("foo")
-        assert "'foo'" in e.value  # type: ignore[operator]
-        assert "'GridGeometry'" in e.value  # type: ignore[operator]
 
 
 @pytest.mark.parametrize(

--- a/model/common/tests/common/grid/unit_tests/test_grid_manager.py
+++ b/model/common/tests/common/grid/unit_tests/test_grid_manager.py
@@ -352,14 +352,13 @@ def test_gridmanager_given_file_not_found_then_abort(
     cpu_allocator: gtx_typing.Allocator,
 ) -> None:
     fname = "./unknown_grid.nc"
-    with pytest.raises(FileNotFoundError) as error:
+    with pytest.raises(FileNotFoundError):
         manager = gm.GridManager(
             grid_file=fname,
             config=v_grid.VerticalGridConfig(num_levels=80),
             offset_transformation=icon4py.model.common.grid.gridfile.NoTransformation(),
         )
         manager(allocator=cpu_allocator, keep_skip_values=True)
-        assert error.value == 1
 
 
 @pytest.mark.parametrize("size", [100, 1500, 20000])

--- a/model/common/tests/common/grid/unit_tests/test_horizontal.py
+++ b/model/common/tests/common/grid/unit_tests/test_horizontal.py
@@ -29,9 +29,8 @@ log = logging.getLogger(__name__)
 
 @pytest.mark.parametrize("dim", utils.non_horizontal_dims())
 def test_domain_raises_for_non_horizontal_dim(dim: gtx.Dimension) -> None:
-    with pytest.raises(AssertionError) as e:
+    with pytest.raises(AssertionError, match="horizontal dimensions"):
         h_grid.domain(dim)
-    e.match("horizontal dimensions")
 
 
 def zones() -> Iterator[h_grid.Zone]:
@@ -47,9 +46,8 @@ def test_domain_raises_for_invalid_zones(dim: gtx.Dimension, zone: h_grid.Zone) 
             h_grid.Zone.LATERAL_BOUNDARY_LEVEL_6,
             h_grid.Zone.LATERAL_BOUNDARY_LEVEL_7,
         ):
-            with pytest.raises(AssertionError) as e:
+            with pytest.raises(AssertionError, match="Invalid zone"):
                 h_grid.domain(dim)(zone)
-            e.match("Invalid zone")
 
 
 @pytest.mark.parametrize("zone", zones())

--- a/model/common/tests/common/grid/unit_tests/test_icon.py
+++ b/model/common/tests/common/grid/unit_tests/test_icon.py
@@ -77,6 +77,7 @@ LATERAL_BOUNDARY_IDX = {
 NUDGING_IDX = {
     dims.CellDim: [3316, 4104],
     dims.EdgeDim: [4989, 5387, 6176],
+    dims.VertexDim: [1673, 2071],
 }
 HALO_IDX = {
     dims.CellDim: [20896, 20896],
@@ -148,7 +149,7 @@ def test_end(grid: base_grid.Grid, dim: gtx.Dimension) -> None:
 @pytest.mark.parametrize("dim", utils.main_horizontal_dims())
 def test_nudging(grid: base_grid.Grid, dim: gtx.Dimension, marker: h_grid.Zone) -> None:
     num = int(next(iter(re.findall(r"\d+", marker.value))))
-    if dim == dims.VertexDim or (dim == dims.CellDim and num > 1):
+    if dim in (dims.VertexDim, dims.CellDim) and num > 1:
         with pytest.raises(AssertionError, match=f"Invalid zone {marker} for dimension"):
             h_grid.domain(dim)(marker)
     else:

--- a/model/common/tests/common/grid/unit_tests/test_icon.py
+++ b/model/common/tests/common/grid/unit_tests/test_icon.py
@@ -125,7 +125,7 @@ def test_local(dim: gtx.Dimension, grid: base_grid.Grid) -> None:
 def test_lateral_boundary(grid: base_grid.Grid, dim: gtx.Dimension, marker: h_grid.Zone) -> None:
     num = int(next(iter(re.findall(r"\d+", marker.value))))
     if num > 4 and dim in (dims.VertexDim, dims.CellDim):
-        with pytest.raises(AssertionError, match=f"Invalid marker '{marker}' for dimension"):
+        with pytest.raises(AssertionError, match=f"Invalid zone {marker} for dimension"):
             h_grid.domain(dim)(marker)
     else:
         domain = h_grid.domain(dim)(marker)
@@ -149,7 +149,7 @@ def test_end(grid: base_grid.Grid, dim: gtx.Dimension) -> None:
 def test_nudging(grid: base_grid.Grid, dim: gtx.Dimension, marker: h_grid.Zone) -> None:
     num = int(next(iter(re.findall(r"\d+", marker.value))))
     if dim == dims.VertexDim or (dim == dims.CellDim and num > 1):
-        with pytest.raises(AssertionError, match="Invalid marker '{marker}' for dimension"):
+        with pytest.raises(AssertionError, match=f"Invalid zone {marker} for dimension"):
             h_grid.domain(dim)(marker)
     else:
         domain = h_grid.domain(dim)(marker)

--- a/model/common/tests/common/grid/unit_tests/test_icon.py
+++ b/model/common/tests/common/grid/unit_tests/test_icon.py
@@ -125,9 +125,8 @@ def test_local(dim: gtx.Dimension, grid: base_grid.Grid) -> None:
 def test_lateral_boundary(grid: base_grid.Grid, dim: gtx.Dimension, marker: h_grid.Zone) -> None:
     num = int(next(iter(re.findall(r"\d+", marker.value))))
     if num > 4 and dim in (dims.VertexDim, dims.CellDim):
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(AssertionError, match=f"Invalid marker '{marker}' for dimension"):
             h_grid.domain(dim)(marker)
-            e.match(f"Invalid marker '{marker}' for dimension")
     else:
         domain = h_grid.domain(dim)(marker)
         start_index = grid.start_index(domain)
@@ -150,9 +149,8 @@ def test_end(grid: base_grid.Grid, dim: gtx.Dimension) -> None:
 def test_nudging(grid: base_grid.Grid, dim: gtx.Dimension, marker: h_grid.Zone) -> None:
     num = int(next(iter(re.findall(r"\d+", marker.value))))
     if dim == dims.VertexDim or (dim == dims.CellDim and num > 1):
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(AssertionError, match="Invalid marker '{marker}' for dimension"):
             h_grid.domain(dim)(marker)
-            e.match(f"Invalid marker '{marker}' for dimension")
     else:
         domain = h_grid.domain(dim)(marker)
         start_index = grid.start_index(domain)

--- a/model/common/tests/common/interpolation/unit_tests/test_interpolation_factory.py
+++ b/model/common/tests/common/interpolation/unit_tests/test_interpolation_factory.py
@@ -96,9 +96,8 @@ def test_factory_raises_error_on_unknown_field(
         backend=backend,
         metadata=attrs.attrs,
     )
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(ValueError, match="Field 'foo' not provided by the source"):
         interpolation_source.get("foo", factory.RetrievalType.METADATA)
-        assert "unknown field" in str(error.value)
 
 
 @pytest.mark.level("integration")

--- a/model/common/tests/common/states/unit_tests/test_factory.py
+++ b/model/common/tests/common/states/unit_tests/test_factory.py
@@ -213,9 +213,8 @@ def test_field_source_raise_error_on_register(cell_coordinate_source: SimpleFiel
     provider = factory.ProgramFieldProvider(
         func=program, domain=domain, fields=fields, deps=deps, do_exchange=False
     )
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match="Missing dependency: 'height_coordinate'"):
         cell_coordinate_source.register_provider(provider)
-        assert "not provided by source " in err.value  # type: ignore[operator]
 
 
 @pytest.mark.datatest
@@ -297,9 +296,8 @@ def test_composite_field_source_raises_upon_get_unknown_field(
     composite = factory.CompositeSource(
         test_source, (cell_coordinate_source, height_coordinate_source)
     )
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match="Field 'alice' not provided by the source"):
         composite.get("alice")
-        assert "not provided by source " in err.value  # type: ignore[operator]
 
 
 def reduce_scalar_min(ar: data_alloc.NDArray, xp: ModuleType) -> gtx.float:


### PR DESCRIPTION
https://hackmd.io/cuEsccnkTniYTn0ABCa7LQ?both#H8-Unreachable-assertions-inside-pytestraises-blocks-multiple-locations

The assertions were never run, because the tests are supposed to test that an exception is raised. This changes the tests to use pytest.raise's match keyword instead.