### PR TITLE
Standalone driver: derive do_prep_adv from ltransport

### DIFF
--- a/model/standalone_driver/src/icon4py/model/standalone_driver/config.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/config.py
@@ -81,6 +81,8 @@ class DriverConfig:
     end_of_simulation: time.EndOfSimulation
     output_path: pathlib.Path = dataclasses.field(default_factory=lambda: pathlib.Path("./output"))
     apply_extra_second_order_divdamp: bool = False
+    # lprep_adv in fortran. The default matches the namelist default of ltransport.
+    do_prep_adv: bool = False
     vertical_cfl_threshold: ta.wpfloat = dataclasses.field(default_factory=lambda: ta.wpfloat(0.85))
     ndyn_substeps: int = 5
     enable_statistics_output: bool = False
@@ -119,6 +121,10 @@ class DriverConfig:
             # variable in fortran. It is coded as follows in mo_nh_stepping.f90:
             # IF (elapsed_time_global <= 7200._wp+0.5_wp*dtime .AND. .NOT. ltestcase)
             apply_extra_second_order_divdamp=not run_nml.get("ltestcase", False),
+            # mo_nh_stepping.f90 (perform_dyn_substepping):
+            # lprep_adv = ltransport .OR. (n_childdom > 0 .AND. grf_intmethod_e == 6)
+            # There are no nested domains in ICON4Py, so lprep_adv is ltransport.
+            do_prep_adv=run_nml.get("ltransport", False),
             vertical_cfl_threshold=ta.wpfloat(str(nonhydrostatic_nml["vcfl_threshold"])),
             ndyn_substeps=nonhydrostatic_nml["ndyn_substeps"],
             **overrides,

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/config.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/config.py
@@ -124,7 +124,7 @@ class DriverConfig:
             # mo_nh_stepping.f90 (perform_dyn_substepping):
             # lprep_adv = ltransport .OR. (n_childdom > 0 .AND. grf_intmethod_e == 6)
             # There are no nested domains in ICON4Py, so lprep_adv is ltransport.
-            do_prep_adv=run_nml.get("ltransport", False),
+            do_prep_adv=run_nml["ltransport"],
             vertical_cfl_threshold=ta.wpfloat(str(nonhydrostatic_nml["vcfl_threshold"])),
             ndyn_substeps=nonhydrostatic_nml["ndyn_substeps"],
             **overrides,

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/config.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/config.py
@@ -81,7 +81,7 @@ class DriverConfig:
     end_of_simulation: time.EndOfSimulation
     output_path: pathlib.Path = dataclasses.field(default_factory=lambda: pathlib.Path("./output"))
     apply_extra_second_order_divdamp: bool = False
-    # lprep_adv in fortran. The default matches the namelist default of ltransport.
+    # lprep_adv in fortran
     do_prep_adv: bool = False
     vertical_cfl_threshold: ta.wpfloat = dataclasses.field(default_factory=lambda: ta.wpfloat(0.85))
     ndyn_substeps: int = 5
@@ -120,10 +120,9 @@ class DriverConfig:
             # apply_extra_second_order_divdamp does not have a namelist
             # variable in fortran. It is coded as follows in mo_nh_stepping.f90:
             # IF (elapsed_time_global <= 7200._wp+0.5_wp*dtime .AND. .NOT. ltestcase)
