### PR TITLE
Fix numpy/cupy mismatch in RBF unit tests

### DIFF
--- a/model/common/src/icon4py/model/common/interpolation/rbf_interpolation.py
+++ b/model/common/src/icon4py/model/common/interpolation/rbf_interpolation.py
@@ -121,7 +121,7 @@ def construct_rbf_matrix_offsets_tables_for_cells(
     grid: base_grid.Grid,
 ) -> data_alloc.NDArray:
     """Compute the neighbor tables for the cell RBF matrix: rbf_vec_index_c"""
-    connectivity = grid.get_connectivity(dims.C2E2C2E).asnumpy()
+    connectivity = grid.get_connectivity(dims.C2E2C2E).ndarray
     assert connectivity.shape == (grid.num_cells, RBF_STENCIL_SIZE[RBFDimension.CELL])
     return connectivity
 
@@ -130,7 +130,7 @@ def construct_rbf_matrix_offsets_tables_for_edges(
     grid: base_grid.Grid,
 ) -> data_alloc.NDArray:
     """Compute the neighbor tables for the edge RBF matrix: rbf_vec_index_e"""
-    connectivity = grid.get_connectivity(dims.E2C2E).asnumpy()
+    connectivity = grid.get_connectivity(dims.E2C2E).ndarray
     assert connectivity.shape == (grid.num_edges, RBF_STENCIL_SIZE[RBFDimension.EDGE])
     return connectivity
 
@@ -139,7 +139,7 @@ def construct_rbf_matrix_offsets_tables_for_vertices(
     grid: base_grid.Grid,
 ) -> data_alloc.NDArray:
     """Compute the neighbor tables for the edge RBF matrix: rbf_vec_index_v"""
-    connectivity = grid.get_connectivity(dims.V2E).asnumpy()
+    connectivity = grid.get_connectivity(dims.V2E).ndarray
     assert connectivity.shape == (grid.num_vertices, RBF_STENCIL_SIZE[RBFDimension.VERTEX])
     return connectivity
 

--- a/model/common/tests/common/interpolation/unit_tests/test_rbf_interpolation.py
+++ b/model/common/tests/common/interpolation/unit_tests/test_rbf_interpolation.py
@@ -71,7 +71,7 @@ def test_construct_rbf_matrix_offsets_tables_for_cells(
         experiment.grid, 1, True, model_backends.get_allocator(backend)
     )
     grid = grid_manager.grid
-    offset_table = rbf.construct_rbf_matrix_offsets_tables_for_cells(grid)
+    offset_table = data_alloc.as_numpy(rbf.construct_rbf_matrix_offsets_tables_for_cells(grid))
     assert offset_table.shape == (
         grid.num_cells,
         rbf.RBF_STENCIL_SIZE[rbf.RBFDimension.CELL],
@@ -103,7 +103,7 @@ def test_construct_rbf_matrix_offsets_tables_for_edges(
         experiment.grid, 1, True, model_backends.get_allocator(backend)
     )
     grid = grid_manager.grid
-    offset_table = rbf.construct_rbf_matrix_offsets_tables_for_edges(grid)
+    offset_table = data_alloc.as_numpy(rbf.construct_rbf_matrix_offsets_tables_for_edges(grid))
     assert offset_table.shape == (
         grid.num_edges,
         rbf.RBF_STENCIL_SIZE[rbf.RBFDimension.EDGE],
@@ -133,7 +133,7 @@ def test_construct_rbf_matrix_offsets_tables_for_vertices(
         experiment.grid, 1, True, model_backends.get_allocator(backend)
     )
     grid = grid_manager.grid
-    offset_table = rbf.construct_rbf_matrix_offsets_tables_for_vertices(grid)
+    offset_table = data_alloc.as_numpy(rbf.construct_rbf_matrix_offsets_tables_for_vertices(grid))
     assert offset_table.shape == (
         grid.num_vertices,
         rbf.RBF_STENCIL_SIZE[rbf.RBFDimension.VERTEX],


### PR DESCRIPTION
A numpy array was unconditionally returned from the helper `construct_rbf_matrix_offsets_tables_for_foo` functions. Some places need a matching numpy/cupy array, so I moved the conversion to numpy arrays only to the tests that need it.