### PR TITLE
Standalone driver: fix the spin-up second order divergence damping

### DIFF
--- a/model/standalone_driver/src/icon4py/model/standalone_driver/driver_constants.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/driver_constants.py
@@ -18,8 +18,8 @@ CFL_THRESHOLD_FACTOR = ta.wpfloat("0.9")
 #: Factor multiplied to the user-defined CFL number to determine the whether to leave watchmode
 CFL_LEAVE_WATCHMODE_FACTOR = ta.wpfloat("0.76")
 
-#: Adjustment factor for second order divergence damping
-ADJUST_FACTOR_FOR_SECOND_ORDER_DIVDAMP = ta.wpfloat("0.8")
+#: Adjustment factor for second order divergence damping (update_spinup_damping in mo_nh_stepping.f90)
+ADJUST_FACTOR_FOR_SECOND_ORDER_DIVDAMP = ta.wpfloat("8.0")
 
 #: Initial period for second order divergence damping
 INITIAL_PERIOD_FOR_SECOND_ORDER_DIVDAMP = ta.wpfloat("1800.0")

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/driver_states.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/driver_states.py
@@ -120,6 +120,17 @@ class ModelTimeVariables:
     def substep_timestep(self) -> ta.wpfloat:
         return ta.wpfloat(self.dtime_in_seconds / self.ndyn_substeps_var)
 
+    @property
+    def elapsed_time_at_step_midpoint_in_seconds(self) -> ta.wpfloat:
+        """
+        Elapsed time at the middle of the current time step.
+
+        elapsed_time_global = (jstep - 0.5) * dtime in mo_nh_stepping.f90, with a
+        one-based jstep. 'advance_simulation_datetime' is called before the step is
+        integrated, so 'elapsed_time_in_seconds' is already at the end of it.
+        """
+        return ta.wpfloat(self.elapsed_time_in_seconds - 0.5 * self.dtime_in_seconds)
+
     def advance_simulation_datetime(self) -> None:
         self.simulation_current_datetime += self.dtime
         self.elapsed_time_in_seconds += self.dtime_in_seconds

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/driver_utils.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/driver_utils.py
@@ -47,7 +47,7 @@ from icon4py.model.common.metrics import metrics_attributes, metrics_factory
 from icon4py.model.common.states import factory as states_factory, static_fields
 from icon4py.model.common.states.tracer_state import TracerConfig
 from icon4py.model.common.utils import data_allocation as data_alloc
-from icon4py.model.standalone_driver import config as driver_config, driver_states
+from icon4py.model.standalone_driver import config as driver_config, driver_constants, driver_states
 
 
 log = logging.getLogger(__name__)
@@ -444,6 +444,33 @@ def initialize_granules(
         diffusion=diffusion_granule,
         tracer_advection=tracer_advection_granule,
     )
+
+
+def spinup_second_order_divdamp_factor(
+    *,
+    elapsed_time_in_seconds: ta.wpfloat,
+    fourth_order_divdamp_factor: ta.wpfloat,
+) -> ta.wpfloat:
+    """
+    Second order divergence damping factor (divdamp_fac_o2) during the spin-up phase.
+
+    update_spinup_damping in mo_nh_stepping.f90: the damping is enhanced during
+    the first half hour of integration and then decreases linearly to zero.
+    """
+    initial_period = driver_constants.INITIAL_PERIOD_FOR_SECOND_ORDER_DIVDAMP
+    transition_end_period = driver_constants.TRANSITION_END_PERIOD_FOR_SECOND_ORDER_DIVDAMP
+    enhanced_factor = (
+        driver_constants.ADJUST_FACTOR_FOR_SECOND_ORDER_DIVDAMP * fourth_order_divdamp_factor
+    )
+    if elapsed_time_in_seconds <= initial_period:
+        return enhanced_factor
+    if elapsed_time_in_seconds <= transition_end_period:
+        return (
+            enhanced_factor
+            * (transition_end_period - elapsed_time_in_seconds)
+            / (transition_end_period - initial_period)
+        )
+    return ta.wpfloat("0.0")
 
 
 def find_maximum_from_field(

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
@@ -464,17 +464,6 @@ class Icon4pyDriver:
     def _second_order_divdamp_factor(self) -> ta.wpfloat:
         """
         Second order divergence damping factor (divdamp_fac_o2) for the current time step.
-
-        mo_nh_stepping.f90, in the time loop, before integrate_nh:
-
-            IF (divdamp_order==24) THEN
-              elapsed_time_global = (REAL(jstep,wp)-0.5_wp)*dtime
-              IF (elapsed_time_global <= 7200._wp+0.5_wp*dtime .AND. .NOT. ltestcase) THEN
-                CALL update_spinup_damping(elapsed_time_global)
-              ELSE
-                divdamp_fac_o2 = 0._wp
-              ENDIF
-            ENDIF
         """
         assert self.config.nonhydrostatic is not None
         fourth_order_divdamp_factor = self.config.nonhydrostatic.fourth_order_divdamp_factor

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
@@ -191,7 +191,6 @@ class Icon4pyDriver:
                     prognostic_states=prognostic_states,
                     prep_adv=prep_adv,
                     tracer_prep_adv=tracer_prep_adv,
-                    second_order_divdamp_factor=self._second_order_divdamp_factor(),
                 )
                 device_utils.sync(self.backend)
 
