### PR TITLE
CI: switch to normal partition

### DIFF
--- a/.cscs-ci/base.yml
+++ b/.cscs-ci/base.yml
@@ -286,7 +286,6 @@ variables:
     OMPI_MCA_mpi_cuda_support: "0"
     SLURM_NTASKS: "1"
     SLURM_GPUS_PER_TASK: "1"
-    SLURM_PARTITION: "normal"
     SLURM_TIMELIMIT: "00:10:00"
   script:
     - cd /icon4py

--- a/.cscs-ci/base.yml
+++ b/.cscs-ci/base.yml
@@ -75,7 +75,7 @@ variables:
   variables:
     SLURM_JOB_NUM_NODES: 1
     SLURM_GPUS_PER_NODE: 1
-    SLURM_PARTITION: "shared"
+    SLURM_PARTITION: "normal"
     SLURM_CPU_BIND: "verbose"
     SLURM_TIMELIMIT: '00:30:00'
     SLURM_MPI_TYPE: pmix
@@ -169,6 +169,8 @@ variables:
     SLURM_NTASKS: 12
     ICON4PY_TEST_MPI_SUBCOMM_SIZE: 4
     SLURM_LABELIO: 1
+    SLURM_GPUS_PER_NODE: 4
+    SLURM_GRES_FLAGS: allow-task-sharing
     # Use this to reduce memory requirements from having one venv per rank.
     # Generally this is not recommended but in CI the cache will not get wiped
     # so this can be used safely.
@@ -251,16 +253,10 @@ variables:
         NVCC_APPEND_FLAGS: "--fmad=false"
         # TODO(msimberg): Decrease this when there's more parallelism for compilation.
         SLURM_TIMELIMIT: '02:00:00'
-        # TODO(msimberg): Use shared partition when time limit can be set to at
-        # most an hour. The shared partition only accepts jobs maximum an hour long.
-        SLURM_PARTITION: "normal"
     - if: $MODEL_MPI_SUBPACKAGE == 'driver' || ($MODEL_MPI_SUBPACKAGE == 'common' && ($BACKEND == 'dace_gpu' || $BACKEND == 'gtfn_gpu'))
       variables:
         # TODO(msimberg): Decrease this when there's more parallelism for compilation.
         SLURM_TIMELIMIT: '02:00:00'
-        # TODO(msimberg): Use shared partition when time limit can be set to at
-        # most an hour. The shared partition only accepts jobs maximum an hour long.
-        SLURM_PARTITION: "normal"
     - if: $MODEL_MPI_SUBPACKAGE == 'common'
       variables:
         SLURM_TIMELIMIT: '00:55:00'
@@ -290,7 +286,7 @@ variables:
     OMPI_MCA_mpi_cuda_support: "0"
     SLURM_NTASKS: "1"
     SLURM_GPUS_PER_TASK: "1"
-    SLURM_PARTITION: "shared"
+    SLURM_PARTITION: "normal"
     SLURM_TIMELIMIT: "00:10:00"
   script:
     - cd /icon4py

--- a/.cscs-ci/base.yml
+++ b/.cscs-ci/base.yml
@@ -169,8 +169,6 @@ variables:
     SLURM_NTASKS: 12
     ICON4PY_TEST_MPI_SUBCOMM_SIZE: 4
     SLURM_LABELIO: 1
-    SLURM_GPUS_PER_NODE: 4
-    SLURM_GRES_FLAGS: allow-task-sharing
     # Use this to reduce memory requirements from having one venv per rank.
     # Generally this is not recommended but in CI the cache will not get wiped
     # so this can be used safely.

--- a/.cscs-ci/benchmark_bencher_common.yml
+++ b/.cscs-ci/benchmark_bencher_common.yml
@@ -17,7 +17,9 @@
   extends: [.benchmark_model_base_variables]
   variables:
     SLURM_JOB_NUM_NODES: 1
-    SLURM_PARTITION: "normal"
+    SLURM_GPUS_PER_NODE: 4
+    SLURM_GRES_FLAGS: allow-task-sharing
+    SLURM_PARTITION: normal
     SLURM_TIMELIMIT: '01:30:00'
 
 


### PR DESCRIPTION
Switching to slurm partition `normal`, since the `shared` partition was deleted on Säntis vCluster. The GPU count is kept the same as before: 1 GPU for regular jobs, 4 GPUs (full node) for MPI jobs and for benchmark jobs.