### PR TITLE
refactor(common): EdgeParams as a dataclass with explicit optional members

### DIFF
--- a/bindings/src/icon4py/bindings/grid_wrapper.py
+++ b/bindings/src/icon4py/bindings/grid_wrapper.py
@@ -210,20 +210,32 @@ def grid_init(  # noqa: PLR0917 [too-many-positional-arguments]
         inverse_primal_edge_lengths=inverse_primal_edge_lengths,
         inverse_dual_edge_lengths=inv_dual_edge_length,
         inverse_vertex_vertex_lengths=inv_vert_vert_length,
-        primal_normal_vert_x=primal_normal_vert_x,
-        primal_normal_vert_y=primal_normal_vert_y,
-        dual_normal_vert_x=dual_normal_vert_x,
-        dual_normal_vert_y=dual_normal_vert_y,
-        primal_normal_cell_x=primal_normal_cell_x,
-        primal_normal_cell_y=primal_normal_cell_y,
-        dual_normal_cell_x=dual_normal_cell_x,
-        dual_normal_cell_y=dual_normal_cell_y,
+        primal_normal_vert=(
+            primal_normal_vert_x,
+            primal_normal_vert_y,
+        ),
+        dual_normal_vert=(
+            dual_normal_vert_x,
+            dual_normal_vert_y,
+        ),
+        primal_normal_cell=(
+            primal_normal_cell_x,
+            primal_normal_cell_y,
+        ),
+        dual_normal_cell=(
+            dual_normal_cell_x,
+            dual_normal_cell_y,
+        ),
         edge_areas=edge_areas,
         coriolis_frequency=f_e,
-        edge_center_lat=edge_center_lat,
-        edge_center_lon=edge_center_lon,
-        primal_normal_x=primal_normal_x,
-        primal_normal_y=primal_normal_y,
+        edge_center=(
+            edge_center_lat,
+            edge_center_lon,
+        ),
+        primal_normal=(
+            primal_normal_x,
+            primal_normal_y,
+        ),
     )
 
     # Cell geometry

--- a/bindings/tests/bindings/utils.py
+++ b/bindings/tests/bindings/utils.py
@@ -7,6 +7,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+import dataclasses
+import typing
+
 import numpy as np
 from gt4py.next.embedded.nd_array_field import NdArrayField
 
@@ -83,6 +86,19 @@ def compare_values_shallow(value1, value2, obj_name="value"):  # noqa: PLR0911, 
         return True, None
 
 
+def _optional_fields(obj) -> frozenset[str]:
+    """Dataclass fields whose annotation admits ``None``."""
+    if not dataclasses.is_dataclass(obj):
+        return frozenset()
+    # Deliberately not 'get_type_hints': it resolves forward references in the
+    # defining module's namespace and raises for classes whose annotations name
+    # something not imported there. A class using 'from __future__ import
+    # annotations' therefore reports no optional fields, and is compared strictly.
+    return frozenset(
+        field.name for field in dataclasses.fields(obj) if type(None) in typing.get_args(field.type)
+    )
+
+
 def compare_objects(obj1, obj2, obj_name="object"):  # noqa: PLR0911
     # Check if both objects are instances of numpy scalar types
     if isinstance(obj1, np.ScalarType) and isinstance(obj2, np.ScalarType):
@@ -107,9 +123,14 @@ def compare_objects(obj1, obj2, obj_name="object"):  # noqa: PLR0911
     if obj1.__class__ != obj2.__class__:
         return False, f"Class mismatch for {obj_name}: {obj1.__class__} != {obj2.__class__}"
 
-    # Shallowly compare the attributes of both objects
+    # Shallowly compare the attributes of both objects. A field annotated as
+    # optional may be unset on one side, because the construction path there
+    # cannot supply it; every other field must match.
+    optional = _optional_fields(obj1)
     for attr, value in vars(obj1).items():
         other_value = getattr(obj2, attr, None)
+        if attr in optional and (value is None or other_value is None):
+            continue
         result, error_message = compare_values_shallow(value, other_value, f"{obj_name}.{attr}")
         if not result:
             return False, error_message

--- a/bindings/tests/bindings/utils.py
+++ b/bindings/tests/bindings/utils.py
@@ -90,10 +90,6 @@ def _optional_fields(obj) -> frozenset[str]:
     """Dataclass fields whose annotation admits ``None``."""
     if not dataclasses.is_dataclass(obj):
         return frozenset()
