### PR TITLE
Use `data_alloc.as_numpy` on global halo indices before passing to GHEX to satisfy nanobind 2.14's stricter conversion

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -50,8 +50,6 @@ variables:
     reports:
       dotenv: build.env
   variables:
-    # TODO: Remove
-    CSCS_REBUILD_POLICY: "always"
     DOCKERFILE: ci/docker/venv.Dockerfile
     DOCKER_BUILD_ARGS: '["PYVERSION=$PYVERSION", "BASE_IMAGE=$BASE_IMAGE", "ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS=$ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS"]'
 

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -14,8 +14,6 @@ variables:
   PYVERSION: 3.13.13
   PYVERSION_SHORT: 3.13
   ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS: "cuda12"
-  # TODO: Remove
-  CSCS_REBUILD_POLICY: "always"
 
 # Base image build step with SHA256 checksum for caching
 .build_baseimage:
@@ -52,6 +50,8 @@ variables:
     reports:
       dotenv: build.env
   variables:
+    # TODO: Remove
+    CSCS_REBUILD_POLICY: "always"
     DOCKERFILE: ci/docker/venv.Dockerfile
     DOCKER_BUILD_ARGS: '["PYVERSION=$PYVERSION", "BASE_IMAGE=$BASE_IMAGE", "ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS=$ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS"]'
 

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -14,6 +14,8 @@ variables:
   PYVERSION: 3.13.13
   PYVERSION_SHORT: 3.13
   ICON4PY_NOX_UV_CUSTOM_SESSION_EXTRAS: "cuda12"
+  # TODO: Remove
+  CSCS_REBUILD_POLICY: "always"
 
 # Base image build step with SHA256 checksum for caching
 .build_baseimage:

--- a/model/common/src/icon4py/model/common/decomposition/mpi_decomposition.py
+++ b/model/common/src/icon4py/model/common/decomposition/mpi_decomposition.py
@@ -155,7 +155,7 @@ class GHexMultiNodeExchange(decomp_defs.ExchangeRuntime):
         # if those ids are not different for all domain descriptors the system might deadlock
         # if two parallel exchanges with the same domain id are done
         domain_desc = DomainDescriptor(
-            self._domain_id_gen(), all_global.tolist(), local_halo.tolist()
+            self._domain_id_gen(), data_alloc.as_numpy(all_global), data_alloc.as_numpy(local_halo)
         )
         log.debug(
             f"domain descriptor for dim='{dim.value}' with properties {self._domain_descriptor_info(domain_desc)} created"
@@ -168,7 +168,7 @@ class GHexMultiNodeExchange(decomp_defs.ExchangeRuntime):
         global_halo_idx = self._decomposition_info.global_index(
             horizontal_dim, decomp_defs.DecompositionInfo.EntryType.HALO
         )
-        halo_generator = HaloGenerator.from_gids(global_halo_idx.tolist())
+        halo_generator = HaloGenerator.from_gids(data_alloc.as_numpy(global_halo_idx))
         log.debug(f"halo generator for dim='{horizontal_dim.value}' created")
         pattern = make_pattern(
             self._context,

--- a/model/common/src/icon4py/model/common/decomposition/mpi_decomposition.py
+++ b/model/common/src/icon4py/model/common/decomposition/mpi_decomposition.py
@@ -168,7 +168,7 @@ class GHexMultiNodeExchange(decomp_defs.ExchangeRuntime):
         global_halo_idx = self._decomposition_info.global_index(
             horizontal_dim, decomp_defs.DecompositionInfo.EntryType.HALO
         )
-        halo_generator = HaloGenerator.from_gids(global_halo_idx)
+        halo_generator = HaloGenerator.from_gids(global_halo_idx.tolist())
         log.debug(f"halo generator for dim='{horizontal_dim.value}' created")
         pattern = make_pattern(
             self._context,


### PR DESCRIPTION
With nanobind 2.13 or older the elements of the index list would get converted element-wise using `PyNumber_Long`, which in practice means `__int__`. numpy and cupy arrays would get converted as sequences, and each element of the arrays would get converted through `__int__`. Starting with nanobind 2.14 the conversion of elements now happens through `PyNumber_Index`, i.e. `__index__`. See
https://github.com/wjakob/nanobind/blob/master/docs/changelog.rst#version-2140-aug-7-2026 and https://github.com/wjakob/nanobind/commit/d33465e4a2d1f48e6210dbe6a7c44f7bf2b1fae2 for details. cupy arrays for some reason do not have `__index__` and the conversion fails.

This PR explicitly converts the arrays to numpy arrays because 1. GHEX anyway expects a host array and 2. numpy array elements have `__index__`. This will work with nanobind 2.14 and older. I've also changed two previous `.tolist`s passed to GHEX (for `DomainDescriptor`) that also expect `std::vector<int>` like `HaloGenerator`.

This came up on https://github.com/C2SM/icon4py/pull/1283 not because it in itself changed anything related to halo generators or similar. It only came up on #1283 because uv.lock was changed, the base image was rebuilt, and nanobind 2.14 had just been released (August 7th), _and_ GHEX gets built against the latest nanobind release even though nanobind is pinned to 2.12 for the actual venv used by icon4py.