### PR TITLE
Slightly loosen test tolerances

### DIFF
--- a/model/standalone_driver/tests/standalone_driver/integration_tests/test_standalone_driver.py
+++ b/model/standalone_driver/tests/standalone_driver/integration_tests/test_standalone_driver.py
@@ -45,7 +45,7 @@ _TOLERANCES: dict[test_defs.ExperimentDescription, dict[str, tuple[float, float]
     },
     test_defs.Experiments.MCH_CH_R04B09: {
         "vn": (3.5e-3, 0.0),
-        "w": (7.9e-4, 0.0),
+        "w": (1e-3, 0.0),
         "exner": (6.8e-7, 9.9e-7),
         "theta_v": (1.2e-3, 3.6e-6),
         "rho": (3.5e-6, 3.7e-6),

--- a/model/standalone_driver/tests/standalone_driver/mpi_tests/test_parallel_standalone_driver.py
+++ b/model/standalone_driver/tests/standalone_driver/mpi_tests/test_parallel_standalone_driver.py
@@ -101,7 +101,7 @@ def _run_standalone_driver_compare_single_multi_rank(
         atol = 1e-12
         rtol = 1e-14
     else:
-        atol = 1e-10
+        atol = 1e-9
         rtol = 0.0
     atol, rtol = test_utils.get_mpi_comparison_tolerance(backend, atol=atol, rtol=rtol)
 


### PR DESCRIPTION
#1376 introduced new tests and tolerances but they're a bit unnecessarily tight with the occasional non-determinism. There were two recent failures in CI.

On the nightly all pipeline (https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/5125340235196978/2255149825504677/-/jobs/15422920492#L1501):
```
 4: FAILED tests/standalone_driver/mpi_tests/test_parallel_standalone_driver.py::test_standalone_driver_compare_single_multi_rank[validation-jw-True] - AssertionError: 
 4: Not equal to tolerance rtol=0, atol=1e-10
 4: internal
 4: Mismatched elements: 314 / 1075200 (0.0292%)
 4: First 5 mismatches are at indices:
 4:  [655, 34]: -6.247879062162995 (ACTUAL), -6.247879062265003 (DESIRED)
 4:  [661, 34]: -6.341882740444506 (ACTUAL), -6.3418827405465095 (DESIRED)
 4:  [717, 34]: 6.608391349642585 (ACTUAL), 6.608391349746506 (DESIRED)
 4:  [719, 33]: 6.907742489695851 (ACTUAL), 6.907742489798639 (DESIRED)
 4:  [719, 34]: 6.54542721049649 (ACTUAL), 6.545427210606157 (DESIRED)
 4: Max absolute difference among violations: 1.6844659e-10
 4: Max relative difference among violations: 2.42130552e-10
 4:  ACTUAL: array([[-2.108165e-01, -2.067524e-01, -2.056807e-01, ..., -8.296065e-02,
 4:         -8.080941e-02, -7.964856e-02],
 4:        [ 3.834226e-03,  3.422138e-03,  2.867736e-03, ..., -2.701412e-04,...
 4:  DESIRED: array([[-2.108165e-01, -2.067524e-01, -2.056807e-01, ..., -8.296065e-02,
 4:         -8.080941e-02, -7.964856e-02],
 4:        [ 3.834226e-03,  3.422138e-03,  2.867736e-03, ..., -2.701412e-04,...
```

And on another PR (https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/5125340235196978/2255149825504678/-/jobs/15427357477#L557):
```
FAILED tests/standalone_driver/integration_tests/test_standalone_driver.py::test_standalone_driver[False-experiment_description2-2-2-2021-06-20T12:00:00.000-2021-06-20T12:00:10.000-2021-06-20T12:00:10.000-True-False] - AssertionError: 
Not equal to tolerance rtol=0, atol=0.00079
w
Mismatched elements: 1 / 1379136 (7.25e-05%)
Mismatch at index:
 [19760, 24]: 6.164970832163852 (ACTUAL), 6.165766704633181 (DESIRED)
Max absolute difference among violations: 0.00079587
Max relative difference among violations: 0.00012908
 ACTUAL: array([[-0.014014,  0.02296 ,  0.038716, ..., -0.019412, -0.031826,
        -0.027864],
       [-0.013411,  0.021888,  0.037781, ..., -0.09739 , -0.052057,...
 DESIRED: array([[-0.014014,  0.02296 ,  0.038716, ..., -0.019412, -0.031826,
        -0.027864],
       [-0.013411,  0.021888,  0.037781, ..., -0.09739 , -0.052057,...
```

#1368 will help reduce these as we'll have at least the standalone driver produce bitwise identical results with all backends.