### PR TITLE
Bump version to 0.2.0rc1

### DIFF
--- a/bindings/pyproject.toml
+++ b/bindings/pyproject.toml
@@ -59,8 +59,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py-bindings version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/bindings/pyproject.toml
+++ b/bindings/pyproject.toml
@@ -24,11 +24,11 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  'icon4py-atmosphere-diffusion~=0.1.0',
-  'icon4py-atmosphere-dycore~=0.1.0',
-  'icon4py-atmosphere-muphys~=0.1.0',
-  'icon4py-common~=0.1.0',
-  'icon4py-tools~=0.1.0',
+  'icon4py-atmosphere-diffusion~=0.2.0rc1',
+  'icon4py-atmosphere-dycore~=0.2.0rc1',
+  'icon4py-atmosphere-muphys~=0.2.0rc1',
+  'icon4py-common~=0.2.0rc1',
+  'icon4py-tools~=0.2.0rc1',
   # external dependencies
   'cffi>=1.5',
   'click>=8.0',
@@ -42,7 +42,7 @@ name = 'icon4py-bindings'
 readme = 'README.md'
 requires-python = '>=3.10'
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.optional-dependencies]
 cuda11 = ['cupy-cuda11x>=13.0', 'gt4py[cuda11]']
@@ -56,7 +56,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py-bindings version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/bindings/src/icon4py/bindings/__init__.py
+++ b/bindings/src/icon4py/bindings/__init__.py
@@ -25,5 +25,5 @@ __author__: Final = "ETH Zurich,  MeteoSwiss and individual contributors"
 __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
-__version__: Final = "0.1.0"
+__version__: Final = "0.2.0rc1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/advection/pyproject.toml
+++ b/model/atmosphere/advection/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.1.0",
+  "icon4py-common~=0.2.0rc1",
   # external dependencies
   "gt4py==1.1.9",
   'packaging>=20.0'
@@ -35,7 +35,7 @@ name = "icon4py-atmosphere-advection"
 readme = "README.md"
 requires-python = ">=3.10"
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -44,7 +44,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-advection version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/advection/pyproject.toml
+++ b/model/atmosphere/advection/pyproject.toml
@@ -47,8 +47,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-advection version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/model/atmosphere/advection/src/icon4py/model/atmosphere/advection/__init__.py
+++ b/model/atmosphere/advection/src/icon4py/model/atmosphere/advection/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.1.0"
+__version__: Final = "0.2.0rc1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/diffusion/pyproject.toml
+++ b/model/atmosphere/diffusion/pyproject.toml
@@ -47,8 +47,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-diffusion version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/model/atmosphere/diffusion/pyproject.toml
+++ b/model/atmosphere/diffusion/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.1.0",
+  "icon4py-common~=0.2.0rc1",
   # external dependencies
   "gt4py==1.1.9",
   'packaging>=20.0'
@@ -35,7 +35,7 @@ name = "icon4py-atmosphere-diffusion"
 readme = "README.md"
 requires-python = ">=3.10"
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -44,7 +44,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-diffusion version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/__init__.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.1.0"
+__version__: Final = "0.2.0rc1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/dycore/pyproject.toml
+++ b/model/atmosphere/dycore/pyproject.toml
@@ -47,8 +47,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-dycore version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/model/atmosphere/dycore/pyproject.toml
+++ b/model/atmosphere/dycore/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.1.0",
+  "icon4py-common~=0.2.0rc1",
   # external dependencies
   "gt4py==1.1.9",
   'packaging>=20.0'
@@ -35,7 +35,7 @@ name = "icon4py-atmosphere-dycore"
 readme = "README.md"
 requires-python = ">=3.10"
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -44,7 +44,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-dycore version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/__init__.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.1.0"
+__version__: Final = "0.2.0rc1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/subgrid_scale_physics/microphysics/pyproject.toml
+++ b/model/atmosphere/subgrid_scale_physics/microphysics/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.1.0",
+  "icon4py-common~=0.2.0rc1",
   # external dependencies
   "gt4py==1.1.9",
   'packaging>=20.0'
