### PR TITLE
Make grid and testdata download explicitly true

### DIFF
--- a/.github/workflows/icon4py-test-model.yml
+++ b/.github/workflows/icon4py-test-model.yml
@@ -12,8 +12,8 @@ on:
 env:
   ICON4PY_TEST_DATA_PATH: "${{ github.workspace }}/testdata"
   NUM_PROCESSES: auto
-  ICON4PY_ENABLE_GRID_DOWNLOAD: true
-  ICON4PY_ENABLE_TESTDATA_DOWNLOAD: true
+  ICON4PY_ENABLE_GRID_DOWNLOAD: false
+  ICON4PY_ENABLE_TESTDATA_DOWNLOAD: false
   PYTEST_ADDOPTS: "--durations=0"
 
 jobs:

--- a/.github/workflows/icon4py-test-model.yml
+++ b/.github/workflows/icon4py-test-model.yml
@@ -12,8 +12,8 @@ on:
 env:
   ICON4PY_TEST_DATA_PATH: "${{ github.workspace }}/testdata"
   NUM_PROCESSES: auto
-  ICON4PY_ENABLE_GRID_DOWNLOAD: false
-  ICON4PY_ENABLE_TESTDATA_DOWNLOAD: false
+  ICON4PY_ENABLE_GRID_DOWNLOAD: true
+  ICON4PY_ENABLE_TESTDATA_DOWNLOAD: true
   PYTEST_ADDOPTS: "--durations=0"
 
 jobs:

--- a/ci/benchmark_bencher_common.yml
+++ b/ci/benchmark_bencher_common.yml
@@ -1,7 +1,7 @@
 .benchmark_model_base_variables:
   variables:
-    ICON4PY_ENABLE_GRID_DOWNLOAD: false
-    ICON4PY_ENABLE_TESTDATA_DOWNLOAD: false
+    ICON4PY_ENABLE_GRID_DOWNLOAD: true
+    ICON4PY_ENABLE_TESTDATA_DOWNLOAD: true
     GT4PY_UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE: true
     PYTHONOPTIMIZE: 2
     STENCIL_TEST_SELECTION: "test_Test and compile_time_domain"

--- a/ci/docker/base.Dockerfile
+++ b/ci/docker/base.Dockerfile
@@ -57,7 +57,7 @@ RUN wget -q ${HPC_SDK_URL} -O /tmp/nvhpc.tar.gz && \
 ENV NVHPC_SILENT=true
 ENV NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk
 ENV NVHPC_INSTALL_TYPE=single
-RUN cd /opt/nvidia/${HPC_SDK_NAME} && sudo bash -x ./install
+RUN cd /opt/nvidia/${HPC_SDK_NAME} && bash -x ./install
 
 # Set environment variables
 ARG ARCH=aarch64

--- a/ci/docker/base.Dockerfile
+++ b/ci/docker/base.Dockerfile
@@ -57,7 +57,7 @@ RUN wget -q ${HPC_SDK_URL} -O /tmp/nvhpc.tar.gz && \
 ENV NVHPC_SILENT=true
 ENV NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk
 ENV NVHPC_INSTALL_TYPE=single
-RUN cd /opt/nvidia/${HPC_SDK_NAME} && ./install
+RUN cd /opt/nvidia/${HPC_SDK_NAME} && sudo bash -x ./install
 
 # Set environment variables
 ARG ARCH=aarch64

--- a/ci/docker/base.Dockerfile
+++ b/ci/docker/base.Dockerfile
@@ -38,7 +38,7 @@ RUN rustc --version && which rustc && cargo --version && which cargo
 
 # Install Bencher for performance monitoring
 # Update the following comment to trigger a rebuild  to update the CLI:
-# last update: 2025-11-25
+# last update: 2026-5-11
 # This is necessary because the cloud version and the CLI version have to match
 # but obviously, version changes do not register in the Dockerfile hash.
 RUN curl --proto '=https' --tlsv1.2 -sSfL https://bencher.dev/download/install-cli.sh | sh

