### PR TITLE
Fix default nox sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ import nox
 
 # -- nox configuration --
 nox.options.default_venv_backend = "uv"
-nox.options.sessions = ["test_model", "test_bindings_and_tools"]
+nox.options.sessions = ["test_model", "test_tools_and_bindings"]
 
 
 # -- Parameter sets --


### PR DESCRIPTION
The session is called `test_tools_and_bindings`, not `test_bindings_and_tools`. A plain `nox` would fail with:

```bash
> nox
nox > Error while collecting sessions.
nox > Sessions not found: test_bindings_and_tools
```

https://hackmd.io/cuEsccnkTniYTn0ABCa7LQ?both#H10-Nox-session-name-mismatch