### PR TITLE
Check completion marker on downloads before taking lock

### DIFF
--- a/model/testing/src/icon4py/model/testing/data_handling.py
+++ b/model/testing/src/icon4py/model/testing/data_handling.py
@@ -42,6 +42,9 @@ def download_and_extract(
     completion_marker = dst / ".extraction_complete"
     lockfile = "filelock.lock"
 
+    if completion_marker.exists():
+        return
+
     with locking.lock(dst, lockfile=lockfile):
         if completion_marker.exists():
             return


### PR DESCRIPTION
This avoids unnecessarily taking the file lock when the data is already downloaded.