### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/bindings/pyproject.toml
+++ b/bindings/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  'icon4py-atmosphere-diffusion~=0.3.0',
-  'icon4py-atmosphere-dycore~=0.3.0',
-  'icon4py-atmosphere-muphys~=0.3.0',
-  'icon4py-common[distributed]~=0.3.0',
-  'icon4py-tools~=0.3.0',
+  'icon4py-atmosphere-diffusion~=0.4.0',
+  'icon4py-atmosphere-dycore~=0.4.0',
+  'icon4py-atmosphere-muphys~=0.4.0',
+  'icon4py-common[distributed]~=0.4.0',
+  'icon4py-tools~=0.4.0',
   # external dependencies
   'cffi>=1.5',
   'click>=8.0',
@@ -43,7 +43,7 @@ name = 'icon4py-bindings'
 readme = 'README.md'
 requires-python = '>=3.12'
 # managed by bump-my-version:
-version = "0.3.0"
+version = "0.4.0"
 
 [project.optional-dependencies]
 cuda12 = ['cupy-cuda12x>=13.0', 'gt4py[cuda12]']
@@ -57,7 +57,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.3.0"
+current_version = "0.4.0"
 ignore_missing_version = false
 message = 'Bump icon4py-bindings version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/bindings/pyproject.toml
+++ b/bindings/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  'icon4py-atmosphere-diffusion~=0.4.0',
-  'icon4py-atmosphere-dycore~=0.4.0',
-  'icon4py-atmosphere-muphys~=0.4.0',
-  'icon4py-common[distributed]~=0.4.0',
-  'icon4py-tools~=0.4.0',
+  'icon4py-atmosphere-diffusion~=0.4.1',
+  'icon4py-atmosphere-dycore~=0.4.1',
+  'icon4py-atmosphere-muphys~=0.4.1',
+  'icon4py-common[distributed]~=0.4.1',
+  'icon4py-tools~=0.4.1',
   # external dependencies
   'cffi>=1.5',
   'click>=8.0',
@@ -43,7 +43,7 @@ name = 'icon4py-bindings'
 readme = 'README.md'
 requires-python = '>=3.12'
 # managed by bump-my-version:
-version = "0.4.0"
+version = "0.4.1"
 
 [project.optional-dependencies]
 cuda12 = ['cupy-cuda12x>=13.0', 'gt4py[cuda12]']
@@ -57,7 +57,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.4.0"
+current_version = "0.4.1"
 ignore_missing_version = false
 message = 'Bump icon4py-bindings version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/bindings/src/icon4py/bindings/__init__.py
+++ b/bindings/src/icon4py/bindings/__init__.py
@@ -25,5 +25,5 @@ __author__: Final = "ETH Zurich,  MeteoSwiss and individual contributors"
 __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
-__version__: Final = "0.4.0"
+__version__: Final = "0.4.1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/bindings/src/icon4py/bindings/__init__.py
+++ b/bindings/src/icon4py/bindings/__init__.py
@@ -25,5 +25,5 @@ __author__: Final = "ETH Zurich,  MeteoSwiss and individual contributors"
 __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
-__version__: Final = "0.3.0"
+__version__: Final = "0.4.0"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/docs/release_procedure.md
+++ b/docs/release_procedure.md
@@ -36,8 +36,8 @@ To see the current list of packages:
 
 ### 1. Bump the version
 
-Create a new branch for bumping the version. Open PR against the main branch
-with the bumped versions.
+Create a new branch for bumping the version. You can find the current icon4py version in the pyporject.toml.
+Open PR against the main branch with the bumped versions.
 
 Use the `bump-versions` script to update all packages to the new version:
 
@@ -56,7 +56,7 @@ Use `--dry-run` to preview changes without writing files.
 
 ### 2. Create a GitHub Release
 
-Once the all PRs for the new release, including the one frome the previous step,
+Once all PRs for the new release, including the one frome the previous step,
 are merged to main:
 
 1. Go to **Releases -> Draft a new release**.

