### PR TITLE
Replace one-argument wheres with nonzero

### DIFF
--- a/model/common/src/icon4py/model/common/grid/grid_refinement.py
+++ b/model/common/src/icon4py/model/common/grid/grid_refinement.py
@@ -8,7 +8,6 @@
 import logging
 from typing import Final
 
-import numpy as np
 from gt4py import next as gtx
 
 from icon4py.model.common import dimension as dims
@@ -302,7 +301,7 @@ def convert_to_non_nested_refinement_values(
     """
     assert field.dtype in (gtx.int32, gtx.int64), f"not an integer type {field.dtype}"  # type: ignore [attr-defined]
     array_ns = data_alloc.array_namespace(field)
-    return array_ns.where(field == _UNORDERED[dim][1], 0, np.where(field < 0, -field, field))
+    return array_ns.where(field == _UNORDERED[dim][1], 0, array_ns.where(field < 0, -field, field))
 
 
 def is_limited_area_grid(

--- a/model/common/src/icon4py/model/common/grid/grid_refinement.py
+++ b/model/common/src/icon4py/model/common/grid/grid_refinement.py
@@ -225,13 +225,13 @@ def compute_domain_bounds(
         h_grid.domain(dim)(h_grid.Zone.HALO)
     )
     not_lateral_boundary_1 = (refinement_ctrl < 1) | (refinement_ctrl > upper_boundary_level_1)
-    halo_region_1 = array_ns.where(halo_level_1 & not_lateral_boundary_1)[0]
+    halo_region_1 = array_ns.nonzero(halo_level_1 & not_lateral_boundary_1)[0]
     not_lateral_boundary_2 = (refinement_ctrl < 1) | (
         refinement_ctrl
         > _refinement_level_placed_with_halo(h_grid.domain(dim)(h_grid.Zone.HALO_LEVEL_2))
     )
 
-    halo_region_2 = array_ns.where(halo_level_2 & not_lateral_boundary_2)[0]
+    halo_region_2 = array_ns.nonzero(halo_level_2 & not_lateral_boundary_2)[0]
     start_halo_2, end_halo_2 = (
         (array_ns.min(halo_region_2).item(), array_ns.max(halo_region_2).item() + 1)
         if halo_region_2.size > 0
@@ -257,7 +257,7 @@ def compute_domain_bounds(
             if domain.zone.is_lateral_boundary()
             else _LAST_BOUNDARY[dim].level + domain.zone.level
         )
-        found = array_ns.where((refinement_ctrl == value) & owned)[0]
+        found = array_ns.nonzero((refinement_ctrl == value) & owned)[0]
         start_index, end_index = (
             (array_ns.min(found).item(), array_ns.max(found).item() + 1)
             if found.size > 0

--- a/model/common/src/icon4py/model/common/metrics/metric_fields.py
+++ b/model/common/src/icon4py/model/common/metrics/metric_fields.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import gt4py.next as gtx
-import numpy as np
 from gt4py.next import (
     abs,  # noqa: A004
     astype,
@@ -567,8 +566,8 @@ def compute_flat_max_idx(
 ) -> data_alloc.NDArray:
     array_ns = data_alloc.array_namespace(e2c)
     k_lev_minus1 = k_lev[:-1]
-    coeff_ = np.expand_dims(c_lin_e, axis=-1)
-    z_me = np.sum(z_mc[e2c] * coeff_, axis=1)
+    coeff_ = array_ns.expand_dims(c_lin_e, axis=-1)
+    z_me = array_ns.sum(z_mc[e2c] * coeff_, axis=1)
     exchange.exchange(dims.EdgeDim, z_me, stream=decomposition.BLOCK)
     z_ifc_e_0 = z_ifc[e2c[:, 0], :-1]
     z_ifc_e_k_0 = z_ifc[e2c[:, 0], 1:]
@@ -928,7 +927,7 @@ def compute_exner_w_implicit_weight_parameter(
     maxslope = 0.425 * array_ns.amax(stacked, axis=1) ** (0.75)
     diff = array_ns.minimum(
         0.25,
-        0.00025 * (np.amax(np.abs(zn_off * dual_edge_length[c2e]), axis=1) - 250.0),
+        0.00025 * (array_ns.amax(array_ns.abs(zn_off * dual_edge_length[c2e]), axis=1) - 250.0),
     )
     offctr = array_ns.minimum(
         factor, array_ns.maximum(vwind_offctr, array_ns.maximum(maxslope, diff))
@@ -941,8 +940,8 @@ def compute_exner_w_implicit_weight_parameter(
 
     for jk in range(k_start, nlev):
         zdiff2_sliced = zdiff2[horizontal_start_cell:, jk]
-        index_for_k = np.where(zdiff2_sliced < 0.6)[0]
-        max_value_k = np.maximum(
+        index_for_k = array_ns.nonzero(zdiff2_sliced < 0.6)[0]
+        max_value_k = array_ns.maximum(
             1.2 - zdiff2_sliced, exner_w_implicit_weight_parameter[horizontal_start_cell:]
         )
         exner_w_implicit_weight_parameter[index_for_k + horizontal_start_cell] = max_value_k[

--- a/model/common/tests/common/decomposition/unit_tests/test_halo.py
+++ b/model/common/tests/common/decomposition/unit_tests/test_halo.py
@@ -89,7 +89,7 @@ def test_halo_constructor_decomposition_info_halo_levels(rank, dim, simple_neigh
         "All indices should have a defined DecompositionFlag"
     )
 
-    assert np.where(my_halo_levels == definitions.DecompositionFlag.OWNED)[0].size == len(
+    assert np.nonzero(my_halo_levels == definitions.DecompositionFlag.OWNED)[0].size == len(
         utils.OWNED[dim][process_props.rank]
     )
     owned_local_indices = decomp_info.local_index(
@@ -98,7 +98,7 @@ def test_halo_constructor_decomposition_info_halo_levels(rank, dim, simple_neigh
     assert np.all(my_halo_levels[owned_local_indices] == definitions.DecompositionFlag.OWNED), (
         "owned local indices should have DecompositionFlag.OWNED"
     )
-    first_halo_level_local_index = np.where(
+    first_halo_level_local_index = np.nonzero(
         my_halo_levels == definitions.DecompositionFlag.FIRST_HALO_LEVEL
     )[0]
     first_halo_level_global_index = decomp_info.global_index(
@@ -107,7 +107,7 @@ def test_halo_constructor_decomposition_info_halo_levels(rank, dim, simple_neigh
     utils.assert_same_entries(
         dim, first_halo_level_global_index, utils.FIRST_HALO_LINE, process_props.rank
     )
-    second_halo_level_local_index = np.where(
+    second_halo_level_local_index = np.nonzero(
         my_halo_levels == definitions.DecompositionFlag.SECOND_HALO_LEVEL
     )[0]
     second_halo_level_global_index = decomp_info.global_index(
@@ -116,7 +116,7 @@ def test_halo_constructor_decomposition_info_halo_levels(rank, dim, simple_neigh
     utils.assert_same_entries(
         dim, second_halo_level_global_index, utils.SECOND_HALO_LINE, process_props.rank
     )
-    third_halo_level_index = np.where(
+    third_halo_level_index = np.nonzero(
         my_halo_levels == definitions.DecompositionFlag.THIRD_HALO_LEVEL
     )[0]
     third_halo_level_global_index = decomp_info.global_index(
@@ -196,7 +196,7 @@ def test_owned_halo_mask_contiguous(rank):
 
     for dim in dims.horizontal_dims():
         owner_mask = decomp_info.owner_mask(dim)
-        owned_indices = np.where(owner_mask)[0]
+        owned_indices = np.nonzero(owner_mask)[0]
         # NOTE: These assumptions may change once limited area grids are
         # supported for icon4py domain decomposition.
         assert test_utils.is_sorted(decomp_info.halo_levels(dim)), (

--- a/model/common/tests/common/grid/unit_tests/test_geometry.py
+++ b/model/common/tests/common/grid/unit_tests/test_geometry.py
@@ -478,10 +478,10 @@ def test_create_auxiliary_orientation_coordinates(
         assert test_utils.dallclose(lon_0.asnumpy(), cell_lon.asnumpy()[connectivity[:, 0]])
         assert test_utils.dallclose(lon_1.asnumpy(), cell_lon.asnumpy()[connectivity[:, 1]])
 
-    edge_coordinates_0 = np.where(connectivity[:, 0] < 0)
-    edge_coordinates_1 = np.where(connectivity[:, 1] < 0)
-    cell_coordinates_0 = np.where(connectivity[:, 0] >= 0)
-    cell_coordinates_1 = np.where(connectivity[:, 1] >= 0)
+    edge_coordinates_0 = np.nonzero(connectivity[:, 0] < 0)
+    edge_coordinates_1 = np.nonzero(connectivity[:, 1] < 0)
+    cell_coordinates_0 = np.nonzero(connectivity[:, 0] >= 0)
+    cell_coordinates_1 = np.nonzero(connectivity[:, 1] >= 0)
     assert test_utils.dallclose(
         lat_0.asnumpy()[edge_coordinates_0], edge_lat.asnumpy()[edge_coordinates_0]
     )

--- a/model/common/tests/common/grid/unit_tests/test_grid_manager.py
+++ b/model/common/tests/common/grid/unit_tests/test_grid_manager.py
@@ -657,7 +657,7 @@ def test_local_connectivity(
         if dim == dims.EdgeDim
         else decomp_defs.DecompositionFlag.SECOND_HALO_LEVEL
     )
-    level_index = np.where(
+    level_index = np.nonzero(
         data_alloc.as_numpy(decomposition_info.halo_levels(dim)) == last_halo_level.value
     )
     if (

--- a/model/common/tests/common/io/unit_tests/test_ugrid.py
+++ b/model/common/tests/common/io/unit_tests/test_ugrid.py
@@ -94,7 +94,7 @@ def test_icon_ugrid_patch_fill_value(file):
 
 def assert_start_index(uxds: xa.Dataset, name: str):
     assert uxds[name].attrs["start_index"] == 0
-    assert np.min(np.where(uxds[name].data > FILL_VALUE)) == 0
+    assert np.min(np.nonzero(uxds[name].data > FILL_VALUE)) == 0
 
 
 @pytest.mark.parametrize("file", grid_files())


### PR DESCRIPTION
As pointed out by @nfarabullini in https://github.com/C2SM/icon4py/pull/1282#discussion_r3302974984, `array_ns.where` with only one argument is exactly `array_ns.nonzero`. The documentation states (https://numpy.org/doc/stable/reference/generated/numpy.where.html):
> When only condition is provided, this function is a shorthand for np.asarray(condition).nonzero(). Using [nonzero](https://numpy.org/doc/stable/reference/generated/numpy.nonzero.html#numpy.nonzero) directly should be preferred, as it behaves correctly for subclasses. The rest of this documentation covers only the case where all three arguments are provided.