### PR TITLE
fix(testing): auto-download datatest data via autouse fixture

### DIFF
--- a/model/standalone_driver/tests/standalone_driver/integration_tests/test_initial_condition.py
+++ b/model/standalone_driver/tests/standalone_driver/integration_tests/test_initial_condition.py
@@ -17,7 +17,6 @@ from icon4py.model.testing.fixtures.datatest import (
     backend,
     backend_like,
     data_provider,
-    download_ser_data,
     experiment,
     experiment_description,
     process_props,

--- a/model/standalone_driver/tests/standalone_driver/mpi_tests/test_parallel_initial_conditions.py
+++ b/model/standalone_driver/tests/standalone_driver/mpi_tests/test_parallel_initial_conditions.py
@@ -18,7 +18,6 @@ from icon4py.model.standalone_driver.testcases import initial_condition
 from icon4py.model.testing import definitions as test_defs, grid_utils, parallel_helpers, test_utils
 from icon4py.model.testing.fixtures.datatest import (
     backend_like,
-    download_ser_data,
     experiment,
     experiment_description,
     process_props,

--- a/model/standalone_driver/tests/standalone_driver/mpi_tests/test_parallel_standalone_driver.py
+++ b/model/standalone_driver/tests/standalone_driver/mpi_tests/test_parallel_standalone_driver.py
@@ -17,7 +17,6 @@ from icon4py.model.standalone_driver import main
 from icon4py.model.testing import definitions as test_defs, grid_utils, parallel_helpers, test_utils
 from icon4py.model.testing.fixtures.datatest import (
     backend_like,
-    download_ser_data,
     experiment,
     experiment_description,
     process_props,

--- a/model/testing/src/icon4py/model/testing/pytest_hooks.py
+++ b/model/testing/src/icon4py/model/testing/pytest_hooks.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 from icon4py.model.common import model_backends
-from icon4py.model.testing import filters
+from icon4py.model.testing import datatest_utils, filters
 
 
 __all__ = [
@@ -256,3 +256,19 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
                 f"{benchmark_name:<{max_name_len}} | {np.mean(gtx_metrics):>10.8f} | {np.median(gtx_metrics):>10.8f} | {np.std(gtx_metrics):>10.8f} | {len(gtx_metrics):>4}"
             )
         terminalreporter.line("-" * len(header), blue=True)
+
+
+@pytest.fixture(autouse=True)
+def auto_download_ser_data(request: pytest.FixtureRequest) -> None:
+    marker = request.node.get_closest_marker("datatest")
+    if marker is None:
+        return
+    if "experiment_description" not in request.fixturenames:
+        return
+    if "process_props" not in request.fixturenames:
+        return
+    if "not datatest" in request.config.getoption("-k", ""):
+        return
+    experiment_description = request.getfixturevalue("experiment_description")
+    process_props = request.getfixturevalue("process_props")
+    datatest_utils.download_experiment(experiment_description, process_props)


### PR DESCRIPTION
All datatest tests now automatically download serialized data via an autouse fixture in pytest_hooks, regardless of how experiment_description or process_props are parametrized.

Previously, tests that parametrized experiment_description directly (bypassing the experiment fixture) would skip data download because the fixture function body with the download_ser_data dependency was never called when overridden via pytest.mark.parametrize.

Closes #1314