-            apply_extra_second_order_divdamp=not run_nml.get("ltestcase", False),
-            # mo_nh_stepping.f90 (perform_dyn_substepping):
-            # lprep_adv = ltransport .OR. (n_childdom > 0 .AND. grf_intmethod_e == 6)
-            # There are no nested domains in ICON4Py, so lprep_adv is ltransport.
+            apply_extra_second_order_divdamp=not run_nml["ltestcase"],
+            # lprep_adv is 'ltransport .OR. (n_childdom > 0 .AND. grf_intmethod_e == 6)' in
+            # mo_nh_stepping.f90. ICON4Py has no nested domains, so it is ltransport.
             do_prep_adv=run_nml["ltransport"],
             vertical_cfl_threshold=ta.wpfloat(str(nonhydrostatic_nml["vcfl_threshold"])),
             ndyn_substeps=nonhydrostatic_nml["ndyn_substeps"],

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/driver_utils.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/driver_utils.py
@@ -541,6 +541,7 @@ def display_driver_setup_in_log_file(
     log.info(f"Initial ndyn_substeps  : {config.ndyn_substeps}")
     log.info(f"Vertical CFL threshold : {config.vertical_cfl_threshold}")
     log.info(f"Second-order divdamp   : {config.apply_extra_second_order_divdamp}")
+    log.info(f"Prepare advection      : {config.do_prep_adv}")
     log.info(f"Statistics enabled     : {config.enable_statistics_output}")
     log.info(f"Active tracers         : {tracer_config}")
     log.info("")

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
@@ -145,7 +145,6 @@ class Icon4pyDriver:
     def time_integration(
         self,
         ds: driver_states.DriverStates,
-        do_prep_adv: bool,
     ) -> None:
         diffusion_diagnostic_state = ds.diffusion_diagnostic
         solve_nonhydro_diagnostic_state = ds.solve_nonhydro_diagnostic
@@ -191,7 +190,6 @@ class Icon4pyDriver:
                     tracer_advection_diagnostic_state=tracer_advection_diagnostic_state,
                     prognostic_states=prognostic_states,
                     prep_adv=prep_adv,
-                    do_prep_adv=do_prep_adv,
                     tracer_prep_adv=tracer_prep_adv,
                 )
                 device_utils.sync(self.backend)
@@ -229,7 +227,6 @@ class Icon4pyDriver:
         tracer_advection_diagnostic_state: advection_states.AdvectionDiagnosticState | None,
         prognostic_states: common_utils.TimeStepPair[prognostics.PrognosticState],
         prep_adv: dycore_states.PrepAdvection | None,
-        do_prep_adv: bool,
         tracer_prep_adv: advection_states.AdvectionPrepAdvState | None,
     ) -> None:
         if self.config.nonhydrostatic is not None:
@@ -240,7 +237,6 @@ class Icon4pyDriver:
                 solve_nonhydro_diagnostic_state,
                 prognostic_states,
                 prep_adv,
-                do_prep_adv,
             )
 
         if self.granules.diffusion is not None:
@@ -325,7 +321,6 @@ class Icon4pyDriver:
         solve_nonhydro_diagnostic_state: dycore_states.DiagnosticStateNonHydro,
         prognostic_states: common_utils.TimeStepPair[prognostics.PrognosticState],
         prep_adv: dycore_states.PrepAdvection,
-        do_prep_adv: bool,
     ) -> None:
         # TODO(OngChia): compute airmass for prognostic_state here
 
@@ -353,7 +348,7 @@ class Icon4pyDriver:
                     dtime=self.model_time_variables.substep_timestep,
                     ndyn_substeps_var=self.model_time_variables.ndyn_substeps_var,
                     at_initial_timestep=self.model_time_variables.is_first_step_in_simulation,
-                    lprep_adv=do_prep_adv,
+                    lprep_adv=self.config.driver.do_prep_adv,
                     at_first_substep=self._is_first_substep(dyn_substep),
                     at_last_substep=self._is_last_substep(dyn_substep),
                 )
@@ -710,5 +705,5 @@ def run_driver(
         granules=icon4py_driver.granules,
         states=ds,
     )
-    icon4py_driver.time_integration(ds, do_prep_adv=False)
+    icon4py_driver.time_integration(ds)
     return ds, icon4py_driver

--- a/model/standalone_driver/tests/standalone_driver/unit_tests/test_config.py
+++ b/model/standalone_driver/tests/standalone_driver/unit_tests/test_config.py
@@ -70,3 +70,21 @@ def test_empty_modeltimestep_falls_back_to_dtime() -> None:
         atm_dict=atm_dict, master_dict=master_dict, profiling_stats=None
     )
     assert config.dtime == datetime.timedelta(seconds=120)
+
+
+# ltransport is true for MCH_CH_R04B09, EXCLAIM_APE_AES and Weisman-Klemp, false
+# for the dry testcases (JW, GAUSS3D). The fortran default is false.
+@pytest.mark.parametrize(
+    ("run_nml", "expected"),
+    [
+        ({"dtime": 10.0, "modeltimestep": "  ", "ltransport": True}, True),
+        ({"dtime": 10.0, "modeltimestep": "  ", "ltransport": False}, False),
+        ({"dtime": 10.0, "modeltimestep": "  "}, False),
+    ],
+)
+def test_do_prep_adv_from_ltransport(run_nml: dict, expected: bool) -> None:
+    atm_dict, master_dict = _make_dicts(run_nml)
+    config = driver_config.DriverConfig.from_fortran_dict(
+        atm_dict=atm_dict, master_dict=master_dict, profiling_stats=None
+    )
+    assert config.do_prep_adv is expected