@@ -35,7 +35,7 @@ name = "icon4py-atmosphere-microphysics"
 readme = "README.md"
 requires-python = ">=3.10"
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -44,7 +44,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-microphysics version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/subgrid_scale_physics/microphysics/pyproject.toml
+++ b/model/atmosphere/subgrid_scale_physics/microphysics/pyproject.toml
@@ -47,8 +47,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-microphysics version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/model/atmosphere/subgrid_scale_physics/microphysics/src/icon4py/model/atmosphere/subgrid_scale_physics/microphysics/__init__.py
+++ b/model/atmosphere/subgrid_scale_physics/microphysics/src/icon4py/model/atmosphere/subgrid_scale_physics/microphysics/__init__.py
@@ -26,5 +26,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.1.0"
+__version__: Final = "0.2.0rc1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/subgrid_scale_physics/muphys/pyproject.toml
+++ b/model/atmosphere/subgrid_scale_physics/muphys/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common[io]~=0.1.0",
+  "icon4py-common[io]~=0.2.0rc1",
   # external dependencies
   "numpy>=1.23.3",
   "gt4py==1.1.9",
@@ -36,7 +36,7 @@ name = "icon4py-atmosphere-muphys"
 readme = "README.md"
 requires-python = ">=3.10"
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.urls]
 repository = "https://github.com/C2SM/icon4py"
@@ -45,7 +45,7 @@ repository = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-muphys version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/subgrid_scale_physics/muphys/pyproject.toml
+++ b/model/atmosphere/subgrid_scale_physics/muphys/pyproject.toml
@@ -48,8 +48,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-muphys version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/__init__.py
+++ b/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/__init__.py
@@ -26,5 +26,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.1.0"
+__version__: Final = "0.2.0rc1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/common/pyproject.toml
+++ b/model/common/pyproject.toml
@@ -71,8 +71,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py-common version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/model/common/pyproject.toml
+++ b/model/common/pyproject.toml
@@ -36,7 +36,7 @@ name = "icon4py-common"
 readme = "README.md"
 requires-python = ">=3.10"
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.optional-dependencies]
 all = ["icon4py-common[distributed,io]"]
@@ -68,7 +68,7 @@ repository = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py-common version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/common/src/icon4py/model/common/__init__.py
+++ b/model/common/src/icon4py/model/common/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.1.0"
+__version__: Final = "0.2.0rc1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/driver/pyproject.toml
+++ b/model/driver/pyproject.toml
@@ -56,8 +56,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py-driver version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/model/driver/pyproject.toml
+++ b/model/driver/pyproject.toml
@@ -24,10 +24,10 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-atmosphere-dycore~=0.1.0",
-  "icon4py-atmosphere-diffusion~=0.1.0",
-  "icon4py-common~=0.1.0",
-  "icon4py-testing~=0.1.0",  # TODO(): remove this dependency when driver is fully standalone
+  "icon4py-atmosphere-dycore~=0.2.0rc1",
+  "icon4py-atmosphere-diffusion~=0.2.0rc1",
+  "icon4py-common~=0.2.0rc1",
+  "icon4py-testing~=0.2.0rc1",  # TODO(): remove this dependency when driver is fully standalone
   # external dependencies
   "click>=8.0.1",
   "devtools>=0.12",
@@ -41,7 +41,7 @@ name = "icon4py-driver"
 readme = "README.md"
 requires-python = ">=3.10"
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.scripts]
 icon4py_driver = "icon4py.model.driver.icon4py_driver:main"
@@ -53,7 +53,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py-driver version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/driver/src/icon4py/model/driver/__init__.py
+++ b/model/driver/src/icon4py/model/driver/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.1.0"
+__version__: Final = "0.2.0rc1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/standalone_driver/pyproject.toml
+++ b/model/standalone_driver/pyproject.toml
@@ -24,10 +24,10 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-atmosphere-dycore~=0.1.0",
-  "icon4py-atmosphere-diffusion~=0.1.0",
-  "icon4py-common~=0.1.0",
-  "icon4py-testing~=0.1.0",  # TODO(): remove this dependency when driver is fully standalone
+  "icon4py-atmosphere-dycore~=0.2.0rc1",
+  "icon4py-atmosphere-diffusion~=0.2.0rc1",
+  "icon4py-common~=0.2.0rc1",
+  "icon4py-testing~=0.2.0rc1",  # TODO(): remove this dependency when driver is fully standalone
   # external dependencies
   "typer>=0.20.0",
   "devtools>=0.12",
@@ -40,7 +40,7 @@ name = "icon4py-standalone_driver"
 readme = "README.md"
 requires-python = ">=3.10"
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.scripts]
 icon4py-standalone-driver = "icon4py.model.standalone_driver.main:click"  # TODO (Yilu): change the name (remove the standalone) when it becomes the main driver