@@ -229,7 +228,6 @@ class Icon4pyDriver:
         prognostic_states: common_utils.TimeStepPair[prognostics.PrognosticState],
         prep_adv: dycore_states.PrepAdvection | None,
         tracer_prep_adv: advection_states.AdvectionPrepAdvState | None,
-        second_order_divdamp_factor: ta.wpfloat,
     ) -> None:
         if self.config.nonhydrostatic is not None:
             assert solve_nonhydro_diagnostic_state is not None
@@ -239,7 +237,6 @@ class Icon4pyDriver:
                 solve_nonhydro_diagnostic_state,
                 prognostic_states,
                 prep_adv,
-                second_order_divdamp_factor,
             )
 
         if self.granules.diffusion is not None:
@@ -324,9 +321,11 @@ class Icon4pyDriver:
         solve_nonhydro_diagnostic_state: dycore_states.DiagnosticStateNonHydro,
         prognostic_states: common_utils.TimeStepPair[prognostics.PrognosticState],
         prep_adv: dycore_states.PrepAdvection,
-        second_order_divdamp_factor: ta.wpfloat,
     ) -> None:
         # TODO(OngChia): compute airmass for prognostic_state here
+
+        # updated once per time step, and not cached: it decreases with the elapsed time
+        second_order_divdamp_factor = self._second_order_divdamp_factor()
 
         timer_solve_nh = (
             self.timer_collection.timers[driver_states.DriverTimers.SOLVE_NH_FIRST_STEP.value]
@@ -463,6 +462,8 @@ class Icon4pyDriver:
     def _second_order_divdamp_factor(self) -> ta.wpfloat:
         """
         Second order divergence damping factor (divdamp_fac_o2) for the current time step.
+
+        The guards are those of the call to update_spinup_damping in mo_nh_stepping.f90.
         """
         assert self.config.nonhydrostatic is not None
         fourth_order_divdamp_factor = self.config.nonhydrostatic.fourth_order_divdamp_factor

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
@@ -463,7 +463,16 @@ class Icon4pyDriver:
         """
         Second order divergence damping factor (divdamp_fac_o2) for the current time step.
 
-        The guards are those of the call to update_spinup_damping in mo_nh_stepping.f90.
+        mo_nh_stepping.f90, in the time loop, before integrate_nh:
+
+            IF (divdamp_order==24) THEN
+              elapsed_time_global = (REAL(jstep,wp)-0.5_wp)*dtime
+              IF (elapsed_time_global <= 7200._wp+0.5_wp*dtime .AND. .NOT. ltestcase) THEN
+                CALL update_spinup_damping(elapsed_time_global)
+              ELSE
+                divdamp_fac_o2 = 0._wp
+              ENDIF
+            ENDIF
         """
         assert self.config.nonhydrostatic is not None
         fourth_order_divdamp_factor = self.config.nonhydrostatic.fourth_order_divdamp_factor

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
@@ -191,6 +191,8 @@ class Icon4pyDriver:
                     prognostic_states=prognostic_states,
                     prep_adv=prep_adv,
                     tracer_prep_adv=tracer_prep_adv,
+                    # updated once per time step, as in mo_nh_stepping.f90
+                    second_order_divdamp_factor=self._second_order_divdamp_factor(),
                 )
                 device_utils.sync(self.backend)
 