--- a/model/standalone_driver/tests/standalone_driver/unit_tests/test_config.py
+++ b/model/standalone_driver/tests/standalone_driver/unit_tests/test_config.py
@@ -16,9 +16,11 @@ from icon4py.model.standalone_driver import config as driver_config
 
 
 def _make_dicts(run_nml: dict) -> tuple[dict, dict]:
+    # fortran dumps the whole namelist, so the variables the driver reads are always
+    # present. Here they only need a value when the test does not care about it.
     atm_dict = {
         "nonhydrostatic_nml": {"vcfl_threshold": 0.85, "ndyn_substeps": 5},
-        "run_nml": run_nml,
+        "run_nml": {"ltestcase": True, "ltransport": False} | run_nml,
     }
     master_dict = {
         "master_time_control_nml": {
@@ -72,19 +74,14 @@ def test_empty_modeltimestep_falls_back_to_dtime() -> None:
     assert config.dtime == datetime.timedelta(seconds=120)
 
 
-# ltransport is true for MCH_CH_R04B09, EXCLAIM_APE_AES and Weisman-Klemp, false
-# for the dry testcases (JW, GAUSS3D). The fortran default is false.
-@pytest.mark.parametrize(
-    ("run_nml", "expected"),
-    [
-        ({"dtime": 10.0, "modeltimestep": "  ", "ltransport": True}, True),
-        ({"dtime": 10.0, "modeltimestep": "  ", "ltransport": False}, False),
-        ({"dtime": 10.0, "modeltimestep": "  "}, False),
-    ],
-)
-def test_do_prep_adv_from_ltransport(run_nml: dict, expected: bool) -> None:
-    atm_dict, master_dict = _make_dicts(run_nml)
+# ltransport is true for MCH_CH_R04B09, EXCLAIM_APE_AES and Weisman-Klemp, false for
+# the dry testcases (JW, GAUSS3D).
+@pytest.mark.parametrize("ltransport", [True, False])
+def test_do_prep_adv_from_ltransport(ltransport: bool) -> None:
+    atm_dict, master_dict = _make_dicts(
+        {"dtime": 10.0, "modeltimestep": "  ", "ltransport": ltransport}
+    )
     config = driver_config.DriverConfig.from_fortran_dict(
         atm_dict=atm_dict, master_dict=master_dict, profiling_stats=None
     )
-    assert config.do_prep_adv is expected
+    assert config.do_prep_adv is ltransport


### PR DESCRIPTION
from a friend:

Part 1 of a stack that makes the standalone driver reproduce MCH_CH_R04B09. Stacked on `standalone-driver-more-tests` (#1333).

## Problem

`run_driver` hardcodes `time_integration(ds, do_prep_adv=False)`. ICON derives it (`mo_nh_stepping.f90`, `perform_dyn_substepping`):

```fortran
IF ( ltransport .OR. p_patch%n_childdom > 0 .AND. grf_intmethod_e == 6 ) THEN
  lprep_adv = .TRUE.
```

ICON4Py has no nested domains, so `lprep_adv == ltransport`. That is `true` for MCH_CH_R04B09, EXCLAIM_APE_AES and Weisman-Klemp — and the MCH savepoints record `prep_adv: true` in their metadata.

## Change

`DriverConfig.do_prep_adv`, read from `run_nml.ltransport`, threaded to `solve_nonhydro.time_step(lprep_adv=...)` from the config instead of through the `time_integration` → `_integrate_one_time_step` → `_do_dyn_substepping` parameter chain.

## Impact

`lprep_adv` only gates the tracer-advection quantities (`vn_traj`, `mass_flx_me`, `mass_flx_ic`), not the prognostic fields, so the dry testcases are unchanged. Verified: JW and GAUSS3D driver datatests still pass against the tolerances measured on `standalone-driver-more-tests` (gtfn_cpu).
