### PR TITLE
Fix license specification in muphys pyproject.toml

### DIFF
--- a/model/atmosphere/subgrid_scale_physics/muphys/pyproject.toml
+++ b/model/atmosphere/subgrid_scale_physics/muphys/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "packaging>=20.0"
 ]
 description = "ICON subgrid scale muphys parameterization."
-license = {file = "BSD-3 License"}
+license = {text = "BSD-3 License"}
 name = "icon4py-atmosphere-muphys"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Use "text" instead of "file", as in other pyproject.toml files.

https://hackmd.io/cuEsccnkTniYTn0ABCa7LQ?both#H11-muphys-pyprojecttoml-license-points-to-non-existent-file