@@ -52,7 +52,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py-standalone_driver version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/standalone_driver/pyproject.toml
+++ b/model/standalone_driver/pyproject.toml
@@ -55,8 +55,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py-standalone_driver version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/__init__.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.1.0"
+__version__: Final = "0.2.0rc1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/testing/pyproject.toml
+++ b/model/testing/pyproject.toml
@@ -53,8 +53,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py-testing version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/model/testing/pyproject.toml
+++ b/model/testing/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  'icon4py-common[io]~=0.1.0',
+  'icon4py-common[io]~=0.2.0rc1',
   # external dependencies
   "filelock>=3.18.0",
   "gt4py==1.1.9",
@@ -41,7 +41,7 @@ name = "icon4py-testing"
 readme = "README.md"
 requires-python = ">=3.10"
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.urls]
 Homepage = 'https://github.com/C2SM/icon4py'
@@ -50,7 +50,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py-testing version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/testing/src/icon4py/model/testing/__init__.py
+++ b/model/testing/src/icon4py/model/testing/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.1.0"
+__version__: Final = "0.2.0rc1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,8 +123,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ scripts = [
 ]
 test = [
   # workspace members
-  "icon4py-testing~=0.1.0",
+  "icon4py-testing~=0.2.0rc1",
   # external dependencies
   "coverage[toml]>=7.5.0",
   "nox>=2025.5.1",
@@ -85,14 +85,14 @@ classifiers = [
   'Topic :: Scientific/Engineering :: Physics'
 ]
 dependencies = [
-  "icon4py-atmosphere-advection~=0.1.0",
-  "icon4py-atmosphere-diffusion~=0.1.0",
-  "icon4py-atmosphere-dycore~=0.1.0",
-  "icon4py-atmosphere-microphysics~=0.1.0",
-  "icon4py-atmosphere-muphys~=0.1.0",
-  "icon4py-common~=0.1.0",
-  "icon4py-driver~=0.1.0",
-  "icon4py-standalone_driver~=0.1.0"
+  "icon4py-atmosphere-advection~=0.2.0rc1",
+  "icon4py-atmosphere-diffusion~=0.2.0rc1",
+  "icon4py-atmosphere-dycore~=0.2.0rc1",
+  "icon4py-atmosphere-microphysics~=0.2.0rc1",
+  "icon4py-atmosphere-muphys~=0.2.0rc1",
+  "icon4py-common~=0.2.0rc1",
+  "icon4py-driver~=0.2.0rc1",
+  "icon4py-standalone_driver~=0.2.0rc1"
 ]
 description = 'ICON model in Python.'
 license = {text = "BSD-3 License"}
@@ -100,14 +100,14 @@ name = "icon4py"
 readme = "README.md"
 requires-python = ">=3.10"
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.optional-dependencies]
 all = ["icon4py[distributed,fortran,io,testing,profiling]"]
 cuda12 = ["icon4py-common[cuda12]"]
 cuda13 = ["icon4py-common[cuda13]"]
 distributed = ["icon4py-common[distributed]"]
-fortran = ["icon4py-bindings~=0.1.0"]
+fortran = ["icon4py-bindings~=0.2.0rc1"]
 io = ["icon4py-common[io]"]
 profiling = ['viztracer>=1.1.0']
 rocm7 = ["icon4py-common[rocm7]"]
@@ -120,7 +120,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/scripts/python/bump_versions.py
+++ b/scripts/python/bump_versions.py
@@ -41,7 +41,7 @@ def _find_versioned_package_dirs() -> list[pathlib.Path]:
 #: Pattern matching versioned icon4py cross-package dependency constraints, e.g.
 #: ``icon4py-common>=0.0.6``, ``icon4py-common~=0.0.6``, or ``icon4py-tools~=0.0.6``.
 _ICON4PY_DEP_CONSTRAINT_RE: Final = re.compile(
-    r"(icon4py-[\w-]+(?:\[[\w,]+\])?)(~=|>=)([\d]+\.[\d]+\.[\d]+)"
+    r"(icon4py-[\w-]+(?:\[[\w,]+\])?)(~=|>=)([\d]+\.[\d]+\.[\d]+(?:(?:a|b|rc)\d+)?)"
 )
 
 
@@ -53,7 +53,11 @@ def _detect_current_version(pkg_dirs: list[pathlib.Path]) -> str:
     for pkg_dir in pkg_dirs:
         pyproject = pkg_dir / "pyproject.toml"
         text = pyproject.read_text()
