### PR TITLE
fix timing bug in physics interface

### DIFF
--- a/model/atmosphere/subgrid_scale_physics/physics_driver/src/icon4py/model/atmosphere/subgrid_scale_physics/physics_driver/physics_driver.py
+++ b/model/atmosphere/subgrid_scale_physics/physics_driver/src/icon4py/model/atmosphere/subgrid_scale_physics/physics_driver/physics_driver.py
@@ -84,8 +84,9 @@ class PhysicsDriver:
         dtime: datetime.timedelta,
         simulation_current_datetime: datetime.datetime,
     ) -> None:
-        # 'datetime = datetime_new - dt' in mo_interface_iconam_aes.f90: the processes are
-        # scheduled on the date at the beginning of the step being integrated.
+        # 'simulation_current_datetime' is the end of the step being integrated (ICON's 'datetime_new');
+        # processes are scheduled on the step-start date, per 'datetime = datetime_new - dt'
+        # in mo_interface_iconam_aes.f90.
         step_start_datetime = simulation_current_datetime - dtime
         for process in self._processes:
             tc = process.time_control

--- a/model/atmosphere/subgrid_scale_physics/physics_driver/src/icon4py/model/atmosphere/subgrid_scale_physics/physics_driver/physics_driver.py
+++ b/model/atmosphere/subgrid_scale_physics/physics_driver/src/icon4py/model/atmosphere/subgrid_scale_physics/physics_driver/physics_driver.py
@@ -84,6 +84,9 @@ class PhysicsDriver:
         dtime: datetime.timedelta,
         simulation_current_datetime: datetime.datetime,
     ) -> None:
+        # 'datetime = datetime_new - dt' in mo_interface_iconam_aes.f90: the processes are
+        # scheduled on the date at the beginning of the step being integrated.
+        step_start_datetime = simulation_current_datetime - dtime
         for process in self._processes:
             tc = process.time_control
             tc.validate_interval(dtime)
@@ -91,14 +94,14 @@ class PhysicsDriver:
             state.gather_from_prognostic(prognostic, tracers)
             if not tc.enable_process:
                 continue
-            if not tc.is_in_window(simulation_current_datetime):
+            if not tc.is_in_window(step_start_datetime):
                 # outside the process window: no forcing
                 continue
             # Compute on a firing (active) step, and also on the first in-window step -- when
             # there is nothing cached to recycle yet. Otherwise reuse the last computed forcing.
-            if tc.is_active(simulation_current_datetime) or process.name not in self._recycle_cache:
+            if tc.is_active(step_start_datetime) or process.name not in self._recycle_cache:
                 # compute
-                outputs = process.component(state.as_component_input(), simulation_current_datetime)
+                outputs = process.component(state.as_component_input(), step_start_datetime)
                 self._recycle_cache[process.name] = outputs
             else:
                 # recycle

--- a/model/atmosphere/subgrid_scale_physics/physics_driver/tests/physics_driver/unit_tests/test_physics_driver.py
+++ b/model/atmosphere/subgrid_scale_physics/physics_driver/tests/physics_driver/unit_tests/test_physics_driver.py
@@ -41,6 +41,8 @@ def test_forcing_mode_values() -> None:
 
 _T0 = datetime.datetime(2024, 1, 1, 0, 0, 0)
 _DT = datetime.timedelta(seconds=300)  # 5-min physics interval
+# 'PhysicsDriver.run' takes the date at the END of the step, so the step starting at
+# '_T0' is passed as '_T0 + _DT'.
 
 
 def _tc(
@@ -231,7 +233,7 @@ def test_run_invokes_components_in_order() -> None:
         prognostic="prog",
         tracers="tracers",
         dtime=datetime.timedelta(seconds=300),
-        simulation_current_datetime=_T0,
+        simulation_current_datetime=_T0 + _DT,
     )
 
     assert comp_a.call_count == 1
@@ -329,7 +331,7 @@ def test_active_call_caches_outputs_and_applies_them() -> None:
         prognostic="prog",
         tracers="tracers",
         dtime=datetime.timedelta(seconds=300),