-    # Deliberately not 'get_type_hints': it resolves forward references in the
-    # defining module's namespace and raises for classes whose annotations name
-    # something not imported there. A class using 'from __future__ import
-    # annotations' therefore reports no optional fields, and is compared strictly.
     return frozenset(
         field.name for field in dataclasses.fields(obj) if type(None) in typing.get_args(field.type)
     )
@@ -123,9 +119,7 @@ def compare_objects(obj1, obj2, obj_name="object"):  # noqa: PLR0911
     if obj1.__class__ != obj2.__class__:
         return False, f"Class mismatch for {obj_name}: {obj1.__class__} != {obj2.__class__}"
 
-    # Shallowly compare the attributes of both objects. A field annotated as
-    # optional may be unset on one side, because the construction path there
-    # cannot supply it; every other field must match.
+    # Shallowly compare the attributes of both objects
     optional = _optional_fields(obj1)
     for attr, value in vars(obj1).items():
         other_value = getattr(obj2, attr, None)

--- a/model/atmosphere/diffusion/tests/diffusion/integration_tests/test_benchmark_diffusion.py
+++ b/model/atmosphere/diffusion/tests/diffusion/integration_tests/test_benchmark_diffusion.py
@@ -75,32 +75,44 @@ def test_diffusion_benchmark(  # noqa: PLR0917 [too-many-positional-arguments]
         area=geometry_field_source.get(geometry_meta.CELL_AREA),
     )
     edge_geometry = grid_states.EdgeParams(
-        edge_center_lat=geometry_field_source.get(geometry_meta.EDGE_LAT),
-        edge_center_lon=geometry_field_source.get(geometry_meta.EDGE_LON),
         tangent_orientation=geometry_field_source.get(geometry_meta.TANGENT_ORIENTATION),
-        coriolis_frequency=geometry_field_source.get(geometry_meta.CORIOLIS_PARAMETER),
-        edge_areas=geometry_field_source.get(geometry_meta.EDGE_AREA),
-        primal_edge_lengths=geometry_field_source.get(geometry_meta.EDGE_LENGTH),
         inverse_primal_edge_lengths=geometry_field_source.get(
             f"inverse_of_{geometry_meta.EDGE_LENGTH}"
         ),
-        dual_edge_lengths=geometry_field_source.get(geometry_meta.DUAL_EDGE_LENGTH),
         inverse_dual_edge_lengths=geometry_field_source.get(
             f"inverse_of_{geometry_meta.DUAL_EDGE_LENGTH}"
         ),
         inverse_vertex_vertex_lengths=geometry_field_source.get(
             f"inverse_of_{geometry_meta.VERTEX_VERTEX_LENGTH}"
         ),
-        primal_normal_x=geometry_field_source.get(geometry_meta.EDGE_NORMAL_U),
-        primal_normal_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_V),
-        primal_normal_cell_x=geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_U),
-        primal_normal_cell_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_V),
-        primal_normal_vert_x=geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_U),
-        primal_normal_vert_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
-        dual_normal_cell_x=geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_U),
-        dual_normal_cell_y=geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_V),
-        dual_normal_vert_x=geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_U),
-        dual_normal_vert_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
+        primal_normal_vert=(
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_U),
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
+        ),
+        dual_normal_vert=(
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_U),
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_V),
+        ),
+        primal_normal_cell=(
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_U),
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_V),
+        ),
+        dual_normal_cell=(
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_U),
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_V),
+        ),
+        edge_areas=geometry_field_source.get(geometry_meta.EDGE_AREA),
+        coriolis_frequency=geometry_field_source.get(geometry_meta.CORIOLIS_PARAMETER),
+        edge_center=(
+            geometry_field_source.get(geometry_meta.EDGE_LAT),
+            geometry_field_source.get(geometry_meta.EDGE_LON),
+        ),
+        primal_normal=(
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_U),
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_V),
+        ),
+        primal_edge_lengths=geometry_field_source.get(geometry_meta.EDGE_LENGTH),
+        dual_edge_lengths=geometry_field_source.get(geometry_meta.DUAL_EDGE_LENGTH),
     )
 
     vertical_config = v_grid.VerticalGridConfig(

--- a/model/atmosphere/diffusion/tests/diffusion/integration_tests/test_diffusion.py
+++ b/model/atmosphere/diffusion/tests/diffusion/integration_tests/test_diffusion.py
@@ -57,28 +57,40 @@ def _get_or_initialize(experiment: test_defs.Experiment, backend: gtx_typing.Bac
             area=geometry_.get(geometry_meta.CELL_AREA),
         )
         edge_params = grid_states.EdgeParams(
-            edge_center_lat=geometry_.get(geometry_meta.EDGE_LAT),
-            edge_center_lon=geometry_.get(geometry_meta.EDGE_LON),
             tangent_orientation=geometry_.get(geometry_meta.TANGENT_ORIENTATION),
-            coriolis_frequency=geometry_.get(geometry_meta.CORIOLIS_PARAMETER),
-            edge_areas=geometry_.get(geometry_meta.EDGE_AREA),
-            primal_edge_lengths=geometry_.get(geometry_meta.EDGE_LENGTH),
             inverse_primal_edge_lengths=geometry_.get(f"inverse_of_{geometry_meta.EDGE_LENGTH}"),
-            dual_edge_lengths=geometry_.get(geometry_meta.DUAL_EDGE_LENGTH),
             inverse_dual_edge_lengths=geometry_.get(f"inverse_of_{geometry_meta.DUAL_EDGE_LENGTH}"),
             inverse_vertex_vertex_lengths=geometry_.get(
                 f"inverse_of_{geometry_meta.VERTEX_VERTEX_LENGTH}"
             ),
-            primal_normal_x=geometry_.get(geometry_meta.EDGE_NORMAL_U),
-            primal_normal_y=geometry_.get(geometry_meta.EDGE_NORMAL_V),
-            primal_normal_cell_x=geometry_.get(geometry_meta.EDGE_NORMAL_CELL_U),
-            primal_normal_cell_y=geometry_.get(geometry_meta.EDGE_NORMAL_CELL_V),
-            primal_normal_vert_x=geometry_.get(geometry_meta.EDGE_NORMAL_VERTEX_U),
-            primal_normal_vert_y=geometry_.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
-            dual_normal_cell_x=geometry_.get(geometry_meta.EDGE_TANGENT_CELL_U),
-            dual_normal_cell_y=geometry_.get(geometry_meta.EDGE_TANGENT_CELL_V),
-            dual_normal_vert_x=geometry_.get(geometry_meta.EDGE_TANGENT_VERTEX_U),
-            dual_normal_vert_y=geometry_.get(geometry_meta.EDGE_TANGENT_VERTEX_V),
+            primal_normal_vert=(
+                geometry_.get(geometry_meta.EDGE_NORMAL_VERTEX_U),
+                geometry_.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
+            ),
+            dual_normal_vert=(
+                geometry_.get(geometry_meta.EDGE_TANGENT_VERTEX_U),
+                geometry_.get(geometry_meta.EDGE_TANGENT_VERTEX_V),
+            ),
+            primal_normal_cell=(
+                geometry_.get(geometry_meta.EDGE_NORMAL_CELL_U),
+                geometry_.get(geometry_meta.EDGE_NORMAL_CELL_V),
+            ),
+            dual_normal_cell=(
+                geometry_.get(geometry_meta.EDGE_TANGENT_CELL_U),
+                geometry_.get(geometry_meta.EDGE_TANGENT_CELL_V),
+            ),
+            edge_areas=geometry_.get(geometry_meta.EDGE_AREA),
+            coriolis_frequency=geometry_.get(geometry_meta.CORIOLIS_PARAMETER),
+            edge_center=(
+                geometry_.get(geometry_meta.EDGE_LAT),
+                geometry_.get(geometry_meta.EDGE_LON),
+            ),
+            primal_normal=(
+                geometry_.get(geometry_meta.EDGE_NORMAL_U),
+                geometry_.get(geometry_meta.EDGE_NORMAL_V),
+            ),
+            primal_edge_lengths=geometry_.get(geometry_meta.EDGE_LENGTH),
+            dual_edge_lengths=geometry_.get(geometry_meta.DUAL_EDGE_LENGTH),
         )
         grid_functionality[experiment.name]["grid"] = grid
         grid_functionality[experiment.name]["edge_geometry"] = edge_params

--- a/model/atmosphere/dycore/tests/dycore/integration_tests/test_benchmark_solve_nonhydro.py
+++ b/model/atmosphere/dycore/tests/dycore/integration_tests/test_benchmark_solve_nonhydro.py
@@ -91,20 +91,32 @@ def solve_nonhydro(
         inverse_vertex_vertex_lengths=geometry_field_source.get(
             f"inverse_of_{geometry_meta.VERTEX_VERTEX_LENGTH}"
         ),
-        primal_normal_vert_x=geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_U),
-        primal_normal_vert_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
-        dual_normal_vert_x=geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_U),
-        dual_normal_vert_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
-        primal_normal_cell_x=geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_U),
-        dual_normal_cell_x=geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_U),
-        primal_normal_cell_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_V),
-        dual_normal_cell_y=geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_V),
+        primal_normal_vert=(
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_U),
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
+        ),
+        dual_normal_vert=(
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_U),
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_V),
+        ),
+        primal_normal_cell=(
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_U),
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_V),
+        ),
+        dual_normal_cell=(
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_U),
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_V),
+        ),
         edge_areas=geometry_field_source.get(geometry_meta.EDGE_AREA),
         coriolis_frequency=geometry_field_source.get(geometry_meta.CORIOLIS_PARAMETER),
