### PR TITLE
docs: shared code placement and generic naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ ICON4Py is a Python implementation of the Fortran [ICON climate and weather mode
 
 Always read the CODING_GUIDELINES.md document first and follow it.
 
+In particular, before adding a stencil, a helper, an enum or an options dictionary to a component, check the "Shared code and generic naming" section: if it can be described using only grid entities and mathematical operations, it belongs in `model/common` and must be named after the operation, not after the calling code's variables.
+
 ## Monorepo structure
 
 uv workspace with 10 namespace packages. All share the `icon4py` namespace. Source lives under `<package>/src/icon4py/...`. Packages are installed editable by `uv sync`.

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -35,22 +35,12 @@ then the code is generic and belongs in `model/common`. If the sentence needs a 
 
 For example `tracer_advection/compute_tendency` computes `(new - old) / dtime`. Nothing in that sentence is a tracer, so the stencil belongs in `model/common`.
 
-This does not contradict the YAGNI item above: do not _generalise_ code speculatively so that it might be shared one day. But code that is _already_ generic should be placed and named generically from the start, because moving it later also means moving its tests and coordinating stencil renames with [icon-exclaim](https://github.com/C2SM/icon-exclaim).
+This does not contradict the YAGNI item above: do not _generalise_ code speculatively so that it might be shared one day. But code that is _already_ generic should be placed and named generically from the start, because moving it later also means moving its tests and coordinating stencil renames.
 
-Where to put it inside `model/common`:
-
-| Content                                                      | Location                   |
-| ------------------------------------------------------------ | -------------------------- |
-| differential operators and algebra on fields                 | `math/`                    |
-| cell/edge/vertex and full/half level interpolation           | `interpolation/`           |
-| allocation, copies, index manipulation                       | `utils/`                   |
-| thermodynamic and other diagnostic quantities                | `diagnostic_calculations/` |
-| physical constants                                           | `constants.py`             |
-| configuration enums and options shared by several components | `model_options.py`         |
 
 ### Naming
 
-A generic name states **what the operation does** and **which grid entities it acts on**. It must not encode:
+A generic name states **what the operation does** and **which grid entities it acts on**. It must **not** encode:
 
 - the caller's argument or output variable names: `diffusion/calculate_nabla2_for_z` is named after the Fortran temporary `z_nabla2_e`, while the stencil computes a coefficient-weighted normal gradient of a cell field onto edges;
 - Fortran temporary prefixes (`z_`, `p_`, `opt_`) or Fortran module names (`mo_intp_rbf_rbf_vec_interpol_cell`);
@@ -61,19 +51,7 @@ Use the swap test: replace an input with an unrelated field of the same type. If
 
 Generic does not mean meaningless: name the operation, not placeholders. `add_fields` is a generic name, `compute_a_plus_b` is not.
 
-| Too specific                                                         | Generic                                      |
-| -------------------------------------------------------------------- | -------------------------------------------- |
-| `compute_tangential_wind`, `compute_edge_tangential`                 | `interpolate_normal_to_tangential_on_edges`  |
-| `calculate_nabla2_for_z`                                             | `compute_weighted_normal_gradient_on_edges`  |
-| `copy_cell_kdim_field_to_vp`                                         | `copy_cell_field`                            |
-| `init_cell_kdim_field_with_zero_wp`, `init_constant_cell_kdim_field` | `set_cell_field_to_constant`                 |
-| `mo_intp_rbf_rbf_vec_interpol_cell`                                  | `interpolate_edge_vector_to_cell_center_rbf` |
-
 The same applies outside stencils: shared enums, options and dictionaries are named after what they configure, not after the component that introduced them.
-
-### Existing code
-
-Do not open repository-wide renaming pull requests. Rename and move opportunistically, while you are already modifying a file, and keep one move per pull request so that the diff stays reviewable. Names under `stencil_tests/` are consumed by [icon-exclaim](https://github.com/C2SM/icon-exclaim), so coordinate before renaming them.
 
 ## Code Style
 

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -20,6 +20,61 @@ TODO: we should add a doc folder (separate for `tools` and `model`? separate for
 Remember that important design decisions should be properly documented for future reference and to share the knowledge with other developers. We decided to use lightweight _Architecture Decision Records_ (ADRs) for this purpose. The full list of ADRs and documentation for writing new ones can be found in [docs/functional/architecture/Index.md](docs/functional/architecture/Index.md).
 -->
 
+## Shared code and generic naming
+
+Code that is not specific to a single model component belongs in `model/common`, and code that lives there must be named after the operation it performs, not after the caller that happens to use it. When a generic operation carries a caller-specific name, the next component does not find it and ports the same Fortran expression again: `dycore/compute_tangential_wind` and `tracer_advection/compute_edge_tangential` are the same `neighbor_sum` over `E2C2E`, written twice.
+
+### Does it belong in `model/common`?
+
+Describe in one sentence what the code does. If the sentence only needs
+
+- grid entities (cell, edge, vertex, level) and dimensions, and
+- mathematical operations (gradient, divergence, curl, interpolation, average, copy, tendency),
+
+then the code is generic and belongs in `model/common`. If the sentence needs a named prognostic or diagnostic field (`vn`, `theta_v`, `exner`, a tracer) or a numerical scheme (Smagorinsky, PPM, FFSL, divergence damping), it is component-specific and stays in the component.
+
+For example `tracer_advection/compute_tendency` computes `(new - old) / dtime`. Nothing in that sentence is a tracer, so the stencil belongs in `model/common`.
+
+This does not contradict the YAGNI item above: do not _generalise_ code speculatively so that it might be shared one day. But code that is _already_ generic should be placed and named generically from the start, because moving it later also means moving its tests and coordinating stencil renames with [icon-exclaim](https://github.com/C2SM/icon-exclaim).
+
+Where to put it inside `model/common`:
+
+| Content                                                      | Location                   |
+| ------------------------------------------------------------ | -------------------------- |
+| differential operators and algebra on fields                 | `math/`                    |
+| cell/edge/vertex and full/half level interpolation           | `interpolation/`           |
+| allocation, copies, index manipulation                       | `utils/`                   |
+| thermodynamic and other diagnostic quantities                | `diagnostic_calculations/` |
+| physical constants                                           | `constants.py`             |
+| configuration enums and options shared by several components | `model_options.py`         |
+
+### Naming
+
+A generic name states **what the operation does** and **which grid entities it acts on**. It must not encode:
+
+- the caller's argument or output variable names: `diffusion/calculate_nabla2_for_z` is named after the Fortran temporary `z_nabla2_e`, while the stencil computes a coefficient-weighted normal gradient of a cell field onto edges;
+- Fortran temporary prefixes (`z_`, `p_`, `opt_`) or Fortran module names (`mo_intp_rbf_rbf_vec_interpol_cell`);
+- the floating point precision (`_wp`, `_vp`), which is already part of the signature;
+- the physical meaning of an operand that the mathematics does not depend on.
+
+Use the swap test: replace an input with an unrelated field of the same type. If the code still works but the name no longer reads correctly, the name is too specific.
+
+Generic does not mean meaningless: name the operation, not placeholders. `add_fields` is a generic name, `compute_a_plus_b` is not.
+
+| Too specific                                                         | Generic                                      |
+| -------------------------------------------------------------------- | -------------------------------------------- |
+| `compute_tangential_wind`, `compute_edge_tangential`                 | `interpolate_normal_to_tangential_on_edges`  |
+| `calculate_nabla2_for_z`                                             | `compute_weighted_normal_gradient_on_edges`  |
+| `copy_cell_kdim_field_to_vp`                                         | `copy_cell_field`                            |
+| `init_cell_kdim_field_with_zero_wp`, `init_constant_cell_kdim_field` | `set_cell_field_to_constant`                 |
+| `mo_intp_rbf_rbf_vec_interpol_cell`                                  | `interpolate_edge_vector_to_cell_center_rbf` |
+
+The same applies outside stencils: shared enums, options and dictionaries are named after what they configure, not after the component that introduced them.
+
+### Existing code
+
+Do not open repository-wide renaming pull requests. Rename and move opportunistically, while you are already modifying a file, and keep one move per pull request so that the diff stays reviewable. Names under `stencil_tests/` are consumed by [icon-exclaim](https://github.com/C2SM/icon-exclaim), so coordinate before renaming them.
+
 ## Code Style
 
 We follow the [Google Python Style Guide][google-style-guide] with a few minor changes (mentioned below). Since the best way to remember something is to understand the reasons behind it, make sure you go through the style guide at least once, paying special attention to the discussions in the _Pros_, _Cons_, and _Decision_ subsections.

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -37,19 +37,9 @@ For example `tracer_advection/compute_tendency` computes `(new - old) / dtime`. 
 
 This does not contradict the YAGNI item above: do not _generalise_ code speculatively so that it might be shared one day. But code that is _already_ generic should be placed and named generically from the start, because moving it later also means moving its tests and coordinating stencil renames.
 
-
 ### Naming
 
-A generic name states **what the operation does** and **which grid entities it acts on**. It must **not** encode:
-
-- the caller's argument or output variable names: `diffusion/calculate_nabla2_for_z` is named after the Fortran temporary `z_nabla2_e`, while the stencil computes a coefficient-weighted normal gradient of a cell field onto edges;
-- Fortran temporary prefixes (`z_`, `p_`, `opt_`) or Fortran module names (`mo_intp_rbf_rbf_vec_interpol_cell`);
-- the floating point precision (`_wp`, `_vp`), which is already part of the signature;
-- the physical meaning of an operand that the mathematics does not depend on.
-
-Use the swap test: replace an input with an unrelated field of the same type. If the code still works but the name no longer reads correctly, the name is too specific.
-
-Generic does not mean meaningless: name the operation, not placeholders. `add_fields` is a generic name, `compute_a_plus_b` is not.
+Stencil names must follow the [naming conventions for stencils](docs/stencil_naming_convention.md).
 
 The same applies outside stencils: shared enums, options and dictionaries are named after what they configure, not after the component that introduced them.
 

--- a/docs/stencil_naming_convention.md
+++ b/docs/stencil_naming_convention.md
@@ -19,7 +19,19 @@ The `program` name should start with a verb.
 Commonly used verbs are accumulate, add, apply, compute, copy, correct, extrapolate, interpolate, return, set, and
 solve.
 The verb can be followed by more describing words.
-If possible one should not use the names of variables that are part of the signature already as describing words.
+
+The describing words must state what the stencil computes and on which grid entities, and must not repeat the names of the variables in the signature.
+In particular, a stencil name must not contain:
+
+- the caller's argument or output variable names, for example `calculate_nabla2_for_z`, named after the Fortran temporary `z_nabla2_e`;
+- Fortran temporary prefixes (`z_`, `p_`, `opt_`) or Fortran module names, for example `mo_intp_rbf_rbf_vec_interpol_cell`;
+- the floating point precision (`_wp`, `_vp`), which is already part of the signature;
+- the physical meaning of an operand that the mathematics does not depend on.
+
+To check a name, replace an input with an unrelated field of the same type: if the stencil still works but the name no longer reads correctly, the name is too specific.
+
+A stencil whose name passes this check is usually generic enough to belong in `model/common`.
+See the section on shared code and generic naming in [CODING_GUIDELINES.md](../CODING_GUIDELINES.md) for where to place it.
 
 ## Example
 

--- a/docs/stencil_naming_convention.md
+++ b/docs/stencil_naming_convention.md
@@ -18,20 +18,23 @@ The `program` name should be the same as for the field_operator without the unde
 The `program` name should start with a verb.
 Commonly used verbs are accumulate, add, apply, compute, copy, correct, extrapolate, interpolate, return, set, and
 solve.
+Prefer the most specific verb that describes the operation; `compute` is the catch-all for operations that have no more specific verb.
 The verb can be followed by more describing words.
 
 The describing words must state what the stencil computes and on which grid entities, and must not repeat the names of the variables in the signature.
 In particular, a stencil name must not contain:
 
-- the caller's argument or output variable names, for example `calculate_nabla2_for_z`, named after the Fortran temporary `z_nabla2_e`;
+- the caller's argument or output variable names, for example `calculate_nabla2_for_z`, named after the Fortran temporary `z_nabla2_e`; unless the mathematics genuinely depends on the quantity itself (then the swap test below does not pass);
 - Fortran temporary prefixes (`z_`, `p_`, `opt_`) or Fortran module names, for example `mo_intp_rbf_rbf_vec_interpol_cell`;
-- the floating point precision (`_wp`, `_vp`), which is already part of the signature;
 - the physical meaning of an operand that the mathematics does not depend on.
 
-To check a name, replace an input with an unrelated field of the same type: if the stencil still works but the name no longer reads correctly, the name is too specific.
+The floating point precision (`_wp`, `_vp`) is an exception to the list above: GT4Py does not yet have dtype generics, so the same operator may exist in both precisions, for example `interpolate_edge_field_to_half_levels_vp` and `interpolate_edge_field_to_half_levels_wp`. The suffix is then required and stays in the name; drop it once the precision is part of the operator's type.
 
-A stencil whose name passes this check is usually generic enough to belong in `model/common`.
-See the section on shared code and generic naming in [CODING_GUIDELINES.md](../CODING_GUIDELINES.md) for where to place it.
+To check a name, replace an input with an unrelated field of the same type: if the stencil still works but the name no longer reads correctly, the name is too specific. If the computation genuinely depends on the quantity, naming after it is fine: the swap test will not pass.
+
+Generic does not mean meaningless: name the operation, not placeholders. `add_fields` is a generic name, `compute_a_plus_b` is not.
+
+These naming rules apply to every stencil, wherever it lives. Whether a stencil belongs in `model/common` is a separate question, answered by the section on shared code and generic naming in [CODING_GUIDELINES.md](../CODING_GUIDELINES.md).
 
 ## Example
 


### PR DESCRIPTION
from a friend:

Generic operations keep getting implemented inside components under names taken from the caller's variables, so the next component does not find them and ports the same Fortran expression again. `dycore/compute_tangential_wind` and `tracer_advection/compute_edge_tangential` are the same `neighbor_sum` over `E2C2E`; `copy_cell_kdim_field_to_vp` and `copy_cell_kdim_field` are the same identity copy; `diffusion/calculate_nabla2_for_z` is named after the Fortran temporary `z_nabla2_e`.

- `CODING_GUIDELINES.md`: new "Shared code and generic naming" section with a test for whether something belongs in `model/common`, a naming rule with the forbidden categories, and before/after examples.
- `docs/stencil_naming_convention.md`: turn the existing "do not use signature variable names" hint into a rule and cross-reference the guidelines.
- `AGENTS.md`: pointer to the new section.

Docs only, no renames. Existing offenders are meant to be fixed opportunistically, one move per PR.