--- a/docs/release_procedure.md
+++ b/docs/release_procedure.md
@@ -36,7 +36,7 @@ To see the current list of packages:
 
 ### 1. Bump the version
 
-Create a new branch for bumping the version. You can find the current icon4py version in the pyporject.toml.
+Create a new branch for bumping the version. You can find the current icon4py version in the main pyproject.toml file.
 Open PR against the main branch with the bumped versions.
 
 Use the `bump-versions` script to update all packages to the new version:

--- a/model/atmosphere/diffusion/pyproject.toml
+++ b/model/atmosphere/diffusion/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.3.0",
+  "icon4py-common~=0.4.0",
   # external dependencies
   "gt4py==1.2.1",
   'packaging>=20.0'
@@ -36,7 +36,7 @@ name = "icon4py-atmosphere-diffusion"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.3.0"
+version = "0.4.0"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -45,7 +45,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.3.0"
+current_version = "0.4.0"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-diffusion version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/diffusion/pyproject.toml
+++ b/model/atmosphere/diffusion/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.4.0",
+  "icon4py-common~=0.4.1",
   # external dependencies
   "gt4py==1.2.1",
   'packaging>=20.0'
@@ -36,7 +36,7 @@ name = "icon4py-atmosphere-diffusion"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.4.0"
+version = "0.4.1"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -45,7 +45,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.4.0"
+current_version = "0.4.1"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-diffusion version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/__init__.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.4.0"
+__version__: Final = "0.4.1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/__init__.py
+++ b/model/atmosphere/diffusion/src/icon4py/model/atmosphere/diffusion/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.3.0"
+__version__: Final = "0.4.0"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/dycore/pyproject.toml
+++ b/model/atmosphere/dycore/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.3.0",
+  "icon4py-common~=0.4.0",
   # external dependencies
   "gt4py==1.2.1",
   'packaging>=20.0'
@@ -36,7 +36,7 @@ name = "icon4py-atmosphere-dycore"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.3.0"
+version = "0.4.0"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -45,7 +45,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.3.0"
+current_version = "0.4.0"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-dycore version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/dycore/pyproject.toml
+++ b/model/atmosphere/dycore/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.4.0",
+  "icon4py-common~=0.4.1",
   # external dependencies
   "gt4py==1.2.1",
   'packaging>=20.0'
@@ -36,7 +36,7 @@ name = "icon4py-atmosphere-dycore"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.4.0"
+version = "0.4.1"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -45,7 +45,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.4.0"
+current_version = "0.4.1"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-dycore version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/__init__.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.4.0"
+__version__: Final = "0.4.1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/__init__.py
+++ b/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.3.0"
+__version__: Final = "0.4.0"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/subgrid_scale_physics/microphysics/pyproject.toml
+++ b/model/atmosphere/subgrid_scale_physics/microphysics/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.3.0",
+  "icon4py-common~=0.4.0",
   # external dependencies
   "gt4py==1.2.1",
   'packaging>=20.0'
@@ -36,7 +36,7 @@ name = "icon4py-atmosphere-microphysics"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.3.0"
+version = "0.4.0"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -45,7 +45,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.3.0"
+current_version = "0.4.0"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-microphysics version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/subgrid_scale_physics/microphysics/pyproject.toml
+++ b/model/atmosphere/subgrid_scale_physics/microphysics/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.4.0",
+  "icon4py-common~=0.4.1",
   # external dependencies
   "gt4py==1.2.1",
   'packaging>=20.0'
