### PR TITLE
Change some CSCS CI variable choices to use all instead of explicit lists

### DIFF
--- a/ci/default.yml
+++ b/ci/default.yml
@@ -9,10 +9,10 @@ variables:
   # jobs. They are meant to be overridden with e.g.
   #
   # cscs-ci run default;BACKENDS=gtfn_cpu;LEVELS=unit;MODEL_SUBPACKAGES=common:standalone_driver;MODEL_MPI_SUBPACKAGES=common;SESSIONS=model;MODEL_SUBSETS=datatest
-  SESSIONS: "model:model_mpi:tools"
-  MODEL_SUBPACKAGES: "tracer_advection:diffusion:dycore:microphysics:muphys:common:standalone_driver"
+  SESSIONS: "all"
+  MODEL_SUBPACKAGES: "all"
   MODEL_SUBSETS: "datatest"
-  MODEL_MPI_SUBPACKAGES: "tracer_advection:diffusion:dycore:common:standalone_driver"
+  MODEL_MPI_SUBPACKAGES: "all"
   MODEL_MPI_SUBSETS: "datatest"
   BACKENDS: "gtfn_gpu"
   LEVELS: "unit"

--- a/ci/merge.yml
+++ b/ci/merge.yml
@@ -5,11 +5,11 @@ variables:
   # See default.yml and generate_ci_pipeline.py for details on how these are
   # used. This pipeline gates merges and variables should not be overridden.
   SESSIONS: "model:model_mpi:tools"
-  MODEL_SUBPACKAGES: "tracer_advection:diffusion:dycore:microphysics:muphys:common:standalone_driver"
+  MODEL_SUBPACKAGES: "all"
   MODEL_SUBSETS: "stencils:datatest"
-  MODEL_MPI_SUBPACKAGES: "tracer_advection:diffusion:dycore:common:standalone_driver"
+  MODEL_MPI_SUBPACKAGES: "all"
   MODEL_MPI_SUBSETS: "datatest"
-  BACKENDS: "embedded:dace_cpu:dace_gpu:gtfn_cpu:gtfn_gpu"
+  BACKENDS: "all"
   LEVELS: "unit:integration"
   GRIDS: "simple:icon_regional"
   TOOLS_SUBSETS: "datatest:unittest"


### PR DESCRIPTION
By default, all subpackages are meant to be tested, so replacing the explicit lists with `all` in both `default` and `merge`. Same with `SESSIONS`. For `merge` I'm updating the list of backends to use `all` as well. `default` keeps the single backend.

This avoids the need to update the lists whenever a new package is added, removed, or renamed (for CSCS CI).