@@ -228,6 +230,7 @@ class Icon4pyDriver:
         prognostic_states: common_utils.TimeStepPair[prognostics.PrognosticState],
         prep_adv: dycore_states.PrepAdvection | None,
         tracer_prep_adv: advection_states.AdvectionPrepAdvState | None,
+        second_order_divdamp_factor: ta.wpfloat,
     ) -> None:
         if self.config.nonhydrostatic is not None:
             assert solve_nonhydro_diagnostic_state is not None
@@ -237,6 +240,7 @@ class Icon4pyDriver:
                 solve_nonhydro_diagnostic_state,
                 prognostic_states,
                 prep_adv,
+                second_order_divdamp_factor,
             )
 
         if self.granules.diffusion is not None:
@@ -321,6 +325,7 @@ class Icon4pyDriver:
         solve_nonhydro_diagnostic_state: dycore_states.DiagnosticStateNonHydro,
         prognostic_states: common_utils.TimeStepPair[prognostics.PrognosticState],
         prep_adv: dycore_states.PrepAdvection,
+        second_order_divdamp_factor: ta.wpfloat,
     ) -> None:
         # TODO(OngChia): compute airmass for prognostic_state here
 
@@ -344,7 +349,7 @@ class Icon4pyDriver:
                     diagnostic_state_nh=solve_nonhydro_diagnostic_state,
                     prognostic_states=prognostic_states,
                     prep_adv=prep_adv,
-                    second_order_divdamp_factor=self._update_spinup_second_order_divergence_damping(),
+                    second_order_divdamp_factor=second_order_divdamp_factor,
                     dtime=self.model_time_variables.substep_timestep,
                     ndyn_substeps_var=self.model_time_variables.ndyn_substeps_var,
                     at_initial_timestep=self.model_time_variables.is_first_step_in_simulation,
@@ -456,38 +461,45 @@ class Icon4pyDriver:
             0.0, self._allocator
         )
 
-    def _update_spinup_second_order_divergence_damping(self) -> ta.wpfloat:
-        if self.config.driver.apply_extra_second_order_divdamp:
-            assert self.config.nonhydrostatic is not None
-            fourth_order_divdamp_factor = self.config.nonhydrostatic.fourth_order_divdamp_factor
-            if (
-                self.model_time_variables.elapsed_time_in_seconds
-                <= driver_constants.INITIAL_PERIOD_FOR_SECOND_ORDER_DIVDAMP
-            ):
-                return (
-                    driver_constants.ADJUST_FACTOR_FOR_SECOND_ORDER_DIVDAMP
-                    * fourth_order_divdamp_factor
-                )
-            elif (
-                self.model_time_variables.elapsed_time_in_seconds
-                <= driver_constants.TRANSITION_END_PERIOD_FOR_SECOND_ORDER_DIVDAMP
-            ):
-                return (
-                    driver_constants.ADJUST_FACTOR_FOR_SECOND_ORDER_DIVDAMP
-                    * fourth_order_divdamp_factor
-                    * (
-                        self.model_time_variables.elapsed_time_in_seconds
-                        - driver_constants.INITIAL_PERIOD_FOR_SECOND_ORDER_DIVDAMP
-                    )
-                    / (
-                        driver_constants.TRANSITION_END_PERIOD_FOR_SECOND_ORDER_DIVDAMP
-                        - driver_constants.INITIAL_PERIOD_FOR_SECOND_ORDER_DIVDAMP
-                    )
-                )
-            else:
-                return ta.wpfloat("0.0")
-        else:
+    def _second_order_divdamp_factor(self) -> ta.wpfloat:
+        """
+        Second order divergence damping factor (divdamp_fac_o2) for the current time step.
+
+        mo_nh_stepping.f90, in the time loop, before integrate_nh:
+
+            IF (divdamp_order==24) THEN
+              elapsed_time_global = (REAL(jstep,wp)-0.5_wp)*dtime
+              IF (elapsed_time_global <= 7200._wp+0.5_wp*dtime .AND. .NOT. ltestcase) THEN
+                CALL update_spinup_damping(elapsed_time_global)
+              ELSE
+                divdamp_fac_o2 = 0._wp
+              ENDIF
+            ENDIF
+        """
+        assert self.config.nonhydrostatic is not None
+        fourth_order_divdamp_factor = self.config.nonhydrostatic.fourth_order_divdamp_factor
+        if (
+            self.config.nonhydrostatic.divdamp_order
+            != dycore_states.DivergenceDampingOrder.COMBINED
+        ):
+            # divdamp_fac_o2 is only updated at runtime for divdamp_order = 24. Otherwise it
+            # keeps the value it is initialized with in mo_nonhydrostatic_nml.f90: divdamp_fac.
+            return fourth_order_divdamp_factor
+
+        elapsed_time_in_seconds = self.model_time_variables.elapsed_time_at_step_midpoint_in_seconds
+        spinup_cutoff = driver_constants.TRANSITION_END_PERIOD_FOR_SECOND_ORDER_DIVDAMP + (
+            0.5 * self.model_time_variables.dtime_in_seconds
+        )
+        if (
+            not self.config.driver.apply_extra_second_order_divdamp
+            or elapsed_time_in_seconds > spinup_cutoff
+        ):
             return ta.wpfloat("0.0")