@@ -36,7 +36,7 @@ name = "icon4py-atmosphere-microphysics"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.4.0"
+version = "0.4.1"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -45,7 +45,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.4.0"
+current_version = "0.4.1"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-microphysics version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/subgrid_scale_physics/microphysics/src/icon4py/model/atmosphere/subgrid_scale_physics/microphysics/__init__.py
+++ b/model/atmosphere/subgrid_scale_physics/microphysics/src/icon4py/model/atmosphere/subgrid_scale_physics/microphysics/__init__.py
@@ -26,5 +26,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.3.0"
+__version__: Final = "0.4.0"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/subgrid_scale_physics/microphysics/src/icon4py/model/atmosphere/subgrid_scale_physics/microphysics/__init__.py
+++ b/model/atmosphere/subgrid_scale_physics/microphysics/src/icon4py/model/atmosphere/subgrid_scale_physics/microphysics/__init__.py
@@ -26,5 +26,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.4.0"
+__version__: Final = "0.4.1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/subgrid_scale_physics/muphys/pyproject.toml
+++ b/model/atmosphere/subgrid_scale_physics/muphys/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common[io]~=0.4.0",
+  "icon4py-common[io]~=0.4.1",
   # external dependencies
   "numpy>=1.23.3",
   "gt4py==1.2.1",
@@ -37,7 +37,7 @@ name = "icon4py-atmosphere-muphys"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.4.0"
+version = "0.4.1"
 
 [project.urls]
 repository = "https://github.com/C2SM/icon4py"
@@ -46,7 +46,7 @@ repository = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.4.0"
+current_version = "0.4.1"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-muphys version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/subgrid_scale_physics/muphys/pyproject.toml
+++ b/model/atmosphere/subgrid_scale_physics/muphys/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common[io]~=0.3.0",
+  "icon4py-common[io]~=0.4.0",
   # external dependencies
   "numpy>=1.23.3",
   "gt4py==1.2.1",
@@ -37,7 +37,7 @@ name = "icon4py-atmosphere-muphys"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.3.0"
+version = "0.4.0"
 
 [project.urls]
 repository = "https://github.com/C2SM/icon4py"
@@ -46,7 +46,7 @@ repository = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.3.0"
+current_version = "0.4.0"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-muphys version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/__init__.py
+++ b/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/__init__.py
@@ -26,5 +26,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.3.0"
+__version__: Final = "0.4.0"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/__init__.py
+++ b/model/atmosphere/subgrid_scale_physics/muphys/src/icon4py/model/atmosphere/subgrid_scale_physics/muphys/__init__.py
@@ -26,5 +26,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.4.0"
+__version__: Final = "0.4.1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/subgrid_scale_physics/physics_driver/pyproject.toml
+++ b/model/atmosphere/subgrid_scale_physics/physics_driver/pyproject.toml
@@ -15,8 +15,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
@@ -27,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.2.0",
+  "icon4py-common~=0.4.1",
   # external dependencies
   "packaging>=20.0"
 ]
@@ -35,12 +33,37 @@ description = "The physics driver (PhysicsDriver) and its process registry for I
 license = {text = "BSD-3 License"}
 name = "icon4py-atmosphere-physics-driver"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.2.0"
+version = "0.4.1"
 
 [project.urls]
 repository = "https://github.com/C2SM/icon4py"
+
+# -- bumpversion --
+[tool.bumpversion]
+allow_dirty = false
+commit = false
+current_version = "0.4.1"
+ignore_missing_version = false
+message = 'Bump icon4py-atmosphere-physics_driver version: {current_version} → {new_version}'
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}{pre_l}{pre_n}", "{major}.{minor}.{patch}"]
+tag = false
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+replace = '''
+# managed by bump-my-version:
+version = "{new_version}"
+'''
+search = '''
+# managed by bump-my-version:
+version = "{current_version}"
+'''
+
+[[tool.bumpversion.files]]
+filename = "src/icon4py/model/atmosphere/subgrid_scale_physics/physics_driver/__init__.py"
 
 # --ruff --
 [tool.ruff]

--- a/model/atmosphere/subgrid_scale_physics/physics_driver/src/icon4py/model/atmosphere/subgrid_scale_physics/physics_driver/__init__.py
+++ b/model/atmosphere/subgrid_scale_physics/physics_driver/src/icon4py/model/atmosphere/subgrid_scale_physics/physics_driver/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.2.0"
+__version__: Final = "0.4.1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/tracer_advection/pyproject.toml
+++ b/model/atmosphere/tracer_advection/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.4.0",
+  "icon4py-common~=0.4.1",
   # external dependencies
   "gt4py==1.2.1",
   'packaging>=20.0'
