### PR TITLE
Make the dace TopLevelDataFlowStep hook picklable

### DIFF
--- a/model/common/src/icon4py/model/common/model_options.py
+++ b/model/common/src/icon4py/model/common/model_options.py
@@ -25,6 +25,14 @@ def dict_values_to_list(d: dict[str, Any]) -> dict[str, list]:
     return {k: [v] for k, v in d.items()}
 
 
+def _remove_access_node_copies(sdfg: Any) -> None:
+    sdfg.apply_transformations_repeated(
+        gtx_transformations.RemoveAccessNodeCopies(),
+        validate=False,
+        validate_all=False,
+    )
+
+
 def get_dace_options(
     program_name: str, **backend_descriptor: Any
 ) -> model_backends.BackendDescriptor:
@@ -38,11 +46,7 @@ def get_dace_options(
         if gtx_transformations.GT4PyAutoOptHook.TopLevelDataFlowStep not in optimization_hooks:
             # Enable pass that removes access node (next_w) copies for vertically implicit solver programs
             optimization_hooks[gtx_transformations.GT4PyAutoOptHook.TopLevelDataFlowStep] = (
-                lambda sdfg: sdfg.apply_transformations_repeated(
-                    gtx_transformations.RemoveAccessNodeCopies(),
-                    validate=False,
-                    validate_all=False,
-                )
+                _remove_access_node_copies
             )
         if "scan_loop_unrolling" not in optimization_args:
             optimization_args["scan_loop_unrolling"] = True

--- a/model/common/src/icon4py/model/common/model_options.py
+++ b/model/common/src/icon4py/model/common/model_options.py
@@ -10,6 +10,7 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+import dace
 import gt4py.next as gtx
 import gt4py.next.typing as gtx_typing
 from gt4py.next import backend as gtx_backend
@@ -25,7 +26,7 @@ def dict_values_to_list(d: dict[str, Any]) -> dict[str, list]:
     return {k: [v] for k, v in d.items()}
 
 
-def _remove_access_node_copies(sdfg: Any) -> None:
+def _dace_remove_access_node_copies(sdfg: dace.SDFG) -> None:
     sdfg.apply_transformations_repeated(
         gtx_transformations.RemoveAccessNodeCopies(),
         validate=False,
@@ -46,7 +47,7 @@ def get_dace_options(
         if gtx_transformations.GT4PyAutoOptHook.TopLevelDataFlowStep not in optimization_hooks:
             # Enable pass that removes access node (next_w) copies for vertically implicit solver programs
             optimization_hooks[gtx_transformations.GT4PyAutoOptHook.TopLevelDataFlowStep] = (
-                _remove_access_node_copies
+                _dace_remove_access_node_copies
             )
         if "scan_loop_unrolling" not in optimization_args:
             optimization_args["scan_loop_unrolling"] = True


### PR DESCRIPTION
The `TopLevelDataFlowStep` hook set in `get_dace_options` for the vertically implicit solver programs was a lambda, so the customized dace backend executor could not be pickled and the gt4py compilation process pool fell back to compiling in the calling thread. Defining the hook at module scope fixes this.

Before: `pickle.dumps(backend.executor)` raised `AttributeError: Can't get local object 'get_dace_options.<locals>.<lambda>'`. After: it round-trips.