### PR TITLE
Fix SyntaxWarnings from invalid escape sequences in strings

### DIFF
--- a/model/atmosphere/dycore/docs/ext/icon4py_sphinx.py
+++ b/model/atmosphere/dycore/docs/ext/icon4py_sphinx.py
@@ -254,7 +254,7 @@ class ScidocMethodDocumenter(autodoc.MethodDocumenter):
                 continue
 
             # Collect offset providers
-            if "\offProv" in line:
+            if r"\offProv" in line:
                 match = re.search(r"\\offProv\{([^}]+)\}", line)
                 if match:
                     offset_providers.add(match.group(1))
@@ -288,7 +288,7 @@ class ScidocMethodDocumenter(autodoc.MethodDocumenter):
                                 var_longname = method_info["map_shortname_to_longname"][element]
                                 parent_name, short_name = self.split_variable_name(var_longname)
                                 vname = (
-                                    f"$\color{{grey}}{{\scriptstyle{{\\texttt{{{parent_name}.}}}}}}$"
+                                    rf"$\color{{grey}}{{\scriptstyle{{\texttt{{{parent_name}.}}}}}}$"
                                     if parent_name
                                     else ""
                                 ) + f"{short_name}"
@@ -323,7 +323,7 @@ class ScidocMethodDocumenter(autodoc.MethodDocumenter):
         Returns:
             The processed LaTeX math line with applied formatting rules.
         """
-        symbols_needing_space = ["\Wrbf", "\Wlev", "\WtimeExner"]
+        symbols_needing_space = [r"\Wrbf", r"\Wlev", r"\WtimeExner"]
 
         if options["NeedsAlignChar"]:
             # Align multiline equations to the left

--- a/model/common/src/icon4py/model/common/grid/grid_refinement.py
+++ b/model/common/src/icon4py/model/common/grid/grid_refinement.py
@@ -38,7 +38,7 @@ _MAX_ORDERED: Final[dict[gtx.Dimension, int]] = {
     dims.EdgeDim: gridfile.FixedSizeDimension.EDGE_GRF.size,
     dims.VertexDim: gridfile.FixedSizeDimension.VERTEX_GRF.size,
 }
-"""
+r"""
 Grid points in the grid refinement fields are labeled with their distance to the lateral boundary.
 The distance is counted in "rows" and distances up to _MAX_BOUNDARY_DISTANCE are computed, elements
 at distances larger than _MAX_BOUNDARY_DISTANCE are labeled as _UNORDERED

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/driver_utils.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/driver_utils.py
@@ -453,7 +453,7 @@ def find_maximum_from_field(
 
 
 def display_icon4py_logo_in_log_file() -> None:
-    """
+    r"""
     Print out icon4py signature and some important information of the initial setup to the log file.
 
                                                                ___

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,6 +333,7 @@ select = [
   'T10',  # flake8-debugger
   'TD',  # flake8-todos
   'UP',  # pyupgrade
+  'W605',  # invalid-escape-sequence
   'YTT'  # flake8-2020
 ]
 typing-modules = ['gt4py.eve.extended_typing']


### PR DESCRIPTION
A lot of strings (docstrings included) use `\` not to actually escape anything, but just as a plain backslash. This PR fixes warnings by invalid escape sequences by either using raw strings where appropriate. This also adds W605 (https://docs.astral.sh/ruff/rules/invalid-escape-sequence/) to the ruff checks.

Without this, running icon4py results in warnings such as
```
model/common/src/icon4py/model/common/grid/grid_refinement.py:53: SyntaxWarning: invalid escape sequence '\ '
  /\ 1  /\ 1  /\ 1  /    ← Row 1
```
at runtime which is pure noise.