--- a/ci/docker/base.Dockerfile
+++ b/ci/docker/base.Dockerfile
@@ -45,22 +45,22 @@ RUN curl --proto '=https' --tlsv1.2 -sSfL https://bencher.dev/download/install-c
 RUN bencher --version && which bencher
 
 # Install NVIDIA HPC SDK for nvfortran
+ARG ARCH=aarch64
 ARG HPC_SDK_VERSION=24.11
-ARG HPC_SDK_NAME=nvhpc_2024_2411_Linux_aarch64_cuda_12.6
+ARG HPC_SDK_NAME=nvhpc_2024_2411_Linux_${ARCH}_cuda_12.6
 ENV HPC_SDK_URL=https://developer.download.nvidia.com/hpc-sdk/${HPC_SDK_VERSION}/${HPC_SDK_NAME}.tar.gz
-
-RUN wget -q ${HPC_SDK_URL} -O /tmp/nvhpc.tar.gz && \
-    mkdir -p /opt/nvidia && \
-    tar -xzf /tmp/nvhpc.tar.gz -C /opt/nvidia && \
-    rm /tmp/nvhpc.tar.gz
 
 ENV NVHPC_SILENT=true
 ENV NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk
 ENV NVHPC_INSTALL_TYPE=single
-RUN cd /opt/nvidia/${HPC_SDK_NAME} && bash -x ./install
+RUN wget -q ${HPC_SDK_URL} -O /tmp/nvhpc.tar.gz && \
+    mkdir -p /opt/nvidia && \
+    tar -xzf /tmp/nvhpc.tar.gz -C /opt/nvidia && \
+    rm /tmp/nvhpc.tar.gz && \
+    cd /opt/nvidia/${HPC_SDK_NAME} && ./install && \
+    rm -rf /opt/nvidia/${HPC_SDK_NAME}
 
 # Set environment variables
-ARG ARCH=aarch64
 ENV HPC_SDK_PATH=/opt/nvidia/hpc_sdk/Linux_${ARCH}/${HPC_SDK_VERSION}
 # The variable CUDA_PATH is used by cupy to find the cuda toolchain
 ENV CUDA_PATH=${HPC_SDK_PATH}/cuda \

--- a/ci/docker/base.Dockerfile
+++ b/ci/docker/base.Dockerfile
@@ -54,7 +54,9 @@ RUN wget -q ${HPC_SDK_URL} -O /tmp/nvhpc.tar.gz && \
     tar -xzf /tmp/nvhpc.tar.gz -C /opt/nvidia && \
     rm /tmp/nvhpc.tar.gz
 
-ENV NVHPC_SILENT=1
+ENV NVHPC_SILENT=true
+ENV NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk
+ENV NVHPC_INSTALL_TYPE=single
 RUN cd /opt/nvidia/${HPC_SDK_NAME} && ./install
 
 # Set environment variables


### PR DESCRIPTION
- Fixes bencher CI issue: https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/5125340235196978/2255149825504672/-/jobs/14297540064
```
    def _download_grid_file(grid: definitions.GridDescription) -> pathlib.Path:
        full_name = dt_utils.get_grid_filepath(grid)
        grid_directory = full_name.parent
        grid_directory.mkdir(parents=True, exist_ok=True)
        if config.ENABLE_GRID_DOWNLOAD:
            uri = dt_utils.get_grid_archive_url(definitions.TESTDATA_ROOT_URL, grid)
            data_handling.download_and_extract(
                uri,
                grid_directory,
            )
        else:
            # If grid download is disabled, we check if the file exists
            # without locking. We assume the location is managed by the user
            # and avoid locking shared directories (e.g. on CI).
            if not full_name.exists():
>               raise FileNotFoundError(
                    f"Grid file {full_name} does not exist and grid download is disabled."
                )
E               FileNotFoundError: Grid file /icon4py/testdata/grids/icon_grid_0021_R02B06_G/icon_grid_0021_R02B06_G.nc does not exist and grid download is disabled.
```
- Update bencher version