### PR TITLE
Remove redundant mpi4py import checks from MPI test files

### DIFF
--- a/model/common/tests/common/io/mpi_tests/test_parallel_io.py
+++ b/model/common/tests/common/io/mpi_tests/test_parallel_io.py
@@ -31,15 +31,12 @@ import zarr
 
 import icon4py.model.common.exceptions as errors
 from icon4py.model.common import dimension as dims, time as common_time
-from icon4py.model.common.decomposition import definitions as decomp_defs, mpi_decomposition
+from icon4py.model.common.decomposition import definitions as decomp_defs
 from icon4py.model.common.grid import vertical as v_grid
 from icon4py.model.common.io import distributed, io as common_io, netcdf_writers, writers
 
 from ...fixtures import process_props
 
-
-if mpi_decomposition.mpi4py is None:
-    pytest.skip("Skipping parallel tests on single node installation", allow_module_level=True)
 
 NUM_LEVELS = 4
 GLOBAL_SIZES = {dims.CellDim: 109, dims.EdgeDim: 75, dims.VertexDim: 41}

--- a/model/common/tests/common/states/mpi_tests/test_parallel_factory.py
+++ b/model/common/tests/common/states/mpi_tests/test_parallel_factory.py
@@ -14,11 +14,7 @@ import pytest
 from gt4py import next as gtx
 
 from icon4py.model.common import dimension as dims, field_type_aliases as fa, model_backends
-from icon4py.model.common.decomposition import (
-    decomposer as decomp,
-    definitions as decomp_defs,
-    mpi_decomposition,
-)
+from icon4py.model.common.decomposition import decomposer as decomp, definitions as decomp_defs
 from icon4py.model.common.grid import horizontal as h_grid
 from icon4py.model.common.states import factory
 from icon4py.model.common.utils import data_allocation as data_alloc
@@ -31,10 +27,6 @@ from ..unit_tests.test_factory import SimpleFieldSource
 
 if TYPE_CHECKING:
     import gt4py.next.typing as gtx_typing
-
-
-if mpi_decomposition.mpi4py is None:
-    pytest.skip("Skipping parallel tests on single node installation", allow_module_level=True)
 
 
 @gtx.field_operator

--- a/model/driver/tests/driver/mpi_tests/test_parallel_driver.py
+++ b/model/driver/tests/driver/mpi_tests/test_parallel_driver.py
@@ -13,7 +13,7 @@ import gt4py.next.typing as gtx_typing
 import pytest
 
 from icon4py.model.common import model_backends, time
-from icon4py.model.common.decomposition import definitions as decomp_defs, mpi_decomposition
+from icon4py.model.common.decomposition import definitions as decomp_defs
 from icon4py.model.driver import config as driver_config, driver, driver_utils
 from icon4py.model.testing import (
     datatest_utils as dt_utils,
@@ -30,9 +30,6 @@ from icon4py.model.testing.fixtures.datatest import (
     process_props,
 )
 
-
-if mpi_decomposition.mpi4py is None:
-    pytest.skip("Skipping parallel tests on single node installation", allow_module_level=True)
 
 _log = logging.getLogger(__file__)
 

--- a/model/driver/tests/driver/mpi_tests/test_parallel_driver_io.py
+++ b/model/driver/tests/driver/mpi_tests/test_parallel_driver_io.py
@@ -25,7 +25,7 @@ import pytest
 import xarray as xr
 
 from icon4py.model.common import model_backends, time
-from icon4py.model.common.decomposition import definitions as decomp_defs, mpi_decomposition
+from icon4py.model.common.decomposition import definitions as decomp_defs
 from icon4py.model.common.io import io as common_io, netcdf_writers, writers
 from icon4py.model.driver import config as driver_config, driver, driver_io, driver_utils
 from icon4py.model.testing import (
@@ -42,9 +42,6 @@ from icon4py.model.testing.fixtures.datatest import (
     process_props,
 )
 
-
-if mpi_decomposition.mpi4py is None:
-    pytest.skip("Skipping parallel tests on single node installation", allow_module_level=True)
 
 _log = logging.getLogger(__file__)
 

--- a/model/driver/tests/driver/mpi_tests/test_parallel_initial_conditions.py
+++ b/model/driver/tests/driver/mpi_tests/test_parallel_initial_conditions.py
@@ -13,7 +13,7 @@ import gt4py.next.typing as gtx_typing
 import pytest
 
 from icon4py.model.common import initial_condition, model_backends, model_options
-from icon4py.model.common.decomposition import definitions as decomp_defs, mpi_decomposition
+from icon4py.model.common.decomposition import definitions as decomp_defs
 from icon4py.model.common.states import (
     diagnostic_state as diagnostics,
     nonhydro_states,
@@ -37,9 +37,6 @@ from icon4py.model.testing.fixtures.datatest import (
     process_props,
 )
 
-
-if mpi_decomposition.mpi4py is None:
-    pytest.skip("Skipping parallel tests on single node installation", allow_module_level=True)
 
 _log = logging.getLogger(__file__)
 


### PR DESCRIPTION
These module-level `if mpi_decomposition.mpi4py is None: pytest.skip(...)` guards are redundant since #1223: MPI tests are filtered out at collection time, and `--with-mpi` raises a hard error if mpi4py/ghex couldn't be imported. #1318 removed the same pattern from `test_parallel_advection.py`; this removes it from the remaining files where it crept back in.