### PR TITLE
Fix characteristic length computation

### DIFF
--- a/model/common/src/icon4py/model/common/grid/geometry.py
+++ b/model/common/src/icon4py/model/common/grid/geometry.py
@@ -358,7 +358,7 @@ class GridGeometry(factory.FieldSource):
             func=math_utils.compute_sqrt,
             domain=(),
             deps={
-                "input_val": attrs.MEAN_DUAL_AREA,
+                "input_val": attrs.MEAN_CELL_AREA,
             },
             fields=(attrs.CHARACTERISTIC_LENGTH,),
         )


### PR DESCRIPTION
It was incorrectly based on the mean dual cell area instead of the mean primal cell area (introduced in #994).

With the tests that we currently have:
- torus was unaffected in any case because it uses the mean edge length as the scale in RBF
- r2b4 and r4b9 were in principle affected in the sense that the dual cell area is bigger than the primal cell area. However, the characteristic length for both is above the 2.5 km threshold (for cells: https://github.com/C2SM/icon4py/blob/796bff14b95875e14006b9391d4046f635eb541a/model/common/src/icon4py/model/common/interpolation/rbf_interpolation.py#L58-L67; it's 2.0 km for edges and vertices) where the RBF scale is just a constant. So basing the characteristic length on the mean dual cell area didn't change the RBF computation at all, for these grids.

Thank you @jcanton ~~(with help)~~ for noticing this.
@jcanton noticed this without help ;-)