### PR TITLE
Hash CI_JOB_NAME for gt4py cache directory

### DIFF
--- a/ci/scripts/gt4py-cache.sh
+++ b/ci/scripts/gt4py-cache.sh
@@ -4,7 +4,7 @@
 # hash, compiler flags, job name and week to start with a fresh cache every week.
 # ICON4PY_CI_GT4PY_BUILD_CACHE_BASE_DIR is set as the root and
 # GT4PY_BUILD_CACHE_DIR is set to
-# ${ICON4PY_CI_GT4PY_BUILD_CACHE_BASE_DIR}/icon4py/gt4py-cache/base-<hash>-uv-lock-<hash of uv.lock>-flags-<hash of CXXFLAGS=${CXXFLAGS} NVCC_APPEND_FLAGS=${NVCC_APPEND_FLAGS}>-job-<job name>-${DATE}.
+# ${ICON4PY_CI_GT4PY_BUILD_CACHE_BASE_DIR}/icon4py/gt4py-cache/base-<hash>-uv-lock-<hash of uv.lock>-flags-<hash of CXXFLAGS=${CXXFLAGS} NVCC_APPEND_FLAGS=${NVCC_APPEND_FLAGS}>-job-<job name hash>-${DATE}.
 
 set -euo pipefail
 
@@ -13,7 +13,7 @@ set -euo pipefail
 find "${ICON4PY_CI_GT4PY_BUILD_CACHE_BASE_DIR}/icon4py/gt4py-cache" -mindepth 1 -maxdepth 1 -type d -mtime +7 -exec rm -rf {} + || true
 
 uv_lock_hash=$(sha256sum "./uv.lock" | awk '{print substr($1,1,32)}')
-job_name="${CI_JOB_NAME_SLUG}"
+job_name_hash=$(echo -n "${CI_JOB_NAME}" | sha256sum | awk '{print substr($1,1,32)}')
 if [[ -z "${BASE_IMAGE:-}" ]]; then
     echo "BASE_IMAGE must be set and non-empty" >&2
     exit 1
@@ -23,7 +23,7 @@ flags_hash=$(echo -n "CXXFLAGS=${CXXFLAGS:-} NVCC_APPEND_FLAGS=${NVCC_APPEND_FLA
 
 # Then set the cache directory for this run based on the backend and current date.
 DATE=$(date +%Y-%W)
-export GT4PY_BUILD_CACHE_DIR="${ICON4PY_CI_GT4PY_BUILD_CACHE_BASE_DIR}/icon4py/gt4py-cache/base-${base_image_hash}-uv-lock-${uv_lock_hash}-flags-${flags_hash}-job-${job_name}-${DATE}"
+export GT4PY_BUILD_CACHE_DIR="${ICON4PY_CI_GT4PY_BUILD_CACHE_BASE_DIR}/icon4py/gt4py-cache/base-${base_image_hash}-uv-lock-${uv_lock_hash}-flags-${flags_hash}-job-${job_name_hash}-${DATE}"
 mkdir -p "${GT4PY_BUILD_CACHE_DIR}"
 
 echo "Using GT4PY_BUILD_CACHE_DIR=${GT4PY_BUILD_CACHE_DIR}"


### PR DESCRIPTION
CI_JOB_NAME_SLUG is truncated and can lead to cache directory conflicts if truncated at the wrong place. Instead use the full CI_JOB_NAME and hash it to guarantee the full name is used.

Discovered in #970 by @starkphi. Separating the change from #970 since it's a good change on its own.