@@ -36,7 +36,7 @@ name = "icon4py-atmosphere-tracer_advection"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.4.0"
+version = "0.4.1"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -45,7 +45,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.4.0"
+current_version = "0.4.1"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-tracer_advection version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/tracer_advection/pyproject.toml
+++ b/model/atmosphere/tracer_advection/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-common~=0.3.0",
+  "icon4py-common~=0.4.0",
   # external dependencies
   "gt4py==1.2.1",
   'packaging>=20.0'
@@ -36,7 +36,7 @@ name = "icon4py-atmosphere-tracer_advection"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.3.0"
+version = "0.4.0"
 
 [project.urls]
 Homepage = "https://github.com/C2SM/icon4py"
@@ -45,7 +45,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.3.0"
+current_version = "0.4.0"
 ignore_missing_version = false
 message = 'Bump icon4py-atmosphere-tracer_advection version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/atmosphere/tracer_advection/src/icon4py/model/atmosphere/tracer_advection/__init__.py
+++ b/model/atmosphere/tracer_advection/src/icon4py/model/atmosphere/tracer_advection/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.4.0"
+__version__: Final = "0.4.1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/atmosphere/tracer_advection/src/icon4py/model/atmosphere/tracer_advection/__init__.py
+++ b/model/atmosphere/tracer_advection/src/icon4py/model/atmosphere/tracer_advection/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.3.0"
+__version__: Final = "0.4.0"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/common/pyproject.toml
+++ b/model/common/pyproject.toml
@@ -38,7 +38,7 @@ name = "icon4py-common"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.4.0"
+version = "0.4.1"
 
 [project.optional-dependencies]
 all = ["icon4py-common[distributed,io]"]
@@ -73,7 +73,7 @@ repository = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.4.0"
+current_version = "0.4.1"
 ignore_missing_version = false
 message = 'Bump icon4py-common version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/common/pyproject.toml
+++ b/model/common/pyproject.toml
@@ -38,7 +38,7 @@ name = "icon4py-common"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.3.0"
+version = "0.4.0"
 
 [project.optional-dependencies]
 all = ["icon4py-common[distributed,io]"]
@@ -73,7 +73,7 @@ repository = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.3.0"
+current_version = "0.4.0"
 ignore_missing_version = false
 message = 'Bump icon4py-common version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/common/src/icon4py/model/common/__init__.py
+++ b/model/common/src/icon4py/model/common/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.4.0"
+__version__: Final = "0.4.1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/common/src/icon4py/model/common/__init__.py
+++ b/model/common/src/icon4py/model/common/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.3.0"
+__version__: Final = "0.4.0"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/driver/pyproject.toml
+++ b/model/driver/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-atmosphere-dycore~=0.3.0",
-  "icon4py-atmosphere-diffusion~=0.3.0",
-  "icon4py-atmosphere-physics-driver~=0.3.0",
-  "icon4py-atmosphere-muphys~=0.3.0",
-  "icon4py-common[io]~=0.3.0",
+  "icon4py-atmosphere-dycore~=0.4.0",
+  "icon4py-atmosphere-diffusion~=0.4.0",
+  "icon4py-atmosphere-physics-driver~=0.4.0",
+  "icon4py-atmosphere-muphys~=0.4.0",
+  "icon4py-common[io]~=0.4.0",
   # external dependencies
   "typer>=0.20.0",
   "devtools>=0.12",
@@ -42,7 +42,7 @@ name = "icon4py-driver"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.3.0"
+version = "0.4.0"
 
 [project.scripts]
 icon4py-driver = "icon4py.model.driver.main:app"
@@ -54,7 +54,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.3.0"
+current_version = "0.4.0"
 ignore_missing_version = false
 message = 'Bump icon4py-driver version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/driver/pyproject.toml
