### PR TITLE
Update merge pipeline to run more tests

### DIFF
--- a/ci/merge.yml
+++ b/ci/merge.yml
@@ -4,11 +4,11 @@ include:
 variables:
   # See default.yml and generate_ci_pipeline.py for details on how these are
   # used. This pipeline gates merges and variables should not be overridden.
-  SESSIONS: "model:model_mpi:tools"
+  SESSIONS: "all"
   MODEL_SUBPACKAGES: "all"
-  MODEL_SUBSETS: "stencils:datatest"
+  MODEL_SUBSETS: "all"
   MODEL_MPI_SUBPACKAGES: "all"
-  MODEL_MPI_SUBSETS: "datatest"
+  MODEL_MPI_SUBSETS: "all"
   BACKENDS: "all"
   LEVELS: "unit:integration"
   GRIDS: "simple:icon_regional"


### PR DESCRIPTION
`SESSIONS` was already effectively using `all`, just explicitly spelled out, so that is not a functional change.

`MODEL_SUBSETS` and `MODEL_MPI_SUBSETS` being updated to `all` means that non-datatests now get run on merges as well. These should generally be the cheapest tests but are not entirely free, so let's see if we end up using way too much CI resources with this.