### PR TITLE
Update merge pipeline to only produce success status on PRs

### DIFF
--- a/.github/workflows/mandatory_and_optional_test_reminder.yml
+++ b/.github/workflows/mandatory_and_optional_test_reminder.yml
@@ -12,10 +12,6 @@ jobs:
           refresh-message-position: true
           message: |2
 
-            **Mandatory Tests**
-
-            **Before merging, run the `merge` pipeline with `cscs-ci run merge`. Merging is blocked unless this pipeline passes.**
-
             When developing, you can test your changes on CSCS CI before merge with the `default` pipeline: `cscs-ci run default`. This will run a default subset of tests.
 
             You can pass options to override pipeline variables, for example:
@@ -38,6 +34,10 @@ jobs:
             See `scripts/python/generate_ci_pipeline.py` and `noxfile.py` for available values for each option.
 
             The `all` pipeline can be run with `cscs-ci run all`. This will run all icon4py tests in CSCS CI which can be expensive. This pipeline runs on a schedule on main, and can be run when extensive validation is needed (e.g. before releases).
+
+            **Merging**
+
+            Once your PR is approved and ready for merging, add it to the merge queue. The `merge` CSCS CI pipeline will run automatically on the merge-queue branch and must pass before the PR is merged. A dummy `merge` check will be triggered on the PR itself since it's required to add a PR to the merge queue.
 
             **Optional Tests**
 

--- a/ci/merge.yml
+++ b/ci/merge.yml
@@ -21,14 +21,14 @@ variables:
   GRIDS: "simple:icon_regional"
   TOOLS_SUBSETS: "datatest:unittest"
 
-.merge_queue_only: &merge_queue_only
-  rules:
+.merge_queue_only:
+  rules: &merge_queue_only
     - if: $CI_COMMIT_BRANCH =~ /^gh-readonly-queue/
       when: always
     - when: never
 
-.pr_only: &pr_only
-  rules:
+.pr_only:
+  rules: &pr_only
     - if: $CI_COMMIT_BRANCH =~ /^gh-readonly-queue/
       when: never
     - if: $CI_COMMIT_BRANCH == "main"
@@ -36,7 +36,6 @@ variables:
     - when: always
 
 merge_check:
-  stage: .pre
   extends: [.container-runner-lightweight-zen2]
   rules: *pr_only
   image: alpine:latest

--- a/ci/merge.yml
+++ b/ci/merge.yml
@@ -1,6 +1,13 @@
 include:
   - local: 'ci/base.yml'
 
+workflow:
+  rules:
+    # Completely skip the pipeline on main, not needed there.
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: never
+    - when: always
+
 variables:
   # See default.yml and generate_ci_pipeline.py for details on how these are
   # used. This pipeline gates merges and variables should not be overridden.
@@ -14,18 +21,38 @@ variables:
   GRIDS: "simple:icon_regional"
   TOOLS_SUBSETS: "datatest:unittest"
 
+.merge_queue_only:
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^gh-readonly-queue\//
+      when: always
+    - when: never
+
+.pr_only:
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^gh-readonly-queue\//
+      when: never
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: never
+    - when: always
+
+merge_check:
+  stage: .pre
+  extends: [.container-runner-lightweight-zen2, .pr_only]
+  image: alpine:latest
+  script:
+    - echo "Skipping full CSCS merge tests on PR; will run in merge queue"
 
 build_baseimage_aarch64:
-  extends: [.build_baseimage_aarch64]
+  extends: [.build_baseimage_aarch64, .merge_queue_only]
 
 build_venv_aarch64:
-  extends: [.build_venv_aarch64]
+  extends: [.build_venv_aarch64, .merge_queue_only]
 
 build_image_aarch64:
-  extends: [.build_image_aarch64]
+  extends: [.build_image_aarch64, .merge_queue_only]
 
 generate_test_child_pipeline:
-  extends: [.generate_test_child_pipeline]
+  extends: [.generate_test_child_pipeline, .merge_queue_only]
 
 trigger_test_child_pipeline:
-  extends: [.trigger_test_child_pipeline]
+  extends: [.trigger_test_child_pipeline, .merge_queue_only]

--- a/ci/merge.yml
+++ b/ci/merge.yml
@@ -21,15 +21,15 @@ variables:
   GRIDS: "simple:icon_regional"
   TOOLS_SUBSETS: "datatest:unittest"
 
-.merge_queue_only:
+.merge_queue_only: &merge_queue_only
   rules:
-    - if: $CI_COMMIT_BRANCH =~ /^gh-readonly-queue\//
+    - if: $CI_COMMIT_BRANCH =~ /^gh-readonly-queue/
       when: always
     - when: never
 
-.pr_only:
+.pr_only: &pr_only
   rules:
-    - if: $CI_COMMIT_BRANCH =~ /^gh-readonly-queue\//
+    - if: $CI_COMMIT_BRANCH =~ /^gh-readonly-queue/
       when: never
     - if: $CI_COMMIT_BRANCH == "main"
       when: never
@@ -37,22 +37,28 @@ variables:
 
 merge_check:
   stage: .pre
-  extends: [.container-runner-lightweight-zen2, .pr_only]
+  extends: [.container-runner-lightweight-zen2]
+  rules: *pr_only
   image: alpine:latest
   script:
     - echo "Skipping full CSCS merge tests on PR; will run in merge queue"
 
 build_baseimage_aarch64:
-  extends: [.build_baseimage_aarch64, .merge_queue_only]
+  extends: [.build_baseimage_aarch64]
+  rules: *merge_queue_only
 
 build_venv_aarch64:
-  extends: [.build_venv_aarch64, .merge_queue_only]
+  extends: [.build_venv_aarch64]
+  rules: *merge_queue_only
 
 build_image_aarch64:
-  extends: [.build_image_aarch64, .merge_queue_only]
+  extends: [.build_image_aarch64]
+  rules: *merge_queue_only
 
 generate_test_child_pipeline:
-  extends: [.generate_test_child_pipeline, .merge_queue_only]
+  extends: [.generate_test_child_pipeline]
+  rules: *merge_queue_only
 
 trigger_test_child_pipeline:
-  extends: [.trigger_test_child_pipeline, .merge_queue_only]
+  extends: [.trigger_test_child_pipeline]
+  rules: *merge_queue_only


### PR DESCRIPTION
This is required to have merge queues work smoothly. Updates the `merge` pipeline to automatically trigger a dummy job when run on PRs so that a green checkmark is produced on the PR and the PR can be added to the merge queue. Github's required checks are the same for adding a PR to the merge queue and for merging from the merge queue to main, and we don't want to have to first run the full `merge` pipeline on the PR and then repeat it in the merge queue.