+
+        return driver_utils.spinup_second_order_divdamp_factor(
+            elapsed_time_in_seconds=elapsed_time_in_seconds,
+            fourth_order_divdamp_factor=fourth_order_divdamp_factor,
+        )
 
     def _compute_statistics(
         self, current_dyn_substep: int, prognostic_states: prognostics.PrognosticState

--- a/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
+++ b/model/standalone_driver/src/icon4py/model/standalone_driver/standalone_driver.py
@@ -191,7 +191,6 @@ class Icon4pyDriver:
                     prognostic_states=prognostic_states,
                     prep_adv=prep_adv,
                     tracer_prep_adv=tracer_prep_adv,
-                    # updated once per time step, as in mo_nh_stepping.f90
                     second_order_divdamp_factor=self._second_order_divdamp_factor(),
                 )
                 device_utils.sync(self.backend)

--- a/model/standalone_driver/tests/standalone_driver/unit_tests/test_driver_utils.py
+++ b/model/standalone_driver/tests/standalone_driver/unit_tests/test_driver_utils.py
@@ -1,0 +1,42 @@
+"""Unit tests for ``standalone_driver.driver_utils`` (data-free)."""
+
+import pytest
+
+from icon4py.model.standalone_driver import driver_utils
+
+
+# MCH_CH_R04B09 has divdamp_fac = 0.004, so the enhanced factor is 8 * 0.004 = 0.032.
+# That is the value of divdamp_fac_o2 recorded in its solve-nonhydro savepoints.
+@pytest.mark.parametrize(
+    ("elapsed_time_in_seconds", "expected"),
+    [
+        (0.0, 0.032),
+        (5.0, 0.032),
+        (1800.0, 0.032),
+        # linear decrease from 8 * divdamp_fac to zero between 1800 s and 7200 s
+        (4500.0, 0.016),
+        (7200.0, 0.0),
+        (7201.0, 0.0),
+    ],
+)
+def test_spinup_second_order_divdamp_factor(
+    elapsed_time_in_seconds: float, expected: float
+) -> None:
+    factor = driver_utils.spinup_second_order_divdamp_factor(
+        elapsed_time_in_seconds=elapsed_time_in_seconds,
+        fourth_order_divdamp_factor=0.004,
+    )
+    assert factor == pytest.approx(expected)
+
+
+def test_spinup_second_order_divdamp_factor_decreases_after_the_initial_period() -> None:
+    factors = [
+        driver_utils.spinup_second_order_divdamp_factor(
+            elapsed_time_in_seconds=float(elapsed_time_in_seconds),
+            fourth_order_divdamp_factor=0.004,
+        )
+        for elapsed_time_in_seconds in range(1800, 7201, 100)
+    ]
+    assert all(later < earlier for earlier, later in zip(factors, factors[1:], strict=False)), (
+        factors
+    )

