### PR TITLE
Add missing datatest markers to `test_parallel_grid_manager.py`

### DIFF
--- a/model/common/tests/common/grid/mpi_tests/test_parallel_grid_manager.py
+++ b/model/common/tests/common/grid/mpi_tests/test_parallel_grid_manager.py
@@ -55,6 +55,7 @@ from . import utils
 _log = logging.getLogger(__file__)
 
 
+@pytest.mark.datatest
 @pytest.mark.parametrize("process_props", [True], indirect=True)
 @pytest.mark.mpi(min_size=2)
 def test_grid_manager_validate_decomposer(
@@ -205,6 +206,7 @@ def _compare_geometry_fields_single_multi_rank(
     _log.info(f"rank = {process_props.rank} - DONE")
 
 
+@pytest.mark.datatest
 @pytest.mark.level("unit")
 @pytest.mark.mpi
 @pytest.mark.parametrize("process_props", [True], indirect=True)
@@ -244,6 +246,7 @@ def test_geometry_fields_compare_single_multi_rank_unit(
     _compare_geometry_fields_single_multi_rank(process_props, backend, grid_description, attrs_name)
 
 
+@pytest.mark.datatest
 @pytest.mark.level("integration")
 @pytest.mark.mpi
 @pytest.mark.parametrize("process_props", [True], indirect=True)
@@ -360,6 +363,7 @@ def _compare_interpolation_fields_single_multi_rank(
     _log.info(f"rank = {process_props.rank} - DONE")
 
 
+@pytest.mark.datatest
 @pytest.mark.level("unit")
 @pytest.mark.mpi
 @pytest.mark.parametrize("process_props", [True], indirect=True)
@@ -390,6 +394,7 @@ def test_interpolation_fields_compare_single_multi_rank_unit(
     _compare_interpolation_fields_single_multi_rank(process_props, backend, experiment, attrs_name)
 
 
+@pytest.mark.datatest
 @pytest.mark.level("integration")
 @pytest.mark.mpi
 @pytest.mark.parametrize("process_props", [True], indirect=True)
@@ -557,6 +562,7 @@ def _compare_metrics_fields_single_multi_rank(
     _log.info(f"rank = {process_props.rank} - DONE")
 
 
+@pytest.mark.datatest
 @pytest.mark.level("unit")
 @pytest.mark.mpi
 @pytest.mark.parametrize("process_props", [True], indirect=True)
@@ -610,6 +616,7 @@ def test_metrics_fields_compare_single_multi_rank_unit(
     _compare_metrics_fields_single_multi_rank(process_props, backend, experiment, attrs_name)
 
 
+@pytest.mark.datatest
 @pytest.mark.level("integration")
 @pytest.mark.mpi
 @pytest.mark.parametrize("process_props", [True], indirect=True)
@@ -642,6 +649,7 @@ def test_metrics_fields_compare_single_multi_rank_integration(
 # MASK_PROG_HALO_C is defined specially only on halos, so we have a separate
 # test for it. It doesn't make sense to compare to a single-rank reference since
 # it has no halos.
+@pytest.mark.datatest
 @pytest.mark.mpi
 @pytest.mark.parametrize("process_props", [True], indirect=True)
 def test_metrics_mask_prog_halo_c(
@@ -739,6 +747,7 @@ def test_metrics_mask_prog_halo_c(
     _log.info(f"rank = {process_props.rank} - DONE")
 
 
+@pytest.mark.datatest
 @pytest.mark.mpi
 @pytest.mark.parametrize("process_props", [True], indirect=True)
 def test_validate_skip_values_in_distributed_connectivities(
@@ -774,6 +783,7 @@ def test_validate_skip_values_in_distributed_connectivities(
                 )
 
 
+@pytest.mark.datatest
 @pytest.mark.mpi
 @pytest.mark.parametrize("process_props", [True], indirect=True)
 @pytest.mark.parametrize("grid", [test_defs.Grids.MCH_CH_R04B09_DSL])
@@ -793,6 +803,7 @@ def test_limited_area_raises(
         )
 
 
+@pytest.mark.datatest
 @pytest.mark.mpi
 @pytest.mark.parametrize("process_props", [True], indirect=True)
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follows #1326 to correctly mark these tests as datatests (they don't require serialized data, but do require grids).