+++ b/model/driver/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  "icon4py-atmosphere-dycore~=0.4.0",
-  "icon4py-atmosphere-diffusion~=0.4.0",
-  "icon4py-atmosphere-physics-driver~=0.4.0",
-  "icon4py-atmosphere-muphys~=0.4.0",
-  "icon4py-common[io]~=0.4.0",
+  "icon4py-atmosphere-dycore~=0.4.1",
+  "icon4py-atmosphere-diffusion~=0.4.1",
+  "icon4py-atmosphere-physics-driver~=0.4.1",
+  "icon4py-atmosphere-muphys~=0.4.1",
+  "icon4py-common[io]~=0.4.1",
   # external dependencies
   "typer>=0.20.0",
   "devtools>=0.12",
@@ -42,7 +42,7 @@ name = "icon4py-driver"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.4.0"
+version = "0.4.1"
 
 [project.scripts]
 icon4py-driver = "icon4py.model.driver.main:app"
@@ -54,7 +54,7 @@ Homepage = "https://github.com/C2SM/icon4py"
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.4.0"
+current_version = "0.4.1"
 ignore_missing_version = false
 message = 'Bump icon4py-driver version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/driver/src/icon4py/model/driver/__init__.py
+++ b/model/driver/src/icon4py/model/driver/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.4.0"
+__version__: Final = "0.4.1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/driver/src/icon4py/model/driver/__init__.py
+++ b/model/driver/src/icon4py/model/driver/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.3.0"
+__version__: Final = "0.4.0"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/testing/pyproject.toml
+++ b/model/testing/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  'icon4py-common[io]~=0.4.0',
+  'icon4py-common[io]~=0.4.1',
   # external dependencies
   # TODO(msimberg): https://github.com/tox-dev/filelock/pull/408 added in 3.20.4
   # and 3.21.0 seems to lead to hangs in CI. Investigate if other lock types are
@@ -44,7 +44,7 @@ name = "icon4py-testing"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.4.0"
+version = "0.4.1"
 
 [project.urls]
 Homepage = 'https://github.com/C2SM/icon4py'
@@ -53,7 +53,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.4.0"
+current_version = "0.4.1"
 ignore_missing_version = false
 message = 'Bump icon4py-testing version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/testing/pyproject.toml
+++ b/model/testing/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # workspace members
-  'icon4py-common[io]~=0.3.0',
+  'icon4py-common[io]~=0.4.0',
   # external dependencies
   # TODO(msimberg): https://github.com/tox-dev/filelock/pull/408 added in 3.20.4
   # and 3.21.0 seems to lead to hangs in CI. Investigate if other lock types are
@@ -44,7 +44,7 @@ name = "icon4py-testing"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.3.0"
+version = "0.4.0"
 
 [project.urls]
 Homepage = 'https://github.com/C2SM/icon4py'
@@ -53,7 +53,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.3.0"
+current_version = "0.4.0"
 ignore_missing_version = false
 message = 'Bump icon4py-testing version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/model/testing/src/icon4py/model/testing/__init__.py
+++ b/model/testing/src/icon4py/model/testing/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.4.0"
+__version__: Final = "0.4.1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/model/testing/src/icon4py/model/testing/__init__.py
+++ b/model/testing/src/icon4py/model/testing/__init__.py
@@ -25,5 +25,5 @@ __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
 