-        edge_center_lat=geometry_field_source.get(geometry_meta.EDGE_LAT),
-        edge_center_lon=geometry_field_source.get(geometry_meta.EDGE_LON),
-        primal_normal_x=geometry_field_source.get(geometry_meta.EDGE_NORMAL_U),
-        primal_normal_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_V),
+        edge_center=(
+            geometry_field_source.get(geometry_meta.EDGE_LAT),
+            geometry_field_source.get(geometry_meta.EDGE_LON),
+        ),
+        primal_normal=(
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_U),
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_V),
+        ),
     )
 
     interpolation_state = dycore_states.InterpolationState(

--- a/model/common/src/icon4py/model/common/grid/states.py
+++ b/model/common/src/icon4py/model/common/grid/states.py
@@ -15,10 +15,7 @@ from icon4py.model.common import dimension as dims, field_type_aliases as fa
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class EdgeParams:
-    """Edge geometry of the grid, from ICON's ``t_grid_edges``.
-
-    An optional member is one that not every construction path can supply.
-    """
+    """Edge geometry of the grid, from ICON's ``t_grid_edges``."""
 
     tangent_orientation: fa.EdgeField[float]
     r"""
@@ -170,16 +167,14 @@ class EdgeParams:
     edge_cell_distances: gtx.Field[[dims.EdgeDim, dims.E2CDim], float] | None = None
     """
     Distance between the edge midpoint and the circumcenters of the two adjacent cells.
+
     defined in ICON in mo_model_domain.f90:t_grid_edges%edge_cell_length
     """
 
 
 @dataclasses.dataclass(frozen=True)
 class CellParams:
-    """Cell geometry of the grid, from ICON's ``t_grid_cells``.
-
-    An optional member is one that not every construction path can supply.
-    """
+    """Cell geometry of the grid, from ICON's ``t_grid_cells``."""
 
     cell_center_lat: fa.CellField[float]
     """

--- a/model/common/src/icon4py/model/common/grid/states.py
+++ b/model/common/src/icon4py/model/common/grid/states.py
@@ -13,203 +13,179 @@ from gt4py import next as gtx
 from icon4py.model.common import dimension as dims, field_type_aliases as fa
 
 
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class EdgeParams:
-    def __init__(
-        self,
-        *,
-        tangent_orientation=None,
-        primal_edge_lengths=None,
-        inverse_primal_edge_lengths=None,
-        dual_edge_lengths=None,
-        inverse_dual_edge_lengths=None,
-        inverse_vertex_vertex_lengths=None,
-        primal_normal_vert_x=None,
-        primal_normal_vert_y=None,
-        dual_normal_vert_x=None,
-        dual_normal_vert_y=None,
-        primal_normal_cell_x=None,
-        dual_normal_cell_x=None,
-        primal_normal_cell_y=None,
-        dual_normal_cell_y=None,
-        edge_areas=None,
-        coriolis_frequency=None,
-        edge_center_lat=None,
-        edge_center_lon=None,
-        primal_normal_x=None,
-        primal_normal_y=None,
-    ):
-        self.tangent_orientation: fa.EdgeField[float] = tangent_orientation
-        r"""
-        Orientation of vector product of the edge and the adjacent cell centers
-             v3
-            /  \
-           /    \
-          /  c1  \
-         /    |   \
-         v1---|--->v2
-         \    |   /
-          \   v  /
-           \ c2 /
-            \  /
-            v4
-        +1 or -1 depending on whether the vector product of
-        (v2-v1) x (c2-c1) points outside (+) or inside (-) the sphere
+    """Edge geometry of the grid, from ICON's ``t_grid_edges``.
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%tangent_orientation
-        """
+    A member annotated ``| None`` is one that not every construction path can
+    supply; everything else must be provided by all of them.
+    """
 
-        self.primal_edge_lengths: fa.EdgeField[float] = primal_edge_lengths
-        """
-        Length of the triangle edge.
+    tangent_orientation: fa.EdgeField[float]
+    r"""
+    Orientation of vector product of the edge and the adjacent cell centers
+         v3
+        /  \
+       /    \
+      /  c1  \
+     /    |   \
+     v1---|--->v2
+     \    |   /
+      \   v  /
+       \ c2 /
+        \  /
+        v4
+    +1 or -1 depending on whether the vector product of
+    (v2-v1) x (c2-c1) points outside (+) or inside (-) the sphere
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%primal_edge_length
-        """
+    defined in ICON in mo_model_domain.f90:t_grid_edges%tangent_orientation
+    """
 
-        self.inverse_primal_edge_lengths: fa.EdgeField[float] = inverse_primal_edge_lengths
-        """
-        Inverse of the triangle edge length: 1.0/primal_edge_length.
+    inverse_primal_edge_lengths: fa.EdgeField[float]
+    """
+    Inverse of the triangle edge length: 1.0/primal_edge_length.
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%inv_primal_edge_length
-        """
+    defined in ICON in mo_model_domain.f90:t_grid_edges%inv_primal_edge_length
+    """
 
-        self.dual_edge_lengths: fa.EdgeField[float] = dual_edge_lengths
-        """
-        Length of the hexagon/pentagon edge.
-        vertices of the hexagon/pentagon are cell centers and its center
-        is located at the common vertex.
-        the dual edge bisects the primal edge othorgonally.
+    inverse_dual_edge_lengths: fa.EdgeField[float]
+    """
+    Inverse of hexagon/pentagon edge length: 1.0/dual_edge_length.
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%dual_edge_length
-        """
+    defined in ICON in mo_model_domain.f90:t_grid_edges%inv_dual_edge_length
+    """
 
-        self.inverse_dual_edge_lengths: fa.EdgeField[float] = inverse_dual_edge_lengths
-        """
-        Inverse of hexagon/pentagon edge length: 1.0/dual_edge_length.
+    inverse_vertex_vertex_lengths: fa.EdgeField[float]
+    """
+    Inverse distance between outer vertices of adjacent cells.
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%inv_dual_edge_length
-        """
+    v1--------
+    |       /|
+    |      / |
+    |    e   |
+    |  /     |
+    |/       |
+    --------v2
 
-        self.inverse_vertex_vertex_lengths: fa.EdgeField[float] = inverse_vertex_vertex_lengths
-        """
-        Inverse distance between outer vertices of adjacent cells.
+    inverse_vertex_vertex_length(e) = 1.0/|v2-v1|
 
-        v1--------
-        |       /|
-        |      / |
-        |    e   |
-        |  /     |
-        |/       |
-        --------v2
+    defined in ICON in mo_model_domain.f90:t_grid_edges%inv_vert_vert_length
+    """
 
-        inverse_vertex_vertex_length(e) = 1.0/|v2-v1|
+    primal_normal_vert: tuple[
+        gtx.Field[[dims.EdgeDim, dims.E2C2VDim], float],
+        gtx.Field[[dims.EdgeDim, dims.E2C2VDim], float],
+    ]
+    """
+    Normal of the triangle edge, projected onto the location of the
+    four vertices of neighboring cells.
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%inv_vert_vert_length
-        """
+    defined in ICON in mo_model_domain.f90:t_grid_edges%primal_normal_vert
+    and computed in ICON in mo_intp_coeffs.f90
+    """
 
-        self.primal_normal_vert: tuple[
-            gtx.Field[[dims.EdgeDim, dims.E2C2VDim], float],
-            gtx.Field[[dims.EdgeDim, dims.E2C2VDim], float],
-        ] = (
-            primal_normal_vert_x,
-            primal_normal_vert_y,
-        )
-        """
-        Normal of the triangle edge, projected onto the location of the
-        four vertices of neighboring cells.
+    dual_normal_vert: tuple[
+        gtx.Field[[dims.EdgeDim, dims.E2C2VDim], float],
+        gtx.Field[[dims.EdgeDim, dims.E2C2VDim], float],
+    ]
+    """
+    zonal (x) and meridional (y) components of vector tangent to the triangle edge,
+    projected onto the location of the four vertices of neighboring cells.
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%primal_normal_vert
-        and computed in ICON in mo_intp_coeffs.f90
-        """
+    defined in ICON in mo_model_domain.f90:t_grid_edges%dual_normal_vert
+    and computed in ICON in mo_intp_coeffs.f90
+    """
 
-        self.dual_normal_vert: tuple[
-            gtx.Field[[dims.EdgeDim, dims.E2C2VDim], float],
-            gtx.Field[[dims.EdgeDim, dims.E2C2VDim], float],
-        ] = (
-            dual_normal_vert_x,
-            dual_normal_vert_y,
-        )
-        """
-        zonal (x) and meridional (y) components of vector tangent to the triangle edge,
-        projected onto the location of the four vertices of neighboring cells.
+    primal_normal_cell: tuple[
+        gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
+        gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
+    ]
+    """
+    zonal (x) and meridional (y) components of vector normal to the cell edge
+    projected onto the location of neighboring cell centers.
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%dual_normal_vert
-        and computed in ICON in mo_intp_coeffs.f90
-        """
+    defined in ICON in mo_model_domain.f90:t_grid_edges%primal_normal_cell
+    and computed in ICON in mo_intp_coeffs.f90
+    """
 
-        self.primal_normal_cell: tuple[
-            gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
-            gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
-        ] = (
-            primal_normal_cell_x,
-            primal_normal_cell_y,
-        )
-        """
-        zonal (x) and meridional (y) components of vector normal to the cell edge
-        projected onto the location of neighboring cell centers.
+    dual_normal_cell: tuple[
+        gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
+        gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
+    ]
+    """
+    zonal (x) and meridional (y) components of vector normal to the dual edge
+    projected onto the location of neighboring cell centers.
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%primal_normal_cell
-        and computed in ICON in mo_intp_coeffs.f90
-        """
+    defined in ICON in mo_model_domain.f90:t_grid_edges%dual_normal_cell
+    and computed in ICON in mo_intp_coeffs.f90
+    """
 
-        self.dual_normal_cell: tuple[
-            gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
-            gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
-        ] = (
-            dual_normal_cell_x,
-            dual_normal_cell_y,
-        )
-        """
-        zonal (x) and meridional (y) components of vector normal to the dual edge
-        projected onto the location of neighboring cell centers.
+    edge_areas: fa.EdgeField[float]
+    """
+    Area of the quadrilateral whose edges are the primal edge and
+    the associated dual edge.
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%dual_normal_cell
-        and computed in ICON in mo_intp_coeffs.f90
-        """
+    defined in ICON in mo_model_domain.f90:t_grid_edges%area_edge
+    and computed in ICON in mo_intp_coeffs.f90
+    """
 
-        self.edge_areas: fa.EdgeField[float] = edge_areas
-        """
-        Area of the quadrilateral whose edges are the primal edge and
-        the associated dual edge.
+    coriolis_frequency: fa.EdgeField[float]
+    """
+    Declared as f_e in ICON. Coriolis parameter at cell edges.
+    """
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%area_edge
-        and computed in ICON in mo_intp_coeffs.f90
-        """
+    edge_center: tuple[fa.EdgeField[float], fa.EdgeField[float]]
+    """
+    Latitude and longitude at the edge center
 
-        self.coriolis_frequency: fa.EdgeField[float] = coriolis_frequency
-        """
-        Declared as f_e in ICON. Coriolis parameter at cell edges.
-        """
+    defined in ICON in mo_model_domain.f90:t_grid_edges%center
+    """
 
-        self.edge_center: tuple[fa.EdgeField[float], fa.EdgeField[float]] = (
-            edge_center_lat,
-            edge_center_lon,
-        )
-        """
-        Latitude and longitude at the edge center
+    primal_normal: tuple[
+        gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
+        gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
+    ]
+    """
+    zonal (x) and meridional (y) components of vector normal to the cell edge
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%center
-        """
+    defined in ICON in mo_model_domain.f90:t_grid_edges%primal_normal
+    """
 
-        self.primal_normal: tuple[
-            gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
-            gtx.Field[[dims.EdgeDim, dims.E2CDim], float],
-        ] = (
-            primal_normal_x,
-            primal_normal_y,
-        )
-        """
-        zonal (x) and meridional (y) components of vector normal to the cell edge
+    primal_edge_lengths: fa.EdgeField[float] | None = None
+    """
+    Length of the triangle edge.
 
-        defined in ICON in mo_model_domain.f90:t_grid_edges%primal_normal
-        """
+    defined in ICON in mo_model_domain.f90:t_grid_edges%primal_edge_length
+    """
+
+    dual_edge_lengths: fa.EdgeField[float] | None = None
+    """
+    Length of the hexagon/pentagon edge.
+    vertices of the hexagon/pentagon are cell centers and its center
+    is located at the common vertex.
+    the dual edge bisects the primal edge othorgonally.
+
+    defined in ICON in mo_model_domain.f90:t_grid_edges%dual_edge_length
+    """
+
+    edge_cell_distances: gtx.Field[[dims.EdgeDim, dims.E2CDim], float] | None = None
+    """
+    Distance between the edge midpoint and the circumcenters of the two adjacent cells.
+
+    ICON's ``grid_init`` does not pass this field, so the Fortran bindings path
+    leaves it unset.
+
+    defined in ICON in mo_model_domain.f90:t_grid_edges%edge_cell_length
+    """
 
 
 @dataclasses.dataclass(frozen=True)
 class CellParams:
     #: Latitude at the cell center. The cell center is defined to be the circumcenter of a triangle.
-    cell_center_lat: fa.CellField[float] | None = None
+    cell_center_lat: fa.CellField[float]
     #: Longitude at the cell center. The cell center is defined to be the circumcenter of a triangle.
-    cell_center_lon: fa.CellField[float] | None = None
+    cell_center_lon: fa.CellField[float]
     #: Area of a cell, defined in ICON in mo_model_domain.f90:t_grid_cells%area
-    area: fa.CellField[float] | None = None
+    area: fa.CellField[float]
+    #: Not supplied by every construction path.
     mean_cell_area: float | None = None

--- a/model/common/src/icon4py/model/common/grid/states.py
+++ b/model/common/src/icon4py/model/common/grid/states.py
@@ -17,8 +17,7 @@ from icon4py.model.common import dimension as dims, field_type_aliases as fa
 class EdgeParams:
     """Edge geometry of the grid, from ICON's ``t_grid_edges``.
 
-    A member annotated ``| None`` is one that not every construction path can
-    supply; everything else must be provided by all of them.
+    An optional member is one that not every construction path can supply.
     """
 
     tangent_orientation: fa.EdgeField[float]
@@ -181,11 +180,33 @@ class EdgeParams:
 
 @dataclasses.dataclass(frozen=True)
 class CellParams:
-    #: Latitude at the cell center. The cell center is defined to be the circumcenter of a triangle.
+    """Cell geometry of the grid, from ICON's ``t_grid_cells``.
+
+    An optional member is one that not every construction path can supply.
+    """
+
     cell_center_lat: fa.CellField[float]
-    #: Longitude at the cell center. The cell center is defined to be the circumcenter of a triangle.
+    """
+    Latitude at the cell center. The cell center is defined to be the
+    circumcenter of a triangle.
+    """
+
     cell_center_lon: fa.CellField[float]
-    #: Area of a cell, defined in ICON in mo_model_domain.f90:t_grid_cells%area
+    """
+    Longitude at the cell center. The cell center is defined to be the
+    circumcenter of a triangle.
+    """
+
     area: fa.CellField[float]
-    #: Not supplied by every construction path.
+    """
+    Area of a cell.
+
+    defined in ICON in mo_model_domain.f90:t_grid_cells%area
+    """
+
     mean_cell_area: float | None = None
+    """
+    Mean area of the grid cells [m^2].
+
+    defined in ICON in mo_grid_geometry_info.f90:t_grid_geometry_info%mean_cell_area
+    """

--- a/model/common/src/icon4py/model/common/grid/states.py
+++ b/model/common/src/icon4py/model/common/grid/states.py
@@ -170,10 +170,6 @@ class EdgeParams:
     edge_cell_distances: gtx.Field[[dims.EdgeDim, dims.E2CDim], float] | None = None
     """
     Distance between the edge midpoint and the circumcenters of the two adjacent cells.
-
-    ICON's ``grid_init`` does not pass this field, so the Fortran bindings path
-    leaves it unset.
-
     defined in ICON in mo_model_domain.f90:t_grid_edges%edge_cell_length
     """
 

--- a/model/driver/src/icon4py/model/driver/driver_utils.py
+++ b/model/driver/src/icon4py/model/driver/driver_utils.py
@@ -250,20 +250,33 @@ def initialize_granules(
         inverse_vertex_vertex_lengths=geometry_field_source.get(
             f"inverse_of_{geometry_meta.VERTEX_VERTEX_LENGTH}"
         ),
-        primal_normal_vert_x=geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_U),
-        primal_normal_vert_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
-        dual_normal_vert_x=geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_U),
-        dual_normal_vert_y=geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_V),
-        primal_normal_cell_x=geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_U),
-        dual_normal_cell_x=geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_U),
-        primal_normal_cell_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_V),
-        dual_normal_cell_y=geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_V),
+        primal_normal_vert=(
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_U),
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_VERTEX_V),
+        ),
+        dual_normal_vert=(
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_U),
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_VERTEX_V),
+        ),
+        primal_normal_cell=(
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_U),
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_CELL_V),
+        ),
+        dual_normal_cell=(
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_U),
+            geometry_field_source.get(geometry_meta.EDGE_TANGENT_CELL_V),
+        ),
         edge_areas=geometry_field_source.get(geometry_meta.EDGE_AREA),
         coriolis_frequency=geometry_field_source.get(geometry_meta.CORIOLIS_PARAMETER),
-        edge_center_lat=geometry_field_source.get(geometry_meta.EDGE_LAT),
-        edge_center_lon=geometry_field_source.get(geometry_meta.EDGE_LON),
-        primal_normal_x=geometry_field_source.get(geometry_meta.EDGE_NORMAL_U),
-        primal_normal_y=geometry_field_source.get(geometry_meta.EDGE_NORMAL_V),
+        edge_center=(
+            geometry_field_source.get(geometry_meta.EDGE_LAT),
+            geometry_field_source.get(geometry_meta.EDGE_LON),
+        ),
+        primal_normal=(
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_U),
+            geometry_field_source.get(geometry_meta.EDGE_NORMAL_V),
+        ),
+        edge_cell_distances=geometry_field_source.get(geometry_meta.EDGE_CELL_DISTANCE),
     )
 
     log.info("creating diffusion interpolation state")

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -608,20 +608,33 @@ class IconGridSavepoint(IconSavepoint):
             inverse_primal_edge_lengths=self.inverse_primal_edge_lengths(),
             inverse_dual_edge_lengths=self.inv_dual_edge_length(),
             inverse_vertex_vertex_lengths=self.inv_vert_vert_length(),
-            primal_normal_vert_x=self.primal_normal_vert_x(),
-            primal_normal_vert_y=self.primal_normal_vert_y(),
-            dual_normal_vert_x=self.dual_normal_vert_x(),
-            dual_normal_vert_y=self.dual_normal_vert_y(),
-            primal_normal_cell_x=self.primal_normal_cell_x(),
-            dual_normal_cell_x=self.dual_normal_cell_x(),
-            primal_normal_cell_y=self.primal_normal_cell_y(),
-            dual_normal_cell_y=self.dual_normal_cell_y(),
+            primal_normal_vert=(
+                self.primal_normal_vert_x(),
+                self.primal_normal_vert_y(),
+            ),
+            dual_normal_vert=(
+                self.dual_normal_vert_x(),
+                self.dual_normal_vert_y(),
+            ),
+            primal_normal_cell=(
+                self.primal_normal_cell_x(),
+                self.primal_normal_cell_y(),
+            ),
+            dual_normal_cell=(
+                self.dual_normal_cell_x(),
+                self.dual_normal_cell_y(),
+            ),
             edge_areas=self.edge_areas(),
             coriolis_frequency=self.f_e(),
-            edge_center_lat=self.edge_center_lat(),
-            edge_center_lon=self.edge_center_lon(),
-            primal_normal_x=self.primal_normal_v1(),
-            primal_normal_y=self.primal_normal_v2(),
+            edge_center=(
+                self.edge_center_lat(),
+                self.edge_center_lon(),
+            ),
+            primal_normal=(
+                self.primal_normal_v1(),
+                self.primal_normal_v2(),
+            ),
+            edge_cell_distances=self.edge_cell_length(),
         )
 
     def construct_cell_geometry(self) -> grid_states.CellParams:

--- a/model/testing/src/icon4py/model/testing/serialbox.py
+++ b/model/testing/src/icon4py/model/testing/serialbox.py
@@ -215,7 +215,7 @@ class IconGridSavepoint(IconSavepoint):
 
     def edge_vert_length(self):
         """length of edge midpoint to vertex"""
-        return self._get_field("edge_vert_length", dims.EdgeDim, dims.E2C2VDim)
+        return self._get_field("edge_vert_length", dims.EdgeDim, dims.E2VDim)
 
     def vct_a(self):
         return self._get_field("vct_a", dims.KHalfDim)


### PR DESCRIPTION
`EdgeParams` is a hand-written class whose attribute annotations do not say which members a construction path may leave unset. 

## What changes

- `EdgeParams` becomes dataclass.
- `| None` now means "some source cannot supply this"
- `edge_cell_distances` is new, from `t_grid_edges%edge_cell_length`. **It's not needed required by dycore/diffusion, therefore not passed in via Fortran bindings and we make it optional in this PR**. Alternative could be to still pass it from Fortran, but since the Fortran array has wrong layout it would require a copy.

## Why now

In #1457 it was originally added to tmx directly instead of EdgeParams, therefore we extracted this refactoring in preparation for that PR.