### PR TITLE
Populate uv cache in CSCS CI checkout job

### DIFF
--- a/ci/docker/checkout.Dockerfile
+++ b/ci/docker/checkout.Dockerfile
@@ -1,5 +1,19 @@
 ARG BASE_IMAGE
-ARG PYVERSION
 FROM $BASE_IMAGE
 
 COPY . /icon4py
+WORKDIR /icon4py
+
+ARG PYVERSION
+ENV UV_CACHE_DIR=/opt/uv-cache
+RUN uv sync \
+    --no-dev \
+    --extra cuda12 \
+    --extra fortran \
+    --extra io \
+    --extra profiling \
+    --extra testing \
+    --group test \
+    --python $PYVERSION && \
+    rm -rf .venv && \
+    chmod -R a+rwX "$UV_CACHE_DIR"


### PR DESCRIPTION
Avoid each test job having to rebuild all common dependencies.