### PR TITLE
Retry common CSCS CI failures

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -175,8 +175,7 @@ variables:
     - if: $BACKEND == 'dace_gpu' || $BACKEND == 'gtfn_gpu'
       variables:
         NUM_PROCESSES: 8
-        # TODO: Increase back to normal
-        SLURM_TIMELIMIT: '00:05:00'
+        SLURM_TIMELIMIT: '01:00:00'
     - if: $MODEL_SUBPACKAGE == 'standalone_driver'
       variables:
         SLURM_TIMELIMIT: '00:50:00'

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -150,7 +150,7 @@ variables:
   # signal according to https://man7.org/linux/man-pages/man7/signal.7.html and
   # https://tldp.org/LDP/abs/html/exitcodes.html.
   retry:
-    max: 3
+    max: 2
     when:
       - runner_system_failure
       - runner_interrupted

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -175,7 +175,8 @@ variables:
     - if: $BACKEND == 'dace_gpu' || $BACKEND == 'gtfn_gpu'
       variables:
         NUM_PROCESSES: 8
-        SLURM_TIMELIMIT: '01:00:00'
+        # TODO: Increase back to normal
+        SLURM_TIMELIMIT: '00:05:00'
     - if: $MODEL_SUBPACKAGE == 'standalone_driver'
       variables:
         SLURM_TIMELIMIT: '00:50:00'

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -139,8 +139,32 @@ variables:
     # so this can be used safely.
     UV_LINK_MODE: symlink
 
+.retry_on_transient_failure:
+  # Retry on transient runner/scheduler failures and signal-killed (e.g. slurm
+  # timeouts and cancellations due to filesystem/network hangs) jobs.
+  #
+  # GitLab failure types and exit codes are documented at:
+  # https://docs.gitlab.com/ee/ci/yaml/#retry
+  #
+  # 137 and 143 are SIGKILL and SIGTERM for slurm cancellations. These are 128 +
+  # signal according to https://man7.org/linux/man-pages/man7/signal.7.html and
+  # https://tldp.org/LDP/abs/html/exitcodes.html.
+  retry:
+    max: 3
+    when:
+      - runner_system_failure
+      - runner_interrupted
+      - runner_external_dependency_failure
+      - api_failure
+      - scheduler_failure
+      - server_timeout_running
+      - server_timeout_canceling
+    exit_codes:
+      - 137
+      - 143
+
 .test_model_aarch64:
-  extends: [.test_runner_serial, .test_template_aarch64]
+  extends: [.test_runner_serial, .test_template_aarch64, .retry_on_transient_failure]
   script:
     - |
       PYTEST_ARGS="--backend=$BACKEND"
@@ -163,12 +187,12 @@ variables:
         SLURM_TIMELIMIT: '00:30:00'
 
 .test_tools_aarch64:
-  extends: [.test_runner_serial, .test_template_aarch64]
+  extends: [.test_runner_serial, .test_template_aarch64, .retry_on_transient_failure]
   script:
     - nox -s "test_tools_and_bindings-${PYVERSION_SHORT}($SELECTION)"
 
 .test_model_mpi_aarch64:
-  extends: [.test_runner_mpi, .test_template_aarch64]
+  extends: [.test_runner_mpi, .test_template_aarch64, .retry_on_transient_failure]
   script:
     - ci/scripts/ci-mpi-wrapper.sh nox -s "test_model_mpi-${PYVERSION_SHORT}($SELECTION, $MODEL_MPI_SUBPACKAGE)" -- --backend=$BACKEND --level=$LEVEL
   rules:


### PR DESCRIPTION
Retry common sources of CI test job failures. This adds a number of built-in gitlab error types to be automatically retried, but more importantly retries slurm jobs that get SIGKILLed or SIGTERMed (which happens when a time limit is hit, i.e. a job runs for too long from network/filesystem/whatever hang). Jobs can be retried a maximum of two times (this is a gitlab config maximum), so I've set the retry count to that. There's a small chance for false positives e.g. from OOM kills which I think would also get SIGTERMed or SIGKILLed, but those would typically only happen if concurrency etc. in the job are badly configured, which most PRs won't touch. The retries only happen on test jobs.