-        m = re.search(r"^# managed by bump-my-version:\nversion = \"([\d.]+)\"", text, re.MULTILINE)
+        m = re.search(
+            r"^# managed by bump-my-version:\nversion = \"([\d.]+(?:(?:a|b|rc)\d+)?)\"",
+            text,
+            re.MULTILINE,
+        )
         if m:
             return m.group(1)
     raise RuntimeError("Could not detect current version from any namespace package.")

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -39,7 +39,7 @@ name = 'icon4py-tools'
 readme = 'README.md'
 requires-python = '>=3.10'
 # managed by bump-my-version:
-version = "0.1.0"
+version = "0.2.0rc1"
 
 [project.optional-dependencies]
 cuda12 = ['icon4py-common[cuda12]']
@@ -57,7 +57,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.1.0"
+current_version = "0.2.0rc1"
 ignore_missing_version = false
 message = 'Bump icon4py-tools version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -60,8 +60,8 @@ commit = false
 current_version = "0.1.0"
 ignore_missing_version = false
 message = 'Bump icon4py-tools version: {current_version} → {new_version}'
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?"
-serialize = ["{major}.{minor}.{patch}"]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
 tag = false
 
 [[tool.bumpversion.files]]

--- a/tools/src/icon4py/tools/__init__.py
+++ b/tools/src/icon4py/tools/__init__.py
@@ -25,5 +25,5 @@ __author__: Final = "ETH Zurich,  MeteoSwiss and individual contributors"
 __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
-__version__: Final = "0.1.0"
+__version__: Final = "0.2.0rc1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/uv.lock
+++ b/uv.lock
@@ -1627,7 +1627,7 @@ wheels = [
 
 [[package]]
 name = "icon4py"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "icon4py-atmosphere-advection" },
@@ -1900,7 +1900,7 @@ typing-distributed = [
 
 [[package]]
 name = "icon4py-atmosphere-advection"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "model/atmosphere/advection" }
 dependencies = [
     { name = "gt4py" },
@@ -1917,7 +1917,7 @@ requires-dist = [
 
 [[package]]
 name = "icon4py-atmosphere-diffusion"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "model/atmosphere/diffusion" }
 dependencies = [
     { name = "gt4py" },
@@ -1934,7 +1934,7 @@ requires-dist = [
 
 [[package]]
 name = "icon4py-atmosphere-dycore"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "model/atmosphere/dycore" }
 dependencies = [
     { name = "gt4py" },
@@ -1951,7 +1951,7 @@ requires-dist = [
 
 [[package]]
 name = "icon4py-atmosphere-microphysics"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "model/atmosphere/subgrid_scale_physics/microphysics" }
 dependencies = [
     { name = "gt4py" },
@@ -1968,7 +1968,7 @@ requires-dist = [
 
 [[package]]
 name = "icon4py-atmosphere-muphys"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "model/atmosphere/subgrid_scale_physics/muphys" }
 dependencies = [
     { name = "gt4py" },
@@ -1987,7 +1987,7 @@ requires-dist = [
 
 [[package]]
 name = "icon4py-bindings"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "bindings" }
 dependencies = [
     { name = "cffi" },
@@ -2037,7 +2037,7 @@ provides-extras = ["cuda11", "cuda12", "profiling"]
 
 [[package]]
 name = "icon4py-common"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "model/common" }
 dependencies = [
     { name = "array-api-compat" },
@@ -2120,7 +2120,7 @@ provides-extras = ["all", "cuda12", "cuda13", "distributed", "io", "rocm7"]
 
 [[package]]
 name = "icon4py-driver"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "model/driver" }
 dependencies = [
     { name = "click" },
@@ -2149,7 +2149,7 @@ requires-dist = [
 
 [[package]]
 name = "icon4py-standalone-driver"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "model/standalone_driver" }
 dependencies = [
     { name = "devtools" },
@@ -2176,7 +2176,7 @@ requires-dist = [
 
 [[package]]
 name = "icon4py-testing"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "model/testing" }
 dependencies = [
     { name = "filelock" },
@@ -2205,7 +2205,7 @@ requires-dist = [
 
 [[package]]
 name = "icon4py-tools"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "tools" }
 dependencies = [
     { name = "cffi" },


### PR DESCRIPTION
Updates the bump_version.py helper to accept pre-releases (a|b|rc)N. This pre-release is meant for testing of the workflow added in #1277.