### PR TITLE
Only test python 3.12 in github workflows

### DIFF
--- a/.github/workflows/icon4py-test-model.yml
+++ b/.github/workflows/icon4py-test-model.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12"]
         backend: ["embedded", "dace_cpu", "gtfn_cpu"]
         component: ["tracer_advection", "diffusion", "dycore", "microphysics", "muphys", "physics_driver", "common", "standalone_driver"]
     steps:

--- a/.github/workflows/icon4py-test-tools-and-bindings.yml
+++ b/.github/workflows/icon4py-test-tools-and-bindings.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Reduce the matrix since testing all three python versions is relatively expensive. We're already testing python 3.13 in CSCS CI so there's no need to test that again in github workflows. Removing 3.14 is arguable, but we're currently not recommending it for production, so let's add it back only once we want to recommend it.