### PR TITLE
Add nonzero tolerance for `THETA_REF_ME` with `dace_gpu`

### DIFF
--- a/model/common/tests/common/grid/mpi_tests/test_parallel_grid_manager.py
+++ b/model/common/tests/common/grid/mpi_tests/test_parallel_grid_manager.py
@@ -546,11 +546,12 @@ def _compare_metrics_fields_single_multi_rank(
                 in {
                     metrics_attributes.DDQZ_Z_FULL_E,
                     metrics_attributes.RHO_REF_ME,
+                    metrics_attributes.THETA_REF_ME,
                 }
             )
         ):
             # TODO (jcanton,phimuell): figure out dace undeterministic behaviour
-            atol = 1e-13
+            atol = 2e-13
         else:
             atol = 0.0
         parallel_helpers.check_local_global_field(


### PR DESCRIPTION
Like in #1343, add nonzero tolerance for `THETA_REF_ME`. However, this seems to be indeterministic dace behaviour. The test sometimes passes with zero tolerance and sometimes doesn't. It has failed for example on https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/5125340235196978/2255149825504678/-/jobs/15058348456#L1862.