### PR TITLE
Remove commented out x86 CSCS CI jobs

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -29,11 +29,6 @@ variables:
     DOCKER_BUILD_ARGS: '["ARCH=$ARCH", "HPC_SDK_VERSION=$HPC_SDK_VERSION", "HPC_SDK_NAME=$HPC_SDK_NAME", "PYVERSION=$PYVERSION"]'
     KUBERNETES_MEMORY_REQUEST: 128Gi
     KUBERNETES_MEMORY_LIMIT: 128Gi
-# build_baseimage_x86_64:
-#   extends: [.container-builder-cscs-zen2, .build_baseimage]
-#   variables:
-#     HPC_SDK_VERSION: 22.11
-#     HPC_SDK_NAME: "nvhpc_2022_2211_Linux_${ARCH}_cuda_11.8"
 build_baseimage_aarch64:
   extends: [.container-builder-cscs-gh200, .build_baseimage]
   variables:
@@ -47,9 +42,6 @@ build_baseimage_aarch64:
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/public/$ARCH/icon4py/icon4py-ci:$CI_COMMIT_SHA-$PYVERSION
     DOCKERFILE: ci/docker/checkout.Dockerfile
     DOCKER_BUILD_ARGS: '["PYVERSION=$PYVERSION", "BASE_IMAGE=${BASE_IMAGE_${PYVERSION_PREFIX}}"]'
-# build_image_x86_64:
-#   extends: [.container-builder-cscs-zen2, .build_image]
-#   needs: [build_baseimage_x86_64]
 build_image_aarch64:
   extends: [.container-builder-cscs-gh200, .build_image]
   needs: [build_baseimage_aarch64]
@@ -85,13 +77,6 @@ build_image_aarch64:
     CUDACXX: "${HPC_SDK_PATH}/compilers/bin/nvcc"
     NVFORTRAN_COMPILER: "${HPC_SDK_PATH}/compilers/bin/nvfortran"
     PYTEST_ADDOPTS: "--durations=0"
-# .test_template_x86_64:
-#   extends: [.container-runner-daint-gpu-f7t, .test_template]
-#   needs: [build_image_x86_64]
-#   variables:
-#     CSCS_ADDITIONAL_MOUNTS: '["/project/d121/icon4py/ci/testdata:$ICON4PY_TEST_DATA_PATH"]'
-#     HPC_SDK_PATH: "/opt/nvidia/hpc_sdk/Linux_${ARCH}/22.11"
-#     ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS: "cuda12"
 .test_template_aarch64:
   extends: [.container-runner-santis-gh200, .test_template]
   needs: [build_image_aarch64]

--- a/ci/benchmark_bencher_baseline.yml
+++ b/ci/benchmark_bencher_baseline.yml
@@ -2,13 +2,6 @@ include:
   - local: 'ci/base.yml'
   - local: 'ci/benchmark_bencher_common.yml'
 
-# benchmark_bencher_stencils_baseline_x86_64:
-#   extends: [.benchmark_model_baseline, .test_template_x86_64]
-#   variables:
-#     NOX_SESSION: "__bencher_baseline_CI-3.13"
-#     TEST_SELECTION: "${STENCIL_TEST_SELECTION}"
-#     GT4PY_COLLECT_METRICS_LEVEL: 10
-
 benchmark_bencher_stencils_baseline_aarch64:
   extends: [.test_template_aarch64, .benchmark_nox_job]
   variables:

--- a/ci/dace.yml
+++ b/ci/dace.yml
@@ -18,8 +18,6 @@ include:
       - COMPONENT: [advection, diffusion, dycore, microphysics, muphys, common, driver]
         BACKEND: [dace_cpu, dace_gpu]
         GRID: [simple, icon_regional]
-# test_model_stencils_x86_64:
-#   extends: [.test_model_stencils, .test_template_x86_64]
 test_model_stencils_aarch64:
   extends: [.test_model_stencils, .test_template_aarch64]
 
@@ -40,7 +38,5 @@ test_model_stencils_aarch64:
     - when: on_success
       variables:
         SLURM_TIMELIMIT: '00:30:00'
-# test_model_datatests_x86_64:
-#   extends: [.test_model_datatests, .test_template_x86_64]
 test_model_datatests_aarch64:
   extends: [.test_model_datatests, .test_template_aarch64]

--- a/ci/default.yml
+++ b/ci/default.yml
@@ -21,8 +21,6 @@ include:
       - COMPONENT: [diffusion, dycore, microphysics, muphys, common, driver]
         BACKEND: [dace_gpu, gtfn_gpu]
         GRID: [simple, icon_regional]
-# test_model_stencils_x86_64:
-#   extends: [.test_model_stencils, .test_template_x86_64]
 test_model_stencils_aarch64:
   extends: [.test_model_stencils, .test_template_aarch64]
 
@@ -31,8 +29,6 @@ test_model_stencils_aarch64:
   stage: test
   script:
     - nox -s 'test_tools_and_bindings-3.13(datatest)'
-# test_tools_x86_64:
-#   extends: [.test_tools_datatests, .test_template_x86_64]
 test_tools_datatests_aarch64:
   extends: [.test_tools_datatests, .test_template_aarch64]
 
@@ -59,7 +55,5 @@ test_tools_datatests_aarch64:
       - COMPONENT: [advection, diffusion, dycore, microphysics, muphys, common, driver, standalone_driver]
         BACKEND: [embedded, dace_cpu, dace_gpu, gtfn_cpu, gtfn_gpu]
         LEVEL: [integration]
-# test_model_datatests_x86_64:
-#   extends: [.test_model_datatests, .test_template_x86_64]
 test_model_datatests_aarch64:
   extends: [.test_model_datatests, .test_template_aarch64]

--- a/ci/extra.yml
+++ b/ci/extra.yml
@@ -19,7 +19,5 @@ include:
     - when: on_success
       variables:
         SLURM_TIMELIMIT: '00:30:00'
-# test_model_datatests_x86_64:
-#   extends: [.test_model_datatests, .test_template_x86_64]
 test_model_datatests_aarch64:
   extends: [.test_model_datatests, .test_template_aarch64]


### PR DESCRIPTION
We can always revive them, but right now the commented-out jobs are just collecting dust and outdated compared to the aarch64 jobs.