### PR TITLE
fix flaky test_cross_product

### DIFF
--- a/model/common/tests/common/math/unit_tests/test_helpers.py
+++ b/model/common/tests/common/math/unit_tests/test_helpers.py
@@ -44,9 +44,15 @@ def test_cross_product(backend: gtx_typing.Backend) -> None:
     b = np.column_stack((x2.asnumpy(), y2.asnumpy(), z2.asnumpy()))
     c = np.cross(a, b)
 
-    assert icon4py.model.testing.test_utils.dallclose(c[:, 0], x.asnumpy())
-    assert icon4py.model.testing.test_utils.dallclose(c[:, 1], y.asnumpy())
-    assert icon4py.model.testing.test_utils.dallclose(c[:, 2], z.asnumpy())
+    # The inputs are unseeded, so a component of the cross product occasionally lands near
+    # zero. There the compiled backend's FMA contraction of 'a * b - c * d' shifts one
+    # product by an ulp and the cancellation amplifies it beyond the default
+    # 'rtol = 1e-12, atol = 0.0'. The inputs are in [-1, 1], so the deviation is bounded by
+    # an ulp of 1.0 (2.2e-16 measured) regardless of how small the component gets.
+    atol = 1.0e-15
+    assert icon4py.model.testing.test_utils.dallclose(c[:, 0], x.asnumpy(), atol=atol)
+    assert icon4py.model.testing.test_utils.dallclose(c[:, 1], y.asnumpy(), atol=atol)
+    assert icon4py.model.testing.test_utils.dallclose(c[:, 2], z.asnumpy(), atol=atol)
 
 
 class TestAverageTwoVerticalLevelsDownwardsOnEdges(stencil_tests.StencilTest):


### PR DESCRIPTION
from a friend:

`test_cross_product` fails at random, roughly 0.3% of runs — most recently on `test-model (3.13, dace_cpu, common)` in #1407, where the diff has nothing to do with it.

Inputs come from unseeded `random_field`, so a cross product component occasionally lands near zero. There the backend's FMA contraction of `a * b - c * d` shifts one product by an ulp and the cancellation pushes the relative error past `dallclose`'s default `rtol = 1e-12, atol = 0.0`. The two arrays print identically in the CI log, which makes it look like a real regression.

Inputs are in `[-1, 1]`, so the absolute deviation is bounded by an ulp of 1.0 (measured 2.2e-16 over 2000 draws). Set `atol = 1e-15` at the three call sites.

Same class of problem likely exists in other `dallclose(..., atol=0.0)` comparisons of cancellation-prone quantities; not hunting for those here.