### PR TITLE
Make unmarked tests implicitly unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,15 +132,15 @@ uv run --group test --frozen pytest -n0 <paths>
 
 Registered by `icon4py.model.testing.pytest_hooks` (auto-loaded via `addopts`):
 
-| Option                            | Description                                                              |
-| --------------------------------- | ------------------------------------------------------------------------ |
-| `--datatest-only`                 | Run only `@pytest.mark.datatest` tests                                   |
-| `--datatest-skip`                 | Skip all datatests                                                       |
-| `--backend <name>`                | GT4Py backend (default: roundtrip; others: gtfn_cpu, gtfn_gpu, embedded) |
-| `--grid <name>`                   | Grid to use                                                              |
-| `--enable-mixed-precision`        | Switch from double to mixed-precision                                    |
-| `--level {any,unit,integration}`  | Filter by `@pytest.mark.level` marker                                    |
-| `--skip-stenciltest-verification` | Skip verification of StencilTest against reference outputs               |
+| Option                            | Description                                                                                                               |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `--datatest-only`                 | Run only `@pytest.mark.datatest` tests                                                                                    |
+| `--datatest-skip`                 | Skip all datatests                                                                                                        |
+| `--backend <name>`                | GT4Py backend (default: roundtrip; others: gtfn_cpu, gtfn_gpu, embedded)                                                  |
+| `--grid <name>`                   | Grid to use                                                                                                               |
+| `--enable-mixed-precision`        | Switch from double to mixed-precision                                                                                     |
+| `--level {any,unit,integration}`  | Run only tests matching the given level. Unmarked tests are implicitly treated as `unit`. `any` (default) runs all tests. |
+| `--skip-stenciltest-verification` | Skip verification of StencilTest against reference outputs                                                                |
 
 ### Test directory convention
 

--- a/model/testing/src/icon4py/model/testing/pytest_hooks.py
+++ b/model/testing/src/icon4py/model/testing/pytest_hooks.py
@@ -34,7 +34,7 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "level(name): marks test as unit or integration tests. tests without this marker are implicitly treated as 'unit'.",
+        "level(name): marks test as unit or integration tests, tests without this marker are implicitly treated as 'unit'",
     )
 
     # Check if the --enable-mixed-precision option is set and set the environment variable accordingly

--- a/model/testing/src/icon4py/model/testing/pytest_hooks.py
+++ b/model/testing/src/icon4py/model/testing/pytest_hooks.py
@@ -134,8 +134,7 @@ def pytest_collection_modifyitems(config, items):
     if test_level == "any":
         return
     for item in items:
-        marker = item.get_closest_marker("level")
-        if marker is not None:
+        if (marker := item.get_closest_marker("level")) is not None:
             assert all(level in _TEST_LEVELS for level in marker.args), (
                 f"Invalid test level argument on function '{item.name}' - possible values are {_TEST_LEVELS}"
             )

--- a/model/testing/src/icon4py/model/testing/pytest_hooks.py
+++ b/model/testing/src/icon4py/model/testing/pytest_hooks.py
@@ -34,7 +34,7 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "level(name): marks test as unit or integration tests, mostly applicable where both are available",
+        "level(name): marks test as unit or integration tests. tests without this marker are implicitly treated as 'unit'.",
     )
 
     # Check if the --enable-mixed-precision option is set and set the environment variable accordingly
@@ -116,7 +116,7 @@ def pytest_addoption(parser: pytest.Parser):
             "--level",
             action="store",
             choices=_TEST_LEVELS,
-            help="Set level (unit, integration) of the tests to run. Defaults to 'any'.",
+            help="Set level (unit, integration) of the tests to run. Tests without a level marker are implicitly 'unit'. Defaults to 'any'.",
             default="any",
         )
     with contextlib.suppress(ValueError):
@@ -134,7 +134,8 @@ def pytest_collection_modifyitems(config, items):
     if test_level == "any":
         return
     for item in items:
-        if (marker := item.get_closest_marker("level")) is not None:
+        marker = item.get_closest_marker("level")
+        if marker is not None:
             assert all(level in _TEST_LEVELS for level in marker.args), (
                 f"Invalid test level argument on function '{item.name}' - possible values are {_TEST_LEVELS}"
             )
@@ -144,6 +145,12 @@ def pytest_collection_modifyitems(config, items):
                         reason=f"Selected level '{test_level}' does not match the configured '{marker.args}' level for this test."
                     )
                 )
+        elif test_level != "unit":
+            item.add_marker(
+                pytest.mark.skip(
+                    reason=f"Selected level '{test_level}' does not match the implicit level 'unit' for this test."
+                )
+            )
 
 
 @pytest.hookimpl(trylast=True)


### PR DESCRIPTION
Currently selecting a test level marker with `pytest --level=unit` will run all tests marked `unit` and unmarked tests. Likewise `--level=integration` will run all tests marked `integration` and unmarked tests. This means that `pytest --level=unit` and `pytest --level=integration` aren't disjoint subsets as one would expect.

This makes all unmarked tests implicitly unit tests as I think that's a reasonable default level for tests.

We can separately consider removing the level marker and rely fully on `foo_tests` directories and `-k foo_tests`. With this PR I just want to correct what to me seems like a bug, to help with #1294 where I don't want the same tests to run in multiple CI jobs.