### PR TITLE
Extended `compute_advection_in_predictor_vertical_momentum`

### DIFF
--- a/model/atmosphere/dycore/tests/dycore/stencil_tests/test_compute_advection_in_vertical_momentum_equation.py
+++ b/model/atmosphere/dycore/tests/dycore/stencil_tests/test_compute_advection_in_vertical_momentum_equation.py
@@ -505,6 +505,7 @@ class TestFusedVelocityAdvectionStencilVMomentumAndContravariant(stencil_tests.S
             "vertical_start",
             "vertical_end",
             "nflatlev",
+            "skip_compute_predictor_vertical_advection",
         ),
         stencil_tests.StandardStaticVariants.COMPILE_TIME_DOMAIN: (
             "horizontal_start",
@@ -513,6 +514,7 @@ class TestFusedVelocityAdvectionStencilVMomentumAndContravariant(stencil_tests.S
             "vertical_end",
             "end_index_of_damping_layer",
             "nflatlev",
+            "skip_compute_predictor_vertical_advection",
         ),
     }
 

--- a/model/atmosphere/dycore/tests/dycore/stencil_tests/test_compute_advection_in_vertical_momentum_equation.py
+++ b/model/atmosphere/dycore/tests/dycore/stencil_tests/test_compute_advection_in_vertical_momentum_equation.py
@@ -500,7 +500,20 @@ class TestFusedVelocityAdvectionStencilVMomentumAndContravariant(stencil_tests.S
         "vertical_cfl",
     )
     STATIC_PARAMS = {
-        stencil_tests.StandardStaticVariants.NONE: (),  # For now compile time variants triger error in gt4py
+        stencil_tests.StandardStaticVariants.NONE: (),
+        stencil_tests.StandardStaticVariants.COMPILE_TIME_VERTICAL: (
+            "vertical_start",
+            "vertical_end",
+            "nflatlev",
+        ),
+        stencil_tests.StandardStaticVariants.COMPILE_TIME_DOMAIN: (
+            "horizontal_start",
+            "horizontal_end",
+            "vertical_start",
+            "vertical_end",
+            "end_index_of_damping_layer",
+            "nflatlev",
+        ),
     }
 
     @staticmethod


### PR DESCRIPTION
This PR adds `COMPILE_TIME_VERTICAL` and `COMPILE_TIME_DOMAIN` information to the test that were previously missing.