### PR TITLE
Enable merge queue for github workflows

### DIFF
--- a/.github/workflows/icon4py-qa.yml
+++ b/.github/workflows/icon4py-qa.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
     types: [opened, reopened, synchronize]
+  merge_group:
 jobs:
   pre-commit-icon4py-model:
     runs-on: ubuntu-latest

--- a/.github/workflows/icon4py-test-model.yml
+++ b/.github/workflows/icon4py-test-model.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
     types: [opened, reopened, synchronize]
+  merge_group:
 
 env:
   ICON4PY_TEST_DATA_PATH: "${{ github.workspace }}/testdata"

--- a/.github/workflows/icon4py-test-tools-and-bindings.yml
+++ b/.github/workflows/icon4py-test-tools-and-bindings.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
     types: [opened, reopened, synchronize]
+  merge_group:
 jobs:
   test-bindings:
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi-deploy.yml
+++ b/.github/workflows/pypi-deploy.yml
@@ -9,6 +9,7 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  merge_group:
 
 jobs:
   discover:


### PR DESCRIPTION
Follow up to https://github.com/C2SM/icon4py/pull/1381. The github workflows also need triggers on merge queues to actually run when a PR is added to the merge queue.