-__version__: Final = "0.3.0"
+__version__: Final = "0.4.0"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ scripts = [
 ]
 test = [
   # workspace members
-  "icon4py-testing~=0.3.0",
+  "icon4py-testing~=0.4.0",
   # external dependencies
   "coverage[toml]>=7.5.0",
   "nox>=2025.5.1",
@@ -89,14 +89,14 @@ classifiers = [
   'Topic :: Scientific/Engineering :: Physics'
 ]
 dependencies = [
-  "icon4py-atmosphere-tracer_advection~=0.3.0",
-  "icon4py-atmosphere-diffusion~=0.3.0",
-  "icon4py-atmosphere-dycore~=0.3.0",
-  "icon4py-atmosphere-microphysics~=0.3.0",
-  "icon4py-atmosphere-muphys~=0.3.0",
-  "icon4py-atmosphere-physics-driver~=0.3.0",
-  "icon4py-common~=0.3.0",
-  "icon4py-driver~=0.3.0"
+  "icon4py-atmosphere-tracer_advection~=0.4.0",
+  "icon4py-atmosphere-diffusion~=0.4.0",
+  "icon4py-atmosphere-dycore~=0.4.0",
+  "icon4py-atmosphere-microphysics~=0.4.0",
+  "icon4py-atmosphere-muphys~=0.4.0",
+  "icon4py-atmosphere-physics-driver~=0.4.0",
+  "icon4py-common~=0.4.0",
+  "icon4py-driver~=0.4.0"
 ]
 description = 'ICON model in Python.'
 license = {text = "BSD-3 License"}
@@ -104,14 +104,14 @@ name = "icon4py"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.3.0"
+version = "0.4.0"
 
 [project.optional-dependencies]
 all = ["icon4py[distributed,fortran,io,testing,profiling]"]
 cuda12 = ["icon4py-common[cuda12]"]
 cuda13 = ["icon4py-common[cuda13]"]
 distributed = ["icon4py-common[distributed]"]
-fortran = ["icon4py-bindings~=0.3.0"]
+fortran = ["icon4py-bindings~=0.4.0"]
 io = ["icon4py-common[io]"]
 profiling = ['viztracer>=1.1.0']
 rocm7 = ["icon4py-common[rocm7]"]
@@ -124,7 +124,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.3.0"
+current_version = "0.4.0"
 ignore_missing_version = false
 message = 'Bump icon4py version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ scripts = [
 ]
 test = [
   # workspace members
-  "icon4py-testing~=0.4.0",
+  "icon4py-testing~=0.4.1",
   # external dependencies
   "coverage[toml]>=7.5.0",
   "nox>=2025.5.1",
@@ -89,14 +89,14 @@ classifiers = [
   'Topic :: Scientific/Engineering :: Physics'
 ]
 dependencies = [
-  "icon4py-atmosphere-tracer_advection~=0.4.0",
-  "icon4py-atmosphere-diffusion~=0.4.0",
-  "icon4py-atmosphere-dycore~=0.4.0",
-  "icon4py-atmosphere-microphysics~=0.4.0",
-  "icon4py-atmosphere-muphys~=0.4.0",
-  "icon4py-atmosphere-physics-driver~=0.4.0",
-  "icon4py-common~=0.4.0",
-  "icon4py-driver~=0.4.0"
+  "icon4py-atmosphere-tracer_advection~=0.4.1",
+  "icon4py-atmosphere-diffusion~=0.4.1",
+  "icon4py-atmosphere-dycore~=0.4.1",
+  "icon4py-atmosphere-microphysics~=0.4.1",
+  "icon4py-atmosphere-muphys~=0.4.1",
+  "icon4py-atmosphere-physics-driver~=0.4.1",
+  "icon4py-common~=0.4.1",
+  "icon4py-driver~=0.4.1"
 ]
 description = 'ICON model in Python.'
 license = {text = "BSD-3 License"}
@@ -104,14 +104,14 @@ name = "icon4py"
 readme = "README.md"
 requires-python = ">=3.12"
 # managed by bump-my-version:
-version = "0.4.0"
+version = "0.4.1"
 
 [project.optional-dependencies]
 all = ["icon4py[distributed,fortran,io,testing,profiling]"]
 cuda12 = ["icon4py-common[cuda12]"]
 cuda13 = ["icon4py-common[cuda13]"]
 distributed = ["icon4py-common[distributed]"]
-fortran = ["icon4py-bindings~=0.4.0"]
+fortran = ["icon4py-bindings~=0.4.1"]
 io = ["icon4py-common[io]"]
 profiling = ['viztracer>=1.1.0']
 rocm7 = ["icon4py-common[rocm7]"]
@@ -124,7 +124,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.4.0"
+current_version = "0.4.1"
 ignore_missing_version = false
 message = 'Bump icon4py version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -40,7 +40,7 @@ name = 'icon4py-tools'
 readme = 'README.md'
 requires-python = '>=3.12'
 # managed by bump-my-version:
-version = "0.3.0"
+version = "0.4.0"
 
 [project.optional-dependencies]
 cuda12 = ['icon4py-common[cuda12]']
@@ -58,7 +58,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.3.0"
+current_version = "0.4.0"
 ignore_missing_version = false
 message = 'Bump icon4py-tools version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -40,7 +40,7 @@ name = 'icon4py-tools'
 readme = 'README.md'
 requires-python = '>=3.12'
 # managed by bump-my-version:
-version = "0.4.0"
+version = "0.4.1"
 
 [project.optional-dependencies]
 cuda12 = ['icon4py-common[cuda12]']
@@ -58,7 +58,7 @@ Homepage = 'https://github.com/C2SM/icon4py'
 [tool.bumpversion]
 allow_dirty = false
 commit = false
-current_version = "0.4.0"
+current_version = "0.4.1"
 ignore_missing_version = false
 message = 'Bump icon4py-tools version: {current_version} → {new_version}'
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:(?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"

--- a/tools/src/icon4py/tools/__init__.py
+++ b/tools/src/icon4py/tools/__init__.py
@@ -25,5 +25,5 @@ __author__: Final = "ETH Zurich,  MeteoSwiss and individual contributors"
 __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
-__version__: Final = "0.4.0"
+__version__: Final = "0.4.1"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/tools/src/icon4py/tools/__init__.py
+++ b/tools/src/icon4py/tools/__init__.py
@@ -25,5 +25,5 @@ __author__: Final = "ETH Zurich,  MeteoSwiss and individual contributors"
 __copyright__: Final = "Copyright (c) 2022-2024 ETH Zurich and MeteoSwiss"
 __license__: Final = "BSD-3-Clause"
 
-__version__: Final = "0.3.0"
+__version__: Final = "0.4.0"
 __version_info__: Final = pkg_version.parse(__version__)

--- a/uv.lock
+++ b/uv.lock
@@ -16,10 +16,10 @@ resolution-markers = [
   "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
   "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
   "python_full_version == '3.13.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-  "python_full_version < '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
   "python_full_version == '3.13.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
   "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
   "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+  "python_full_version < '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
   "python_full_version < '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
   "python_full_version < '3.13' and sys_platform == 'emscripten'",
   "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'"
@@ -1771,7 +1771,7 @@ dependencies = [
 ]
 name = "icon4py"
 source = {editable = "."}
-version = "0.3.0"
+version = "0.4.0"
 
 [package.dev-dependencies]
 build = [
@@ -2027,7 +2027,7 @@ dependencies = [
 ]
 name = "icon4py-atmosphere-diffusion"
 source = {editable = "model/atmosphere/diffusion"}
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata]
 requires-dist = [
@@ -2044,7 +2044,7 @@ dependencies = [
 ]
 name = "icon4py-atmosphere-dycore"
 source = {editable = "model/atmosphere/dycore"}
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata]
 requires-dist = [
@@ -2061,7 +2061,7 @@ dependencies = [
 ]
 name = "icon4py-atmosphere-microphysics"
 source = {editable = "model/atmosphere/subgrid_scale_physics/microphysics"}
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata]
 requires-dist = [
@@ -2079,7 +2079,7 @@ dependencies = [
 ]
 name = "icon4py-atmosphere-muphys"
 source = {editable = "model/atmosphere/subgrid_scale_physics/muphys"}
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata]
 requires-dist = [
@@ -2112,7 +2112,7 @@ dependencies = [
 ]
 name = "icon4py-atmosphere-tracer-advection"
 source = {editable = "model/atmosphere/tracer_advection"}
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata]
 requires-dist = [
@@ -2136,7 +2136,7 @@ dependencies = [
 ]
 name = "icon4py-bindings"
 source = {editable = "bindings"}
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata]
 provides-extras = ["cuda12", "cuda13", "profiling"]
@@ -2183,7 +2183,7 @@ dependencies = [
 ]
 name = "icon4py-common"
 source = {editable = "model/common"}
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata]
 provides-extras = ["all", "cuda12", "cuda13", "distributed", "io", "rocm7"]
@@ -2277,7 +2277,7 @@ dependencies = [
 ]
 name = "icon4py-driver"
 source = {editable = "model/driver"}
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata]
 requires-dist = [
@@ -2305,7 +2305,7 @@ dependencies = [
 ]
 name = "icon4py-testing"
 source = {editable = "model/testing"}
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata]
 requires-dist = [
@@ -2332,7 +2332,7 @@ dependencies = [
 ]
 name = "icon4py-tools"
 source = {editable = "tools"}
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata]
 provides-extras = ["cuda12", "cuda13", "profiling", "rocm7"]

--- a/uv.lock
+++ b/uv.lock
@@ -1771,7 +1771,7 @@ dependencies = [
 ]
 name = "icon4py"
 source = {editable = "."}
-version = "0.4.0"
+version = "0.4.1"
 
 [package.dev-dependencies]
 build = [
@@ -2027,7 +2027,7 @@ dependencies = [
 ]
 name = "icon4py-atmosphere-diffusion"
 source = {editable = "model/atmosphere/diffusion"}
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata]
 requires-dist = [
@@ -2044,7 +2044,7 @@ dependencies = [
 ]
 name = "icon4py-atmosphere-dycore"
 source = {editable = "model/atmosphere/dycore"}
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata]
 requires-dist = [
@@ -2061,7 +2061,7 @@ dependencies = [
 ]
 name = "icon4py-atmosphere-microphysics"
 source = {editable = "model/atmosphere/subgrid_scale_physics/microphysics"}
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata]
 requires-dist = [
@@ -2079,7 +2079,7 @@ dependencies = [
 ]
 name = "icon4py-atmosphere-muphys"
 source = {editable = "model/atmosphere/subgrid_scale_physics/muphys"}
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata]
 requires-dist = [
@@ -2096,7 +2096,7 @@ dependencies = [
 ]
 name = "icon4py-atmosphere-physics-driver"
 source = {editable = "model/atmosphere/subgrid_scale_physics/physics_driver"}
-version = "0.2.0"
+version = "0.4.1"
 
 [package.metadata]
 requires-dist = [
@@ -2112,7 +2112,7 @@ dependencies = [
 ]
 name = "icon4py-atmosphere-tracer-advection"
 source = {editable = "model/atmosphere/tracer_advection"}
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata]
 requires-dist = [
@@ -2136,7 +2136,7 @@ dependencies = [
 ]
 name = "icon4py-bindings"
 source = {editable = "bindings"}
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata]
 provides-extras = ["cuda12", "cuda13", "profiling"]
@@ -2183,7 +2183,7 @@ dependencies = [
 ]
 name = "icon4py-common"
 source = {editable = "model/common"}
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata]
 provides-extras = ["all", "cuda12", "cuda13", "distributed", "io", "rocm7"]
@@ -2277,7 +2277,7 @@ dependencies = [
 ]
 name = "icon4py-driver"
 source = {editable = "model/driver"}
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata]
 requires-dist = [
@@ -2305,7 +2305,7 @@ dependencies = [
 ]
 name = "icon4py-testing"
 source = {editable = "model/testing"}
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata]
 requires-dist = [
@@ -2332,7 +2332,7 @@ dependencies = [
 ]
 name = "icon4py-tools"
 source = {editable = "tools"}
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata]
 provides-extras = ["cuda12", "cuda13", "profiling", "rocm7"]


### PR DESCRIPTION
0.4.0 --> 0.4.1 and fixes to physics_driver pyproject.toml. Physics driver package was stuck at 0.2.0 because it was started before 0.3.0 was released, but merged after 0.3.0 was released.