### PR TITLE
Set nonzero tolerance for `RHO_REF_ME` with `dace_gpu` in `test_parallel_grid_manager.py`

### DIFF
--- a/model/common/tests/common/grid/mpi_tests/test_parallel_grid_manager.py
+++ b/model/common/tests/common/grid/mpi_tests/test_parallel_grid_manager.py
@@ -542,7 +542,11 @@ def _compare_metrics_fields_single_multi_rank(
             model_backends.is_cpu_backend(backend)
             or (
                 model_backends.is_gpu_backend(backend)
-                and attrs_name == metrics_attributes.DDQZ_Z_FULL_E
+                and attrs_name
+                in {
+                    metrics_attributes.DDQZ_Z_FULL_E,
+                    metrics_attributes.RHO_REF_ME,
+                }
             )
         ):
             # TODO (jcanton,phimuell): figure out dace undeterministic behaviour


### PR DESCRIPTION
I don't think this is a regression. This field is just not tested by default in the usual default pipeline (one of many "extra" fields that are skipped because they take a long time to test for little added value).