### PR TITLE
Add ruff rule name to noqa in `io.py`

### DIFF
--- a/model/common/src/icon4py/model/common/io/io.py
+++ b/model/common/src/icon4py/model/common/io/io.py
@@ -83,7 +83,7 @@ class FieldGroupIOConfig(Config):
     #: Output schedule: either a number of model steps (``int``) or a simulation-time
     #: delta (``datetime.timedelta``); a delta is normalized to steps using the model time
     #: step. Defaults to every step.
-    output_interval: OutputInterval = NumTimeSteps(1)  # noqa: RUF009 [NumTimeSteps is immutable (int)]
+    output_interval: OutputInterval = NumTimeSteps(1)  # noqa: RUF009 [function-call-in-dataclass-default-argument] NumTimeSteps is immutable (int)
     timesteps_per_file: int = 10
     nc_title: str = "ICON4Py Simulation"
     nc_comment: str = "ICON inspired code in Python and GT4Py"


### PR DESCRIPTION
See discussion in https://github.com/C2SM/icon4py/commit/878bb18f695520f7c85ea7a16b66f34bd203440b#r189834412.

Purely cosmetic, just to give the name of the RUF009 rule in the comment, as suggested in https://github.com/C2SM/icon4py/blob/744c5463d62ed3b35a5ecf36ce902b6857bf27de/CODING_GUIDELINES.md?plain=1#L121.