--- a/model/standalone_driver/tests/standalone_driver/unit_tests/test_driver_utils.py
+++ b/model/standalone_driver/tests/standalone_driver/unit_tests/test_driver_utils.py
@@ -1,4 +1,14 @@
+# ICON4Py - ICON inspired code in Python and GT4Py
+#
+# Copyright (c) 2022-2024, ETH Zurich and MeteoSwiss
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
 """Unit tests for ``standalone_driver.driver_utils`` (data-free)."""
+
+import itertools
 
 import pytest
 
@@ -37,6 +47,4 @@ def test_spinup_second_order_divdamp_factor_decreases_after_the_initial_period()
         )
         for elapsed_time_in_seconds in range(1800, 7201, 100)
     ]
-    assert all(later < earlier for earlier, later in zip(factors, factors[1:], strict=False)), (
-        factors
-    )
+    assert all(later < earlier for earlier, later in itertools.pairwise(factors)), factors


### PR DESCRIPTION
from a friend:

Part 2 of the MCH_CH_R04B09 stack. Stacked on #1369.

## Problem

`update_spinup_damping` (`mo_nh_stepping.f90`):

```fortran
time1 = 1800._wp ; time2 = 7200._wp
IF (elapsed_time <= time1) THEN
  divdamp_fac_o2 = 8._wp*divdamp_fac
ELSE IF (elapsed_time <= time2) THEN
  divdamp_fac_o2 = 8._wp*divdamp_fac*(time2-elapsed_time)/(time2-time1)
ELSE
  divdamp_fac_o2 = 0._wp
ENDIF
```

called **once per model time step**, under `divdamp_order == 24` and `elapsed_time_global = (jstep-0.5)*dtime <= 7200 + 0.5*dtime .AND. .NOT. ltestcase`.

The driver had four defects:

1. `ADJUST_FACTOR_FOR_SECOND_ORDER_DIVDAMP = 0.8`, ICON uses `8.0`.
2. The ramp was inverted: `(elapsed - 1800)/(7200 - 1800)` instead of `(7200 - elapsed)/(7200 - 1800)`, i.e. it ramped *up* where ICON ramps *down*.
3. It was evaluated per dynamics substep rather than once per time step.
4. No `divdamp_order` guard.

Defect 1 is not just a magnitude error. `solve_nonhydro` gates the fourth-order damping on `second_order_divdamp_factor <= 4 * fourth_order_divdamp_factor` (mirroring ICON's `divdamp_fac_o2 <= 4._wp*divdamp_fac`), whose purpose is to *disable* fourth-order damping during spin-up. With `0.8` that condition was always true, so the driver applied fourth-order damping where ICON does not, together with a 10x too small second-order coefficient.

## Change

- The constant becomes `8.0`.
- `driver_utils.spinup_second_order_divdamp_factor` is a pure function mirroring `update_spinup_damping`, with the decreasing ramp.
- `ModelTimeVariables.elapsed_time_at_step_midpoint_in_seconds` reproduces ICON's `(jstep - 0.5)*dtime` (the driver advances the datetime before integrating the step).
- The factor is computed once per time step in `time_integration` and threaded down to `solve_nonhydro.time_step`, with ICON's guards.

For `divdamp_order != 24` the factor now stays at `divdamp_fac`, as in `mo_nonhydrostatic_nml.f90`, where `divdamp_fac_o2` is initialized to `divdamp_fac` and then never updated at runtime. No serialized experiment uses that path (all are `divdamp_order = 24`).

## Verification

New unit tests pin `8 * 0.004 = 0.032` — exactly the `divdamp_fac_o2` recorded in every MCH `solve-nonhydro-init` savepoint — and the decreasing ramp. The JW and GAUSS3D driver datatests are unchanged (`ltestcase = true`, so the factor is `0.0` before and after).

The dycore is untouched: it already implements ICON's `-0.25*divdamp_fac_o2` clip (`dycore_utils.py`) and the `<= 4*divdamp_fac` gate (`solve_nonhydro.py`).
