### PR TITLE
Bump ghex to 0.7.0 in uv.lock

### DIFF
--- a/model/common/pyproject.toml
+++ b/model/common/pyproject.toml
@@ -45,7 +45,7 @@ version = "0.2.0"
 all = ["icon4py-common[distributed,io]"]
 cuda12 = ['cupy-cuda12x>=13.0', 'gt4py[cuda12]']
 cuda13 = ['cupy-cuda13x>=14.0', 'gt4py[cuda13]']
-distributed = ["ghex>=0.5.1", "mpi4py>=3.1.5"]
+distributed = ["ghex>=0.7.0", "mpi4py>=3.1.5"]
 io = [
   # external dependencies
   "cartopy>=0.22.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -401,6 +401,7 @@ url = 'https://gridtools.github.io/pypi/'
 # dace = {index = "gridtools"}
 # gt4py = {git = "https://github.com/GridTools/gt4py", branch = "main"}
 # gt4py = {index = "test.pypi"}
+ghex = {index = "test.pypi"}
 icon4py-atmosphere-advection = {workspace = true}
 icon4py-atmosphere-diffusion = {workspace = true}
 icon4py-atmosphere-dycore = {workspace = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -401,7 +401,6 @@ url = 'https://gridtools.github.io/pypi/'
 # dace = {index = "gridtools"}
 # gt4py = {git = "https://github.com/GridTools/gt4py", branch = "main"}
 # gt4py = {index = "test.pypi"}
-ghex = {index = "test.pypi"}
 icon4py-atmosphere-advection = {workspace = true}
 icon4py-atmosphere-diffusion = {workspace = true}
 icon4py-atmosphere-dycore = {workspace = true}

--- a/uv.lock
+++ b/uv.lock
@@ -2760,7 +2760,7 @@ requires-dist = [
   {name = "cupy-cuda12x", marker = "extra == 'cuda12'", specifier = ">=13.0"},
   {name = "cupy-cuda13x", marker = "extra == 'cuda13'", specifier = ">=14.0"},
   {name = "datashader", marker = "extra == 'io'", specifier = ">=0.16.1"},
-  {name = "ghex", marker = "extra == 'distributed'", specifier = ">=0.5.1"},
+  {name = "ghex", marker = "extra == 'distributed'", specifier = ">=0.7.0"},
   {name = "gt4py", specifier = "==1.1.10"},
   {name = "gt4py", extras = ["cuda12"], marker = "extra == 'cuda12'"},
   {name = "gt4py", extras = ["cuda13"], marker = "extra == 'cuda13'"},

--- a/uv.lock
+++ b/uv.lock
@@ -2094,9 +2094,9 @@ dependencies = [
   {name = "numpy", version = "2.4.6", source = {registry = "https://pypi.org/simple"}, marker = "python_full_version >= '3.11' or (extra == 'extra-7-icon4py-cuda12' and extra == 'extra-7-icon4py-cuda13') or (extra == 'extra-7-icon4py-cuda12' and extra == 'extra-7-icon4py-rocm7') or (extra == 'extra-7-icon4py-cuda13' and extra == 'extra-7-icon4py-rocm7')"}
 ]
 name = "ghex"
-sdist = {url = "https://files.pythonhosted.org/packages/e7/d4/b8a94021a958327b721553b5e63248d0c10bd08204ce494b9bfe994ef987/ghex-0.6.0.tar.gz", hash = "sha256:c0c89d1a2759883fac3f1d9726b13534a3386cc53f73ddfdb666803a7d8e61d6", size = 8912739, upload-time = "2026-05-20T11:43:30.562Z"}
-source = {registry = "https://pypi.org/simple"}
-version = "0.6.0"
+sdist = {url = "https://test-files.pythonhosted.org/packages/12/dc/a5168a63f0543b9f6882487807ec586746cff71fc68f37ac010e63e751b8/ghex-0.7.0.tar.gz", hash = "sha256:4966ef3cee77038edd31444079c0b780d1b0c922a58464c5114092bf503cc308", size = 8915433, upload-time = "2026-06-18T14:04:47.847Z"}
+source = {registry = "https://test.pypi.org/simple/"}
+version = "0.7.0"
 
 [[package]]
 dependencies = [
@@ -2760,7 +2760,7 @@ requires-dist = [
   {name = "cupy-cuda12x", marker = "extra == 'cuda12'", specifier = ">=13.0"},
   {name = "cupy-cuda13x", marker = "extra == 'cuda13'", specifier = ">=14.0"},
   {name = "datashader", marker = "extra == 'io'", specifier = ">=0.16.1"},
-  {name = "ghex", marker = "extra == 'distributed'", specifier = ">=0.5.1"},
+  {name = "ghex", marker = "extra == 'distributed'", specifier = ">=0.5.1", index = "https://test.pypi.org/simple/"},
   {name = "gt4py", specifier = "==1.1.10"},
   {name = "gt4py", extras = ["cuda12"], marker = "extra == 'cuda12'"},
   {name = "gt4py", extras = ["cuda13"], marker = "extra == 'cuda13'"},

--- a/uv.lock
+++ b/uv.lock
@@ -2094,8 +2094,8 @@ dependencies = [
   {name = "numpy", version = "2.4.6", source = {registry = "https://pypi.org/simple"}, marker = "python_full_version >= '3.11' or (extra == 'extra-7-icon4py-cuda12' and extra == 'extra-7-icon4py-cuda13') or (extra == 'extra-7-icon4py-cuda12' and extra == 'extra-7-icon4py-rocm7') or (extra == 'extra-7-icon4py-cuda13' and extra == 'extra-7-icon4py-rocm7')"}
 ]
 name = "ghex"
-sdist = {url = "https://test-files.pythonhosted.org/packages/12/dc/a5168a63f0543b9f6882487807ec586746cff71fc68f37ac010e63e751b8/ghex-0.7.0.tar.gz", hash = "sha256:4966ef3cee77038edd31444079c0b780d1b0c922a58464c5114092bf503cc308", size = 8915433, upload-time = "2026-06-18T14:04:47.847Z"}
-source = {registry = "https://test.pypi.org/simple/"}
+sdist = {url = "https://files.pythonhosted.org/packages/12/dc/a5168a63f0543b9f6882487807ec586746cff71fc68f37ac010e63e751b8/ghex-0.7.0.tar.gz", hash = "sha256:4966ef3cee77038edd31444079c0b780d1b0c922a58464c5114092bf503cc308", size = 8915433, upload-time = "2026-06-18T15:35:30.856Z"}
+source = {registry = "https://pypi.org/simple"}
 version = "0.7.0"
 
 [[package]]
@@ -2760,7 +2760,7 @@ requires-dist = [
   {name = "cupy-cuda12x", marker = "extra == 'cuda12'", specifier = ">=13.0"},
   {name = "cupy-cuda13x", marker = "extra == 'cuda13'", specifier = ">=14.0"},
   {name = "datashader", marker = "extra == 'io'", specifier = ">=0.16.1"},
-  {name = "ghex", marker = "extra == 'distributed'", specifier = ">=0.5.1", index = "https://test.pypi.org/simple/"},
+  {name = "ghex", marker = "extra == 'distributed'", specifier = ">=0.5.1"},
   {name = "gt4py", specifier = "==1.1.10"},
   {name = "gt4py", extras = ["cuda12"], marker = "extra == 'cuda12'"},
   {name = "gt4py", extras = ["cuda13"], marker = "extra == 'cuda13'"},


### PR DESCRIPTION
Fixes builds with ROCm, does not make a difference with CUDA.