-        simulation_current_datetime=_T0,
+        simulation_current_datetime=_T0 + _DT,
     )
 
     assert comp.call_count == 1
@@ -358,14 +360,14 @@ def test_inactive_in_window_recycles_cached_outputs() -> None:
         prognostic="prog",
         tracers="tracers",
         dtime=_DT,
-        simulation_current_datetime=_T0,
+        simulation_current_datetime=_T0 + _DT,
     )
     # Step 2: in window, but not active (elapsed == _DT, not a multiple of 2*_DT).
     driver.run(
         prognostic="prog",
         tracers="tracers",
         dtime=_DT,
-        simulation_current_datetime=_T0 + _DT,
+        simulation_current_datetime=_T0 + 2 * _DT,
     )
 
     # Component invoked once total (compute step only).
@@ -395,7 +397,7 @@ def test_first_in_window_step_inactive_computes_without_keyerror() -> None:
         prognostic="prog",
         tracers="tracers",
         dtime=_DT,
-        simulation_current_datetime=_T0 + _DT,
+        simulation_current_datetime=_T0 + 2 * _DT,
     )
 
     assert comp.call_count == 1

--- a/model/testing/src/icon4py/model/testing/definitions.py
+++ b/model/testing/src/icon4py/model/testing/definitions.py
@@ -156,7 +156,7 @@ class ExperimentDescription:
     name: str
     long_name: str
     grid: GridDescription
-    version: int = 6
+    version: int
 
 
 @dataclasses.dataclass
@@ -191,29 +191,35 @@ class Experiments:
         name="exclaim_ape_R02B04",
         long_name="EXCLAIM Aquaplanet experiment",
         grid=Grids.R02B04_GLOBAL,
+        version=6,
     )
     EXCLAIM_APE_AES: Final = ExperimentDescription(
         name="exclaim_ape_aesPhys",
         long_name="EXCLAIM Aquaplanet experiment. JW IC and AES physics",
         grid=Grids.R02B04_GLOBAL,
+        version=7,
     )
     MCH_CH_R04B09: Final = ExperimentDescription(
         name="exclaim_ch_r04b09_dsl",
         long_name="Regional setup used by EXCLAIM to validate the icon-exclaim.",
         grid=Grids.MCH_CH_R04B09_DSL,
+        version=6,
     )
     JW: Final = ExperimentDescription(
         name="exclaim_nh35_tri_jws",
         long_name="Jablonowski Williamson atmospheric test case",
         grid=Grids.R02B04_GLOBAL,
+        version=6,
     )
     GAUSS3D: Final = ExperimentDescription(
         name="exclaim_gauss3d",
         long_name="Gauss 3d test case",
         grid=Grids.TORUS_50000x5000,
+        version=6,
     )
     WEISMAN_KLEMP_TORUS: Final = ExperimentDescription(
         name="exclaim_nh_weisman_klemp",
         long_name="Weisman-Klemp experiment on Torus Grid",
         grid=Grids.TORUS_50000x5000,
+        version=6,
     )


### PR DESCRIPTION
`time_integration` advances `simulation_current_datetime` before integrating, so it is already at the end of the step. 

`PhysicsDriver.run` checked the `ProcessTimeControl` windows against it, and since those are half-open `[start_date, simulation_end_datetime)`, the last step of every run fell outside its window and ran no physics at all. The standalone-driver datatest is a single step, that's why it never ran muphys and only passed by accident with v06 data.

ICON advances the date at the beginning of the step too (so I did not touch that, but maybe we should?) and subtracts it again in the physics interface (`mo_interface_iconam_aes.f90`: `datetime = datetime_new - dt`), which is why the `aes-graupel-*` savepoints are stamped 00:00/00:05/00:10 against 00:05/00:10/00:15 for `time-step-exit`.

- do the same subtraction in `PhysicsDriver.run`, leaving `ProcessTimeControl` copying fortran's `aes_phy_tc`
- shift the `PhysicsDriver.run` dates in the unit tests to end-of-step
- update ape_aesPhys data to v07