### PR TITLE
ProgramFieldProvider: the declared domain is the field's vertical extent

### DIFF
--- a/model/common/src/icon4py/model/common/grid/geometry.py
+++ b/model/common/src/icon4py/model/common/grid/geometry.py
@@ -836,6 +836,18 @@ class GridGeometry(factory.FieldSource):
         return None
 
 
+class _IntermediateFields(factory.FieldSource):
+    """The outputs of a wrapped provider, declared with the metadata of the field they feed."""
+
+    def __init__(self, provider: factory.FieldProvider, metadata: dict[str, model.FieldMetaData]):
+        self._providers = dict.fromkeys(metadata, provider)
+        self._metadata = metadata
+
+    @property
+    def metadata(self) -> dict[str, model.FieldMetaData]:
+        return self._metadata
+
+
 class SparseFieldProviderWrapper(factory.FieldProvider, factory.NeedsExchange):
     def __init__(
         self,
@@ -864,6 +876,16 @@ class SparseFieldProviderWrapper(factory.FieldProvider, factory.NeedsExchange):
         exchange: decomposition.ExchangeRuntime,
     ) -> state_utils.GTXFieldType | None:
         if self._fields.get(field_name) is None:
+            assert field_src is not None
+            intermediates = _IntermediateFields(
+                self._wrapped_provider,
+                {
+                    name: field_src.get(target, factory.RetrievalType.METADATA)
+                    for target, pair in zip(self.fields, self._pairs, strict=True)
+                    for name in pair
+                },
+            )
+            source = factory.CompositeSource(me=field_src, others=(intermediates,))
             # get the fields from the wrapped provider
             input_fields = []
             for p in self._pairs:
@@ -871,7 +893,7 @@ class SparseFieldProviderWrapper(factory.FieldProvider, factory.NeedsExchange):
                     [
                         self._wrapped_provider(
                             field_name=name,
-                            field_src=field_src,
+                            field_src=source,
                             backend=backend,
                             grid=grid,
                             exchange=exchange,

--- a/model/common/src/icon4py/model/common/metrics/metric_fields.py
+++ b/model/common/src/icon4py/model/common/metrics/metric_fields.py
@@ -285,9 +285,13 @@ def _compute_coeff_dwdz(
         ddqz_z_full(dims.KDim - 1) / ddqz_z_full / (z_ifc(dims.KDim - 1.5) - z_ifc(dims.KDim + 0.5))
     )
 
+    # TODO(havogt): This is a workaround for 2 things:
+    # a) with a plain `0.0` embedded will not work because of the infinite range
+    # b) for `concat_where(dims.KDim == 0, 0.0, ...)` the domain inference is broken in GT4Py,
+    #    see https://github.com/gridTools/gt4py/issues/2205.
     return (
-        concat_where(dims.KDim == 0, 0.0, coeff1_dwdz),
-        concat_where(dims.KDim == 0, 0.0, coeff2_dwdz),
+        concat_where(dims.KDim >= 1, coeff1_dwdz, 0.0 * ddqz_z_full),
+        concat_where(dims.KDim >= 1, coeff2_dwdz, 0.0 * ddqz_z_full),
     )
 
 

--- a/model/common/src/icon4py/model/common/metrics/metric_fields.py
+++ b/model/common/src/icon4py/model/common/metrics/metric_fields.py
@@ -210,6 +210,7 @@ def _compute_rayleigh_w(  # noqa: PLR0917 [too-many-positional-arguments]
     rayleigh_coeff: wpfloat,
     vct_a_1: wpfloat,
     pi_const: wpfloat,
+    end_index_of_damping_layer: gtx.int32,
 ) -> fa.KHalfField[wpfloat]:
     rayleigh_w = broadcast(0.0, (dims.KHalfDim,))
     z_sin_diff = maximum(0.0, vct_a - damping_height)
@@ -224,7 +225,8 @@ def _compute_rayleigh_w(  # noqa: PLR0917 [too-many-positional-arguments]
         rayleigh_w = rayleigh_coeff * (
             1.0 - tanh(3.8 * z_tanh_diff / maximum(0.000001, vct_a_1 - damping_height))
         )
-    return rayleigh_w
+    # embedded rejects a scalar branch on an unbounded region, so the zeros are a field
+    return concat_where(dims.KHalfDim <= end_index_of_damping_layer, rayleigh_w, 0.0 * rayleigh_w)
 
 
 @gtx.program
@@ -236,6 +238,7 @@ def compute_rayleigh_w(  # noqa: PLR0917 [too-many-positional-arguments]
     rayleigh_coeff: wpfloat,
     vct_a_1: wpfloat,
     pi_const: wpfloat,
+    end_index_of_damping_layer: gtx.int32,
     vertical_start: gtx.int32,
     vertical_end: gtx.int32,
 ):
@@ -254,6 +257,7 @@ def compute_rayleigh_w(  # noqa: PLR0917 [too-many-positional-arguments]
         rayleigh_klemp: Klemp (2008) type Rayleigh damping
         rayleigh_coeff: Rayleigh damping coefficient in w-equation
         pi_const: pi constant
+        end_index_of_damping_layer: last level index with damping, rayleigh_w is zero below
         vertical_start: vertical start index
         vertical_end: vertical end index
     """
@@ -264,6 +268,7 @@ def compute_rayleigh_w(  # noqa: PLR0917 [too-many-positional-arguments]
         rayleigh_coeff,
         vct_a_1,
         pi_const,
+        end_index_of_damping_layer,
         out=rayleigh_w,
         domain={dims.KHalfDim: (vertical_start, vertical_end)},
     )
@@ -280,7 +285,10 @@ def _compute_coeff_dwdz(
         ddqz_z_full(dims.KDim - 1) / ddqz_z_full / (z_ifc(dims.KDim - 1.5) - z_ifc(dims.KDim + 0.5))
     )
 
-    return coeff1_dwdz, coeff2_dwdz
+    return (
+        concat_where(dims.KDim == 0, 0.0, coeff1_dwdz),
+        concat_where(dims.KDim == 0, 0.0, coeff2_dwdz),
+    )
 
 
 @gtx.program(grid_type=gtx.GridType.UNSTRUCTURED)
@@ -302,8 +310,8 @@ def compute_coeff_dwdz(  # noqa: PLR0917 [too-many-positional-arguments]
     Args:
         ddqz_z_full: functional determinant of the metrics (is positive), full levels
         z_ifc: geometric height of half levels
-        coeff1_dwdz: coefficient for second-order acurate dw/dz term
-        coeff2_dwdz: coefficient for second-order acurate dw/dz term
+        coeff1_dwdz: coefficient for second-order acurate dw/dz term, zero on the top level
+        coeff2_dwdz: coefficient for second-order acurate dw/dz term, zero on the top level
         horizontal_start: horizontal start index
         horizontal_end: horizontal end index
         vertical_start: vertical start index

--- a/model/common/src/icon4py/model/common/metrics/metrics_factory.py
+++ b/model/common/src/icon4py/model/common/metrics/metrics_factory.py
@@ -349,12 +349,6 @@ class MetricsFieldsFactory(factory.FieldSource, factory.GridProvider):
                     vertical_half_domain(v_grid.Zone.BOTTOM),
                 )
             },
-            compute_domain={
-                dims.KHalfDim: (
-                    vertical_half_domain(v_grid.Zone.TOP),
-                    v_grid.Domain(dims.KHalfDim, v_grid.Zone.DAMPING, 1),
-                )
-            },
             fields={"rayleigh_w": attrs.RAYLEIGH_W},
             params={
                 "damping_height": self._damping_height,
@@ -362,6 +356,7 @@ class MetricsFieldsFactory(factory.FieldSource, factory.GridProvider):
                 "rayleigh_coeff": self._config.rayleigh_coeff,
                 "vct_a_1": self._vct_a_1,
                 "pi_const": math.pi,
+                "end_index_of_damping_layer": self._vertical_grid.end_index_of_damping_layer,
             },
             do_exchange=False,
         )
@@ -380,12 +375,6 @@ class MetricsFieldsFactory(factory.FieldSource, factory.GridProvider):
                 ),
                 dims.KDim: (
                     vertical_domain(v_grid.Zone.TOP),
-                    vertical_domain(v_grid.Zone.BOTTOM),
-                ),
-            },
-            compute_domain={
-                dims.KDim: (
-                    v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1),
                     vertical_domain(v_grid.Zone.BOTTOM),
                 ),
             },

--- a/model/common/src/icon4py/model/common/metrics/metrics_factory.py
+++ b/model/common/src/icon4py/model/common/metrics/metrics_factory.py
@@ -345,7 +345,13 @@ class MetricsFieldsFactory(factory.FieldSource, factory.GridProvider):
             deps={"vct_a": "vct_a"},
             domain={
                 dims.KHalfDim: (
-                    vertical_domain(v_grid.Zone.TOP),
+                    vertical_half_domain(v_grid.Zone.TOP),
+                    vertical_half_domain(v_grid.Zone.BOTTOM),
+                )
+            },
+            compute_domain={
+                dims.KHalfDim: (
+                    vertical_half_domain(v_grid.Zone.TOP),
                     v_grid.Domain(dims.KHalfDim, v_grid.Zone.DAMPING, 1),
                 )
             },
@@ -372,6 +378,12 @@ class MetricsFieldsFactory(factory.FieldSource, factory.GridProvider):
                     cell_domain(h_grid.Zone.LOCAL),
                     cell_domain(h_grid.Zone.END),
                 ),
+                dims.KDim: (
+                    vertical_domain(v_grid.Zone.TOP),
+                    vertical_domain(v_grid.Zone.BOTTOM),
+                ),
+            },
+            compute_domain={
                 dims.KDim: (
                     v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1),
                     vertical_domain(v_grid.Zone.BOTTOM),

--- a/model/common/src/icon4py/model/common/metrics/metrics_factory.py
+++ b/model/common/src/icon4py/model/common/metrics/metrics_factory.py
@@ -868,12 +868,13 @@ class MetricsFieldsFactory(factory.FieldSource, factory.GridProvider):
 
         compute_wgtfacq_c = factory.NumpyDataProvider(
             func=weight_factors.compute_wgtfacq_c_dsl,
-            domain=gtx.domain(
-                {
-                    dims.CellDim: (0, self._grid.num_cells),
-                    dims.KDim: (self._grid.num_levels - 3, self._grid.num_levels),
-                }
-            ),
+            domain={
+                dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.END)),
+                dims.KDim: (
+                    v_grid.Domain(dims.KDim, v_grid.Zone.BOTTOM, -3),
+                    vertical_domain(v_grid.Zone.BOTTOM),
+                ),
+            },
             fields=(attrs.WGTFACQ_C,),
             deps={"z_ifc": attrs.CELL_HEIGHT_ON_HALF_LEVEL},
             params={"nlev": self._grid.num_levels},
@@ -892,12 +893,13 @@ class MetricsFieldsFactory(factory.FieldSource, factory.GridProvider):
                 "wgtfacq_c_dsl": attrs.WGTFACQ_C,
             },
             connectivities={"e2c": dims.E2CDim},
-            domain=gtx.domain(
-                {
-                    dims.EdgeDim: (0, self._grid.num_edges),
-                    dims.KDim: (self._grid.num_levels - 3, self._grid.num_levels),
-                }
-            ),
+            domain={
+                dims.EdgeDim: (edge_domain(h_grid.Zone.LOCAL), edge_domain(h_grid.Zone.END)),
+                dims.KDim: (
+                    v_grid.Domain(dims.KDim, v_grid.Zone.BOTTOM, -3),
+                    vertical_domain(v_grid.Zone.BOTTOM),
+                ),
+            },
             fields=(attrs.WGTFACQ_E,),
             params={"n_edges": self._grid.num_edges, "nlev": self._grid.num_levels},
         )

--- a/model/common/src/icon4py/model/common/states/factory.py
+++ b/model/common/src/icon4py/model/common/states/factory.py
@@ -788,10 +788,4 @@ def _func_name(callable_: Callable[..., Any]) -> str:
 
 
 def output_dtype(field_src: FieldSource, field_name: str) -> state_utils.ScalarType:
-    try:
-        metadata = field_src.get(field_name, RetrievalType.METADATA)
-    except ValueError:
-        # a provider driven by another one (SparseFieldProviderWrapper) is not registered with the
-        # source, so its intermediate outputs have no metadata there
-        return ta.wpfloat
-    return metadata.get("dtype", ta.wpfloat)
+    return field_src.get(field_name, RetrievalType.METADATA).get("dtype", ta.wpfloat)

--- a/model/common/src/icon4py/model/common/states/factory.py
+++ b/model/common/src/icon4py/model/common/states/factory.py
@@ -411,7 +411,10 @@ class EmbeddedFieldOperatorProvider(FieldProvider, NeedsExchange):
             f"{data_alloc.backend_name(compute_backend)}, target backend is: "
             f"{data_alloc.backend_name(factory.backend)}"
         )
-        metadata = {k: factory.get(k, RetrievalType.METADATA) for k in self.fields}
+        try:
+            metadata = {k: factory.get(k, RetrievalType.METADATA) for k in self.fields}
+        except (ValueError, KeyError):
+            metadata = {}
         self._fields = self._allocate_fields(compute_backend, grid_provider, metadata)
         # call field operator
         log.debug(f"transferring dependencies to compute backend: {self._dependencies.keys()}")
@@ -629,7 +632,10 @@ class NumpyDataProvider(FieldProvider, NeedsExchange):
 
     Args:
         func: numpy function that computes the fields
-        domain: the compute domain used for the stencil computation
+        domain: the domain of the computed fields, following `_field_extent` when given with
+            ranges; as a bare tuple of dimensions the returned arrays' shapes are the extent, which
+            is how a field on a dimension without a grid size (e.g. `LsqUnkDim`) is labelled.
+            Empty for a scalar result.
         fields: Seq[str] names under which the results fo the function will be registered
         deps: dict[str, str] input fields used for computing this stencil: the key is the variable name
             used in the function and the value the name of the field it depends on.
@@ -643,7 +649,7 @@ class NumpyDataProvider(FieldProvider, NeedsExchange):
         self,
         *,
         func: Callable,
-        domain: Sequence[gtx.Dimension],
+        domain: dict[gtx.Dimension, tuple[DomainType, DomainType]] | tuple[gtx.Dimension, ...],
         fields: Sequence[str],
         deps: dict[str, str],
         connectivities: dict[str, gtx.Dimension] | None = None,
@@ -651,6 +657,7 @@ class NumpyDataProvider(FieldProvider, NeedsExchange):
         do_exchange: bool = False,
     ):
         self._func = func
+        self._domain = domain if isinstance(domain, dict) else None
         self._dims = tuple(domain)
         self._fields: dict[str, state_utils.ScalarType | state_utils.FieldType | None] = {
             name: None for name in fields
@@ -699,14 +706,19 @@ class NumpyDataProvider(FieldProvider, NeedsExchange):
         # convert to tuple
         results = (results,) if not isinstance(results, tuple) else results
         self._fields = {
-            k: self._as_field(backend, results[i]) if self._dims else results[i]
+            k: self._as_field(backend, results[i], grid_provider) if self._dims else results[i]
             for i, k in enumerate(self.fields)
         }
 
     def _as_field(
-        self, backend: gtx_typing.Backend | None, value: data_alloc.NDArray
+        self, backend: gtx_typing.Backend | None, value: data_alloc.NDArray, grid: GridProvider
     ) -> state_utils.GTXFieldType:
-        return gtx.as_field(tuple(self._dims), value, allocator=backend)
+        if self._domain is None:
+            return gtx.as_field(self._dims, value, allocator=backend)
+        field_domain = gtx.domain(
+            {dim: _field_extent(dim, declared, grid) for dim, declared in self._domain.items()}
+        )
+        return gtx.as_field(field_domain, value, allocator=backend)
 
     def _validate_dependencies(self) -> None:
         # TODO(egparedes): dealing with type annotations at run-time is error prone
@@ -788,4 +800,4 @@ def _func_name(callable_: Callable[..., Any]) -> str:
 def dtype_or_default(
     field_name: str, metadata: dict[str, model.FieldMetaData]
 ) -> state_utils.ScalarType:
-    return metadata[field_name].get("dtype", ta.wpfloat)
+    return metadata.get(field_name, {}).get("dtype", ta.wpfloat)

--- a/model/common/src/icon4py/model/common/states/factory.py
+++ b/model/common/src/icon4py/model/common/states/factory.py
@@ -412,7 +412,8 @@ class EmbeddedFieldOperatorProvider(FieldProvider, NeedsExchange):
             f"{data_alloc.backend_name(factory.backend)}"
         )
         dtype = {k: output_dtype(factory, k) for k in self._fields}
-        self._fields = self._allocate_fields(compute_backend, grid_provider, dtype)
+        # the outputs live on the target backend's device: embedded computes in place on them
+        self._fields = self._allocate_fields(factory.backend, grid_provider, dtype)
         # call field operator
         log.debug(f"transferring dependencies to compute backend: {self._dependencies.keys()}")
 

--- a/model/common/src/icon4py/model/common/states/factory.py
+++ b/model/common/src/icon4py/model/common/states/factory.py
@@ -50,7 +50,6 @@ import logging
 import types
 import typing
 from collections.abc import Callable, Iterator, Mapping, MutableMapping, Sequence
-from types import ModuleType
 from typing import Any, Literal, Protocol, TypeVar, overload
 
 import gt4py.next as gtx
@@ -324,15 +323,33 @@ class PrecomputedFieldProvider(FieldProvider):
         return lambda: self.fields
 
 
+def _field_extent[DomainT: (h_grid.Domain, v_grid.Domain)](
+    dim: gtx.Dimension, declared: tuple[DomainT, DomainT] | None, grid: GridProvider
+) -> tuple[int, int]:
+    """
+    The range a provider allocates for `dim`.
+
+    A declared vertical range is the field's extent: there is no vertical decomposition and no
+    exchange, and a gt4py field keeps absolute level indices, so a sub-range is a field on those
+    levels. Horizontal dimensions are always allocated at full local size, because the halo exchange
+    fills entries outside the compute range and neighbor access indexes the field by absolute local
+    index; so are local (sparse) dimensions and any dimension declared without a range.
+    """
+    if declared is not None and dim.kind == gtx.DimensionKind.VERTICAL:
+        assert grid.vertical_grid is not None
+        start, end = declared
+        return grid.vertical_grid.index(start), grid.vertical_grid.index(end)
+    return 0, grid.grid.size[dim]
+
+
 class EmbeddedFieldOperatorProvider(FieldProvider, NeedsExchange):
     """Provider that calls a GT4Py Fieldoperator.
 
     # TODO(halungge): for now to be used only on FieldView Embedded GT4Py backend.
-    - restrictions:
-         - (if only called on FieldView-Embedded, this is not a necessary restriction)
-            calls field operators without domain args, so it can only be used for full field computations
-    - plus:
-        - can write sparse/local fields
+    The field operator is called without domain args, so it computes on the whole extent of its
+    output fields: the declared vertical range and the full horizontal size, as `_field_extent`
+    describes. A `domain` given as a tuple of dimensions allocates full size in every dimension,
+    which is how sparse/local fields are written.
     """
 
     def __init__(
@@ -346,9 +363,8 @@ class EmbeddedFieldOperatorProvider(FieldProvider, NeedsExchange):
         params: dict[str, state_utils.ScalarType] | None = None,
     ):
         self._func = func
-        self._dims: (
-            dict[gtx.Dimension, tuple[DomainType, DomainType]] | tuple[gtx.Dimension, ...]
-        ) = domain
+        self._domain = domain if isinstance(domain, dict) else dict.fromkeys(domain)
+        self._dims = tuple(self._domain)
         self._dependencies = deps
         self._output = fields
         self._params = {} if params is None else params
@@ -395,9 +411,8 @@ class EmbeddedFieldOperatorProvider(FieldProvider, NeedsExchange):
             f"{data_alloc.backend_name(compute_backend)}, target backend is: "
             f"{data_alloc.backend_name(factory.backend)}"
         )
-        xp = data_alloc.import_array_ns(factory.backend)
         metadata = {k: factory.get(k, RetrievalType.METADATA) for k in self.fields}
-        self._fields = self._allocate_fields(compute_backend, grid_provider, xp, metadata)
+        self._fields = self._allocate_fields(compute_backend, grid_provider, metadata)
         # call field operator
         log.debug(f"transferring dependencies to compute backend: {self._dependencies.keys()}")
 
@@ -448,31 +463,15 @@ class EmbeddedFieldOperatorProvider(FieldProvider, NeedsExchange):
         self,
         backend: gtx_typing.Backend | None,
         grid_provider: GridProvider,
-        xp: ModuleType,
         metadata: dict[str, model.FieldMetaData],
     ) -> dict[str, state_utils.FieldType]:
-        def _map_size(dim: gtx.Dimension, grids: GridProvider) -> int:
-            match dim:
-                case dims.KHalfDim:
-                    return grids.vertical_grid.num_levels + 1
-                case dims.KDim:
-                    return grids.vertical_grid.num_levels
-                case _:
-                    return grids.grid.size[dim]
-
-        def _allocate(
-            grid_provider: GridProvider,
-            backend: gtx_typing.Backend,
-            array_ns: ModuleType,
-            dtype: state_utils.ScalarType = ta.wpfloat,
-        ) -> gtx.Field:
-            shape = tuple(_map_size(dim, grid_provider) for dim in self._dims)
-            buffer = array_ns.zeros(shape, dtype=dtype)
-            return gtx.as_field(tuple(self._dims), data=buffer, allocator=backend, dtype=dtype)
-
+        allocate = gtx.constructors.zeros.partial(allocator=backend)
+        field_domain = {
+            dim: _field_extent(dim, declared, grid_provider)
+            for dim, declared in self._domain.items()
+        }
         return {
-            k: _allocate(grid_provider, backend, xp, dtype=dtype_or_default(k, metadata))
-            for k in self._fields
+            k: allocate(field_domain, dtype=dtype_or_default(k, metadata)) for k in self._fields
         }
 
 
@@ -486,11 +485,7 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
     Args:
         func: GT4Py Program that computes the fields
         domain: the domain of the computed fields and the compute domain of the program. It is
-            the fields' extent only in the vertical:
-            horizontal dimensions are always allocated at full local size, because the halo
-            exchange fills entries outside the compute range and neighbor access indexes the
-            field by absolute local index. Vertical dimensions have neither, and a gt4py field
-            keeps its absolute level indices, so a vertical sub-range is a field on those levels.
+            the fields' extent only in the vertical, see `_field_extent`.
         fields: dict[str, str], fields computed by this stencil:  the key is the variable name of
             the out arguments used in the program and the value the name the field is registered
             under and declared in the metadata.
@@ -522,12 +517,6 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
         }
         self._do_exchange = do_exchange
 
-    def _extent(self, dim: gtx.Dimension, grid: GridProvider) -> tuple[int, int]:
-        if dim.kind == gtx.DimensionKind.VERTICAL:
-            start, end = self._domain[dim]
-            return grid.vertical_grid.index(start), grid.vertical_grid.index(end)
-        return 0, grid.grid.size[dim]
-
     def _allocate(
         self,
         backend: gtx_typing.Backend | None,
@@ -535,7 +524,9 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
         dtype: dict[str, state_utils.ScalarType],
     ) -> dict[str, state_utils.FieldType]:
         allocate = gtx.constructors.zeros.partial(allocator=backend)
-        field_domain = {dim: self._extent(dim, grid) for dim in self._dims}
+        field_domain = {
+            dim: _field_extent(dim, declared, grid) for dim, declared in self._domain.items()
+        }
         return {k: allocate(field_domain, dtype=dtype[k]) for k in self._fields}
 
     # TODO(halungge): this can be simplified when completely disentangling vertical and horizontal grid.
@@ -573,7 +564,7 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
                     }
                 )
             elif dim.kind == gtx.DimensionKind.VERTICAL:
-                vertical_start, vertical_end = self._extent(dim, grid)
+                vertical_start, vertical_end = _field_extent(dim, self._domain[dim], grid)
                 domain_args.update({"vertical_start": vertical_start, "vertical_end": vertical_end})
             else:
                 raise ValueError(f"DimensionKind '{dim.kind}' not supported in Program Domain")

--- a/model/common/src/icon4py/model/common/states/factory.py
+++ b/model/common/src/icon4py/model/common/states/factory.py
@@ -485,8 +485,8 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
 
     Args:
         func: GT4Py Program that computes the fields
-        domain: the domain of the computed fields, and the compute domain of the program unless
-            `compute_domain` overrides it. It is the fields' extent only in the vertical:
+        domain: the domain of the computed fields and the compute domain of the program. It is
+            the fields' extent only in the vertical:
             horizontal dimensions are always allocated at full local size, because the halo
             exchange fills entries outside the compute range and neighbor access indexes the
             field by absolute local index. Vertical dimensions have neither, and a gt4py field
@@ -498,8 +498,6 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
             the key is the variable name used in the `gtx.program` and the value the name
             of the field it depends on.
         params: scalar parameters used in the program
-        compute_domain: per-dimension override of the range the program computes, for fields
-            that exist on the whole `domain` but are computed only on part of it.
     """
 
     def __init__(
@@ -511,16 +509,9 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
         deps: dict[str, str],
         do_exchange: bool,
         params: dict[str, state_utils.ScalarType] | None = None,
-        compute_domain: dict[gtx.Dimension, tuple[DomainType, DomainType]] | None = None,
     ):
-        compute_domain = compute_domain if compute_domain is not None else {}
-        if not compute_domain.keys() <= domain.keys():
-            raise ValueError(
-                f"compute_domain has dimensions not in domain: {compute_domain.keys() - domain.keys()}"
-            )
         self._func = func
         self._domain = domain
-        self._compute_domain = {**domain, **compute_domain}
         self._dims = domain.keys()
         self._dependencies = deps
         self._output = fields
@@ -551,7 +542,7 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
     #   the IconGrid should then only contain horizontal connectivities and no longer any Koff which should be moved to the VerticalGrid
     def _get_offset_providers(self, grid: icon_grid.IconGrid) -> dict[str, gtx.FieldOffset]:
         offset_providers = {}
-        for dim in self._compute_domain:
+        for dim in self._domain:
             if dim.kind == gtx.DimensionKind.HORIZONTAL:
                 horizontal_offsets = {
                     k: v
@@ -573,23 +564,16 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
     def _domain_args(self, grid: GridProvider) -> dict[str, gtx.int32]:
         domain_args = {}
 
-        for dim, (start, end) in self._compute_domain.items():
+        for dim in self._domain:
             if dim.kind == gtx.DimensionKind.HORIZONTAL:
                 domain_args.update(
                     {
-                        "horizontal_start": grid.grid.start_index(start),
-                        "horizontal_end": grid.grid.end_index(end),
+                        "horizontal_start": grid.grid.start_index(self._domain[dim][0]),
+                        "horizontal_end": grid.grid.end_index(self._domain[dim][1]),
                     }
                 )
             elif dim.kind == gtx.DimensionKind.VERTICAL:
-                vertical_start = grid.vertical_grid.index(start)
-                vertical_end = grid.vertical_grid.index(end)
-                first, last = self._extent(dim, grid)
-                if vertical_start < first or vertical_end > last:
-                    raise ValueError(
-                        f"compute range [{vertical_start}, {vertical_end}) of {dim} exceeds "
-                        f"the field domain [{first}, {last})"
-                    )
+                vertical_start, vertical_end = self._extent(dim, grid)
                 domain_args.update({"vertical_start": vertical_start, "vertical_end": vertical_end})
             else:
                 raise ValueError(f"DimensionKind '{dim.kind}' not supported in Program Domain")

--- a/model/common/src/icon4py/model/common/states/factory.py
+++ b/model/common/src/icon4py/model/common/states/factory.py
@@ -61,12 +61,7 @@ from gt4py.next import common as gtx_common
 
 from icon4py.model.common import dimension as dims, type_alias as ta
 from icon4py.model.common.decomposition import definitions as decomposition
-from icon4py.model.common.grid import (
-    base as base_grid,
-    horizontal as h_grid,
-    icon as icon_grid,
-    vertical as v_grid,
-)
+from icon4py.model.common.grid import horizontal as h_grid, icon as icon_grid, vertical as v_grid
 from icon4py.model.common.states import model, utils as state_utils
 from icon4py.model.common.utils import data_allocation as data_alloc
 
@@ -490,7 +485,12 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
 
     Args:
         func: GT4Py Program that computes the fields
-        domain: the compute domain used for the stencil computation
+        domain: the domain of the computed fields, and the compute domain of the program unless
+            `compute_domain` overrides it. It is the fields' extent only in the vertical:
+            horizontal dimensions are always allocated at full local size, because the halo
+            exchange fills entries outside the compute range and neighbor access indexes the
+            field by absolute local index. Vertical dimensions have neither, and a gt4py field
+            keeps its absolute level indices, so a vertical sub-range is a field on those levels.
         fields: dict[str, str], fields computed by this stencil:  the key is the variable name of
             the out arguments used in the program and the value the name the field is registered
             under and declared in the metadata.
@@ -498,6 +498,8 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
             the key is the variable name used in the `gtx.program` and the value the name
             of the field it depends on.
         params: scalar parameters used in the program
+        compute_domain: per-dimension override of the range the program computes, for fields
+            that exist on the whole `domain` but are computed only on part of it.
     """
 
     def __init__(
@@ -509,9 +511,16 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
         deps: dict[str, str],
         do_exchange: bool,
         params: dict[str, state_utils.ScalarType] | None = None,
+        compute_domain: dict[gtx.Dimension, tuple[DomainType, DomainType]] | None = None,
     ):
+        compute_domain = compute_domain if compute_domain is not None else {}
+        if not compute_domain.keys() <= domain.keys():
+            raise ValueError(
+                f"compute_domain has dimensions not in domain: {compute_domain.keys() - domain.keys()}"
+            )
         self._func = func
-        self._compute_domain = domain
+        self._domain = domain
+        self._compute_domain = {**domain, **compute_domain}
         self._dims = domain.keys()
         self._dependencies = deps
         self._output = fields
@@ -522,14 +531,20 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
         }
         self._do_exchange = do_exchange
 
+    def _extent(self, dim: gtx.Dimension, grid: GridProvider) -> tuple[int, int]:
+        if dim.kind == gtx.DimensionKind.VERTICAL:
+            start, end = self._domain[dim]
+            return grid.vertical_grid.index(start), grid.vertical_grid.index(end)
+        return 0, grid.grid.size[dim]
+
     def _allocate(
         self,
         backend: gtx_typing.Backend | None,
-        grid: base_grid.Grid,  # TODO @halungge: change to vertical grid
+        grid: GridProvider,
         dtype: dict[str, state_utils.ScalarType],
     ) -> dict[str, state_utils.FieldType]:
         allocate = gtx.constructors.zeros.partial(allocator=backend)
-        field_domain = {dim: (0, grid.size[dim]) for dim in self._dims}
+        field_domain = {dim: self._extent(dim, grid) for dim in self._dims}
         return {k: allocate(field_domain, dtype=dtype[k]) for k in self._fields}
 
     # TODO(halungge): this can be simplified when completely disentangling vertical and horizontal grid.
@@ -555,26 +570,27 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
                 offset_providers.update(vertical_offsets)
         return offset_providers
 
-    def _domain_args(
-        self, grid: icon_grid.IconGrid, vertical_grid: v_grid.VerticalGrid
-    ) -> dict[str : gtx.int32]:
+    def _domain_args(self, grid: GridProvider) -> dict[str, gtx.int32]:
         domain_args = {}
 
-        for dim in self._compute_domain:
+        for dim, (start, end) in self._compute_domain.items():
             if dim.kind == gtx.DimensionKind.HORIZONTAL:
                 domain_args.update(
                     {
-                        "horizontal_start": grid.start_index(self._compute_domain[dim][0]),
-                        "horizontal_end": grid.end_index(self._compute_domain[dim][1]),
+                        "horizontal_start": grid.grid.start_index(start),
+                        "horizontal_end": grid.grid.end_index(end),
                     }
                 )
             elif dim.kind == gtx.DimensionKind.VERTICAL:
-                domain_args.update(
-                    {
-                        "vertical_start": vertical_grid.index(self._compute_domain[dim][0]),
-                        "vertical_end": vertical_grid.index(self._compute_domain[dim][1]),
-                    }
-                )
+                vertical_start = grid.vertical_grid.index(start)
+                vertical_end = grid.vertical_grid.index(end)
+                first, last = self._extent(dim, grid)
+                if vertical_start < first or vertical_end > last:
+                    raise ValueError(
+                        f"compute range [{vertical_start}, {vertical_end}) of {dim} exceeds "
+                        f"the field domain [{first}, {last})"
+                    )
+                domain_args.update({"vertical_start": vertical_start, "vertical_end": vertical_end})
             else:
                 raise ValueError(f"DimensionKind '{dim.kind}' not supported in Program Domain")
         return domain_args
@@ -609,12 +625,12 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
         except (ValueError, KeyError):
             dtype = {v: ta.wpfloat for v in self._output.values()}
 
-        self._fields = self._allocate(backend, grid.grid, dtype=dtype)
+        self._fields = self._allocate(backend, grid, dtype=dtype)
         log.debug(f" getting dependencies {self._dependencies.values()} from {field_src}")
         deps = {k: field_src.get(v) for k, v in self._dependencies.items()}
         deps.update(self._params)
         deps.update({k: self._fields[v] for k, v in self._output.items()})
-        dims = self._domain_args(grid.grid, grid.vertical_grid)
+        dims = self._domain_args(grid)
         offset_providers = self._get_offset_providers(grid.grid)
         deps.update(dims)
         self._func.with_backend(backend)(**deps, offset_provider=offset_providers)

--- a/model/common/src/icon4py/model/common/states/factory.py
+++ b/model/common/src/icon4py/model/common/states/factory.py
@@ -411,11 +411,8 @@ class EmbeddedFieldOperatorProvider(FieldProvider, NeedsExchange):
             f"{data_alloc.backend_name(compute_backend)}, target backend is: "
             f"{data_alloc.backend_name(factory.backend)}"
         )
-        try:
-            metadata = {k: factory.get(k, RetrievalType.METADATA) for k in self.fields}
-        except (ValueError, KeyError):
-            metadata = {}
-        self._fields = self._allocate_fields(compute_backend, grid_provider, metadata)
+        dtype = {k: output_dtype(factory, k) for k in self._fields}
+        self._fields = self._allocate_fields(compute_backend, grid_provider, dtype)
         # call field operator
         log.debug(f"transferring dependencies to compute backend: {self._dependencies.keys()}")
 
@@ -466,16 +463,14 @@ class EmbeddedFieldOperatorProvider(FieldProvider, NeedsExchange):
         self,
         backend: gtx_typing.Backend | None,
         grid_provider: GridProvider,
-        metadata: dict[str, model.FieldMetaData],
+        dtype: dict[str, state_utils.ScalarType],
     ) -> dict[str, state_utils.FieldType]:
         allocate = gtx.constructors.zeros.partial(allocator=backend)
         field_domain = {
             dim: _field_extent(dim, declared, grid_provider)
             for dim, declared in self._domain.items()
         }
-        return {
-            k: allocate(field_domain, dtype=dtype_or_default(k, metadata)) for k in self._fields
-        }
+        return {k: allocate(field_domain, dtype=dtype[k]) for k in self._fields}
 
 
 class ProgramFieldProvider(FieldProvider, NeedsExchange):
@@ -597,12 +592,7 @@ class ProgramFieldProvider(FieldProvider, NeedsExchange):
         grid: GridProvider,
         backend: gtx_typing.Backend | None,
     ) -> None:
-        try:
-            metadata = {v: field_src.get(v, RetrievalType.METADATA) for v in self._output.values()}
-            dtype = {v: metadata[v]["dtype"] for v in self._output.values()}
-        except (ValueError, KeyError):
-            dtype = {v: ta.wpfloat for v in self._output.values()}
-
+        dtype = {v: output_dtype(field_src, v) for v in self._output.values()}
         self._fields = self._allocate(backend, grid, dtype=dtype)
         log.debug(f" getting dependencies {self._dependencies.values()} from {field_src}")
         deps = {k: field_src.get(v) for k, v in self._dependencies.items()}
@@ -797,7 +787,5 @@ def _func_name(callable_: Callable[..., Any]) -> str:
         return callable_.__name__
 
 
-def dtype_or_default(
-    field_name: str, metadata: dict[str, model.FieldMetaData]
-) -> state_utils.ScalarType:
-    return metadata.get(field_name, {}).get("dtype", ta.wpfloat)
+def output_dtype(field_src: FieldSource, field_name: str) -> state_utils.ScalarType:
+    return field_src.get(field_name, RetrievalType.METADATA).get("dtype", ta.wpfloat)

--- a/model/common/src/icon4py/model/common/states/factory.py
+++ b/model/common/src/icon4py/model/common/states/factory.py
@@ -788,4 +788,10 @@ def _func_name(callable_: Callable[..., Any]) -> str:
 
 
 def output_dtype(field_src: FieldSource, field_name: str) -> state_utils.ScalarType:
-    return field_src.get(field_name, RetrievalType.METADATA).get("dtype", ta.wpfloat)
+    try:
+        metadata = field_src.get(field_name, RetrievalType.METADATA)
+    except ValueError:
+        # a provider driven by another one (SparseFieldProviderWrapper) is not registered with the
+        # source, so its intermediate outputs have no metadata there
+        return ta.wpfloat
+    return metadata.get("dtype", ta.wpfloat)

--- a/model/common/tests/common/metrics/unit_tests/test_metric_fields.py
+++ b/model/common/tests/common/metrics/unit_tests/test_metric_fields.py
@@ -141,7 +141,7 @@ def test_compute_rayleigh_w(
 ) -> None:
     rayleigh_w_ref = metrics_savepoint.rayleigh_w()
     vct_a_1 = grid_savepoint.vct_a().asnumpy()[0]
-    rayleigh_w_full = data_alloc.zero_field(icon_grid, dims.KHalfDim, allocator=backend)
+    rayleigh_w_full = data_alloc.random_field(icon_grid, dims.KHalfDim, allocator=backend)
     mf.compute_rayleigh_w.with_backend(backend=backend)(
         rayleigh_w=rayleigh_w_full,
         vct_a=grid_savepoint.vct_a(),
@@ -150,8 +150,9 @@ def test_compute_rayleigh_w(
         rayleigh_coeff=experiment.config.metrics.rayleigh_coeff,
         vct_a_1=vct_a_1,
         pi_const=math.pi,
+        end_index_of_damping_layer=grid_savepoint.nrdmax(),
         vertical_start=0,
-        vertical_end=gtx.int32(grid_savepoint.nrdmax() + 1),
+        vertical_end=gtx.int32(icon_grid.num_levels + 1),
         offset_provider={},
     )
 
@@ -166,8 +167,12 @@ def test_compute_coeff_dwdz(
     coeff1_dwdz_ref = metrics_savepoint.coeff1_dwdz()
     coeff2_dwdz_ref = metrics_savepoint.coeff2_dwdz()
 
-    coeff1_dwdz_full = data_alloc.zero_field(icon_grid, dims.CellDim, dims.KDim, allocator=backend)
-    coeff2_dwdz_full = data_alloc.zero_field(icon_grid, dims.CellDim, dims.KDim, allocator=backend)
+    coeff1_dwdz_full = data_alloc.random_field(
+        icon_grid, dims.CellDim, dims.KDim, allocator=backend
+    )
+    coeff2_dwdz_full = data_alloc.random_field(
+        icon_grid, dims.CellDim, dims.KDim, allocator=backend
+    )
     ddqz_z_full = gtx.as_field(
         (dims.CellDim, dims.KDim),
         1 / metrics_savepoint.inv_ddqz_z_full().ndarray,
@@ -181,7 +186,7 @@ def test_compute_coeff_dwdz(
         coeff2_dwdz=coeff2_dwdz_full,
         horizontal_start=0,
         horizontal_end=icon_grid.num_cells,
-        vertical_start=1,
+        vertical_start=0,
         vertical_end=gtx.int32(icon_grid.num_levels),
         offset_provider={},
     )

--- a/model/common/tests/common/states/unit_tests/test_factory.py
+++ b/model/common/tests/common/states/unit_tests/test_factory.py
@@ -38,7 +38,7 @@ from icon4py.model.testing.fixtures.datatest import (
 
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
     import gt4py.next.typing as gtx_typing
 
@@ -210,100 +210,54 @@ def test_program_provider(height_coordinate_source: SimpleFieldSource) -> None:
     assert dims.CellDim in x.domain.dims
 
 
-def _run_program_provider(source: SimpleFieldSource, domain: dict) -> gtx.Field:
-    provider = factory.ProgramFieldProvider(
+def _average_downwards(z_ifc: data_alloc.NDArray) -> data_alloc.NDArray:
+    return 0.5 * (z_ifc[:, 1:-1] + z_ifc[:, 2:])
+
+
+def _program_provider(domain: dict) -> factory.FieldProvider:
+    return factory.ProgramFieldProvider(
         func=vertical_ops.average_two_vertical_levels_downwards_on_cells,
         domain=domain,
         fields={"average": "output_f"},
         deps={"input_field": "height_coordinate"},
         do_exchange=False,
     )
-    source.with_metadata({"output_f": {"standard_name": "output_f", "units": ""}})
-    source.register_provider(provider)
-    provider(
-        field_name="output_f",
-        field_src=source,
-        backend=source.backend,
-        grid=source,
-        exchange=decomposition.SingleNodeExchange(),
-    )
-    x = provider.fields["output_f"]
-    assert isinstance(x, gtx.Field)
-    return x
 
 
-@pytest.mark.datatest
-def test_program_provider_vertical_extent_is_declared_domain(
-    height_coordinate_source: SimpleFieldSource,
-) -> None:
-    assert height_coordinate_source.vertical_grid is not None
-    num_levels = height_coordinate_source.vertical_grid.num_levels
-    x = _run_program_provider(
-        height_coordinate_source,
-        domain={
-            dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.LOCAL)),
-            dims.KDim: (v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1), k_domain(v_grid.Zone.BOTTOM)),
-        },
-    )
-    assert x.domain[dims.CellDim].unit_range == gtx.common.UnitRange(
-        0, height_coordinate_source.grid.num_cells
-    )
-    assert x.domain[dims.KDim].unit_range == gtx.common.UnitRange(1, num_levels)
-    assert np.all(x.asnumpy() != 0.0)
-
-
-@pytest.mark.datatest
-def test_field_operator_provider_vertical_extent_is_declared_domain(
-    height_coordinate_source: SimpleFieldSource,
-) -> None:
-    assert height_coordinate_source.vertical_grid is not None
-    num_levels = height_coordinate_source.vertical_grid.num_levels
-    provider = factory.EmbeddedFieldOperatorProvider(
+def _field_operator_provider(domain: dict) -> factory.FieldProvider:
+    return factory.EmbeddedFieldOperatorProvider(
         func=vertical_ops.average_level_plus1_on_cells.with_backend(None),
-        domain={
-            dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.LOCAL)),
-            dims.KDim: (v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1), k_domain(v_grid.Zone.BOTTOM)),
-        },
+        domain=domain,
         fields={"average": "output_f"},
         deps={"half_level_field": "height_coordinate"},
         do_exchange=False,
     )
-    height_coordinate_source.with_metadata({"output_f": {"standard_name": "output_f", "units": ""}})
-    height_coordinate_source.register_provider(provider)
-    provider(
-        field_name="output_f",
-        field_src=height_coordinate_source,
-        backend=height_coordinate_source.backend,
-        grid=height_coordinate_source,
-        exchange=decomposition.SingleNodeExchange(),
+
+
+def _numpy_provider(domain: dict) -> factory.FieldProvider:
+    return factory.NumpyDataProvider(
+        func=_average_downwards,
+        domain=domain,
+        fields=("output_f",),
+        deps={"z_ifc": "height_coordinate"},
     )
-    x = provider.fields["output_f"]
-    assert isinstance(x, gtx.Field)
-    assert x.domain[dims.CellDim].unit_range == gtx.common.UnitRange(
-        0, height_coordinate_source.grid.num_cells
-    )
-    assert x.domain[dims.KDim].unit_range == gtx.common.UnitRange(1, num_levels)
-    assert np.all(x.asnumpy() != 0.0)
 
 
 @pytest.mark.datatest
-def test_numpy_provider_vertical_extent_is_declared_domain(
+@pytest.mark.parametrize(
+    "make_provider", [_program_provider, _field_operator_provider, _numpy_provider]
+)
+def test_provider_vertical_extent_is_declared_domain(
     height_coordinate_source: SimpleFieldSource,
+    make_provider: Callable[[dict], factory.FieldProvider],
 ) -> None:
     assert height_coordinate_source.vertical_grid is not None
     num_levels = height_coordinate_source.vertical_grid.num_levels
-
-    def average_downwards(z_ifc: data_alloc.NDArray) -> data_alloc.NDArray:
-        return 0.5 * (z_ifc[:, 1:-1] + z_ifc[:, 2:])
-
-    provider = factory.NumpyDataProvider(
-        func=average_downwards,
-        domain={
+    provider = make_provider(
+        {
             dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.END)),
             dims.KDim: (v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1), k_domain(v_grid.Zone.BOTTOM)),
-        },
-        fields=("output_f",),
-        deps={"z_ifc": "height_coordinate"},
+        }
     )
     height_coordinate_source.with_metadata({"output_f": {"standard_name": "output_f", "units": ""}})
     height_coordinate_source.register_provider(provider)

--- a/model/common/tests/common/states/unit_tests/test_factory.py
+++ b/model/common/tests/common/states/unit_tests/test_factory.py
@@ -281,6 +281,41 @@ def test_field_operator_provider_vertical_extent_is_declared_domain(
 
 
 @pytest.mark.datatest
+def test_numpy_provider_vertical_extent_is_declared_domain(
+    height_coordinate_source: SimpleFieldSource,
+) -> None:
+    assert height_coordinate_source.vertical_grid is not None
+    num_levels = height_coordinate_source.vertical_grid.num_levels
+
+    def average_downwards(z_ifc: data_alloc.NDArray) -> data_alloc.NDArray:
+        return 0.5 * (z_ifc[:, 1:-1] + z_ifc[:, 2:])
+
+    provider = factory.NumpyDataProvider(
+        func=average_downwards,
+        domain={
+            dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.END)),
+            dims.KDim: (v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1), k_domain(v_grid.Zone.BOTTOM)),
+        },
+        fields=("output_f",),
+        deps={"z_ifc": "height_coordinate"},
+    )
+    provider(
+        field_name="output_f",
+        field_src=height_coordinate_source,
+        backend=height_coordinate_source.backend,
+        grid=height_coordinate_source,
+        exchange=decomposition.SingleNodeExchange(),
+    )
+    x = provider.fields["output_f"]
+    assert isinstance(x, gtx.Field)
+    assert x.domain[dims.CellDim].unit_range == gtx.common.UnitRange(
+        0, height_coordinate_source.grid.num_cells
+    )
+    assert x.domain[dims.KDim].unit_range == gtx.common.UnitRange(1, num_levels)
+    assert np.all(x.asnumpy() != 0.0)
+
+
+@pytest.mark.datatest
 def test_field_source_raise_error_on_register(cell_coordinate_source: SimpleFieldSource) -> None:
     program = vertical_ops.average_two_vertical_levels_downwards_on_cells
     domain = {

--- a/model/common/tests/common/states/unit_tests/test_factory.py
+++ b/model/common/tests/common/states/unit_tests/test_factory.py
@@ -249,6 +249,38 @@ def test_program_provider_vertical_extent_is_declared_domain(
 
 
 @pytest.mark.datatest
+def test_field_operator_provider_vertical_extent_is_declared_domain(
+    height_coordinate_source: SimpleFieldSource,
+) -> None:
+    assert height_coordinate_source.vertical_grid is not None
+    num_levels = height_coordinate_source.vertical_grid.num_levels
+    provider = factory.EmbeddedFieldOperatorProvider(
+        func=vertical_ops.average_level_plus1_on_cells.with_backend(None),
+        domain={
+            dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.LOCAL)),
+            dims.KDim: (v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1), k_domain(v_grid.Zone.BOTTOM)),
+        },
+        fields={"average": "output_f"},
+        deps={"half_level_field": "height_coordinate"},
+        do_exchange=False,
+    )
+    provider(
+        field_name="output_f",
+        field_src=height_coordinate_source,
+        backend=height_coordinate_source.backend,
+        grid=height_coordinate_source,
+        exchange=decomposition.SingleNodeExchange(),
+    )
+    x = provider.fields["output_f"]
+    assert isinstance(x, gtx.Field)
+    assert x.domain[dims.CellDim].unit_range == gtx.common.UnitRange(
+        0, height_coordinate_source.grid.num_cells
+    )
+    assert x.domain[dims.KDim].unit_range == gtx.common.UnitRange(1, num_levels)
+    assert np.all(x.asnumpy() != 0.0)
+
+
+@pytest.mark.datatest
 def test_field_source_raise_error_on_register(cell_coordinate_source: SimpleFieldSource) -> None:
     program = vertical_ops.average_two_vertical_levels_downwards_on_cells
     domain = {

--- a/model/common/tests/common/states/unit_tests/test_factory.py
+++ b/model/common/tests/common/states/unit_tests/test_factory.py
@@ -208,13 +208,10 @@ def test_program_provider(height_coordinate_source: SimpleFieldSource) -> None:
     assert dims.CellDim in x.domain.dims
 
 
-def _run_program_provider(
-    source: SimpleFieldSource, domain: dict, compute_domain: dict | None = None
-) -> gtx.Field:
+def _run_program_provider(source: SimpleFieldSource, domain: dict) -> gtx.Field:
     provider = factory.ProgramFieldProvider(
         func=vertical_ops.average_two_vertical_levels_downwards_on_cells,
         domain=domain,
-        compute_domain=compute_domain,
         fields={"average": "output_f"},
         deps={"input_field": "height_coordinate"},
         do_exchange=False,
@@ -226,13 +223,16 @@ def _run_program_provider(
         grid=source,
         exchange=decomposition.SingleNodeExchange(),
     )
-    return provider.fields["output_f"]
+    x = provider.fields["output_f"]
+    assert isinstance(x, gtx.Field)
+    return x
 
 
 @pytest.mark.datatest
 def test_program_provider_vertical_extent_is_declared_domain(
     height_coordinate_source: SimpleFieldSource,
 ) -> None:
+    assert height_coordinate_source.vertical_grid is not None
     num_levels = height_coordinate_source.vertical_grid.num_levels
     x = _run_program_provider(
         height_coordinate_source,
@@ -246,56 +246,6 @@ def test_program_provider_vertical_extent_is_declared_domain(
     )
     assert x.domain[dims.KDim].unit_range == gtx.common.UnitRange(1, num_levels)
     assert np.all(x.asnumpy() != 0.0)
-
-
-@pytest.mark.datatest
-def test_program_provider_compute_domain_narrows_only_the_computation(
-    height_coordinate_source: SimpleFieldSource,
-) -> None:
-    num_levels = height_coordinate_source.vertical_grid.num_levels
-    x = _run_program_provider(
-        height_coordinate_source,
-        domain={
-            dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.LOCAL)),
-            dims.KDim: (k_domain(v_grid.Zone.TOP), k_domain(v_grid.Zone.BOTTOM)),
-        },
-        compute_domain={
-            dims.KDim: (v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1), k_domain(v_grid.Zone.BOTTOM))
-        },
-    )
-    assert x.domain[dims.KDim].unit_range == gtx.common.UnitRange(0, num_levels)
-    assert np.all(x.asnumpy()[:, 0] == 0.0)
-    assert np.all(x.asnumpy()[:, 1:] != 0.0)
-
-
-@pytest.mark.datatest
-def test_program_provider_compute_domain_outside_domain_raises(
-    height_coordinate_source: SimpleFieldSource,
-) -> None:
-    with pytest.raises(ValueError, match="exceeds"):
-        _run_program_provider(
-            height_coordinate_source,
-            domain={
-                dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.LOCAL)),
-                dims.KDim: (
-                    v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1),
-                    k_domain(v_grid.Zone.BOTTOM),
-                ),
-            },
-            compute_domain={dims.KDim: (k_domain(v_grid.Zone.TOP), k_domain(v_grid.Zone.BOTTOM))},
-        )
-
-
-def test_program_provider_compute_domain_unknown_dimension_raises() -> None:
-    with pytest.raises(ValueError, match="not in domain"):
-        factory.ProgramFieldProvider(
-            func=vertical_ops.average_two_vertical_levels_downwards_on_cells,
-            domain={dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.LOCAL))},
-            compute_domain={dims.KDim: (k_domain(v_grid.Zone.TOP), k_domain(v_grid.Zone.BOTTOM))},
-            fields={"average": "output_f"},
-            deps={"input_field": "height_coordinate"},
-            do_exchange=False,
-        )
 
 
 @pytest.mark.datatest

--- a/model/common/tests/common/states/unit_tests/test_factory.py
+++ b/model/common/tests/common/states/unit_tests/test_factory.py
@@ -208,6 +208,96 @@ def test_program_provider(height_coordinate_source: SimpleFieldSource) -> None:
     assert dims.CellDim in x.domain.dims
 
 
+def _run_program_provider(
+    source: SimpleFieldSource, domain: dict, compute_domain: dict | None = None
+) -> gtx.Field:
+    provider = factory.ProgramFieldProvider(
+        func=vertical_ops.average_two_vertical_levels_downwards_on_cells,
+        domain=domain,
+        compute_domain=compute_domain,
+        fields={"average": "output_f"},
+        deps={"input_field": "height_coordinate"},
+        do_exchange=False,
+    )
+    provider(
+        field_name="output_f",
+        field_src=source,
+        backend=source.backend,
+        grid=source,
+        exchange=decomposition.SingleNodeExchange(),
+    )
+    return provider.fields["output_f"]
+
+
+@pytest.mark.datatest
+def test_program_provider_vertical_extent_is_declared_domain(
+    height_coordinate_source: SimpleFieldSource,
+) -> None:
+    num_levels = height_coordinate_source.vertical_grid.num_levels
+    x = _run_program_provider(
+        height_coordinate_source,
+        domain={
+            dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.LOCAL)),
+            dims.KDim: (v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1), k_domain(v_grid.Zone.BOTTOM)),
+        },
+    )
+    assert x.domain[dims.CellDim].unit_range == gtx.common.UnitRange(
+        0, height_coordinate_source.grid.num_cells
+    )
+    assert x.domain[dims.KDim].unit_range == gtx.common.UnitRange(1, num_levels)
+    assert np.all(x.asnumpy() != 0.0)
+
+
+@pytest.mark.datatest
+def test_program_provider_compute_domain_narrows_only_the_computation(
+    height_coordinate_source: SimpleFieldSource,
+) -> None:
+    num_levels = height_coordinate_source.vertical_grid.num_levels
+    x = _run_program_provider(
+        height_coordinate_source,
+        domain={
+            dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.LOCAL)),
+            dims.KDim: (k_domain(v_grid.Zone.TOP), k_domain(v_grid.Zone.BOTTOM)),
+        },
+        compute_domain={
+            dims.KDim: (v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1), k_domain(v_grid.Zone.BOTTOM))
+        },
+    )
+    assert x.domain[dims.KDim].unit_range == gtx.common.UnitRange(0, num_levels)
+    assert np.all(x.asnumpy()[:, 0] == 0.0)
+    assert np.all(x.asnumpy()[:, 1:] != 0.0)
+
+
+@pytest.mark.datatest
+def test_program_provider_compute_domain_outside_domain_raises(
+    height_coordinate_source: SimpleFieldSource,
+) -> None:
+    with pytest.raises(ValueError, match="exceeds"):
+        _run_program_provider(
+            height_coordinate_source,
+            domain={
+                dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.LOCAL)),
+                dims.KDim: (
+                    v_grid.Domain(dims.KDim, v_grid.Zone.TOP, 1),
+                    k_domain(v_grid.Zone.BOTTOM),
+                ),
+            },
+            compute_domain={dims.KDim: (k_domain(v_grid.Zone.TOP), k_domain(v_grid.Zone.BOTTOM))},
+        )
+
+
+def test_program_provider_compute_domain_unknown_dimension_raises() -> None:
+    with pytest.raises(ValueError, match="not in domain"):
+        factory.ProgramFieldProvider(
+            func=vertical_ops.average_two_vertical_levels_downwards_on_cells,
+            domain={dims.CellDim: (cell_domain(h_grid.Zone.LOCAL), cell_domain(h_grid.Zone.LOCAL))},
+            compute_domain={dims.KDim: (k_domain(v_grid.Zone.TOP), k_domain(v_grid.Zone.BOTTOM))},
+            fields={"average": "output_f"},
+            deps={"input_field": "height_coordinate"},
+            do_exchange=False,
+        )
+
+
 @pytest.mark.datatest
 def test_field_source_raise_error_on_register(cell_coordinate_source: SimpleFieldSource) -> None:
     program = vertical_ops.average_two_vertical_levels_downwards_on_cells

--- a/model/common/tests/common/states/unit_tests/test_factory.py
+++ b/model/common/tests/common/states/unit_tests/test_factory.py
@@ -196,6 +196,8 @@ def test_program_provider(height_coordinate_source: SimpleFieldSource) -> None:
     provider = factory.ProgramFieldProvider(
         func=program, domain=domain, fields=fields, deps=deps, do_exchange=False
     )
+    height_coordinate_source.with_metadata({"output_f": {"standard_name": "output_f", "units": ""}})
+    height_coordinate_source.register_provider(provider)
     provider(
         field_name="output_f",
         field_src=height_coordinate_source,
@@ -216,6 +218,8 @@ def _run_program_provider(source: SimpleFieldSource, domain: dict) -> gtx.Field:
         deps={"input_field": "height_coordinate"},
         do_exchange=False,
     )
+    source.with_metadata({"output_f": {"standard_name": "output_f", "units": ""}})
+    source.register_provider(provider)
     provider(
         field_name="output_f",
         field_src=source,
@@ -264,6 +268,8 @@ def test_field_operator_provider_vertical_extent_is_declared_domain(
         deps={"half_level_field": "height_coordinate"},
         do_exchange=False,
     )
+    height_coordinate_source.with_metadata({"output_f": {"standard_name": "output_f", "units": ""}})
+    height_coordinate_source.register_provider(provider)
     provider(
         field_name="output_f",
         field_src=height_coordinate_source,
@@ -299,6 +305,8 @@ def test_numpy_provider_vertical_extent_is_declared_domain(
         fields=("output_f",),
         deps={"z_ifc": "height_coordinate"},
     )
+    height_coordinate_source.with_metadata({"output_f": {"standard_name": "output_f", "units": ""}})
+    height_coordinate_source.register_provider(provider)
     provider(
         field_name="output_f",
         field_src=height_coordinate_source,


### PR DESCRIPTION
## Description

The field providers in `states/factory.py` allocated (or labelled) every output at full grid size and read `domain` only as a compute range. Now there is one rule, `_field_extent`, shared by all three providers: a declared vertical range is the field's extent, with absolute level indices; horizontal dimensions are always full local size, because the halo exchange fills entries outside the compute range and neighbour access indexes the field by absolute local index. So `domain` is the field's domain and the compute range at once.

Per provider:

- `ProgramFieldProvider`: allocates through the rule; `vertical_start`/`vertical_end` are that range. The two programs that only fill part of the column, `compute_rayleigh_w` and `compute_coeff_dwdz`, now write the zeros themselves with `concat_where` and run over the full column. `compute_rayleigh_w` takes `end_index_of_damping_layer` for that. The zero branches are a closed-domain field (`0.0 * rayleigh_w`) and a single-level scalar (`KDim == 0`) because embedded rejects a scalar branch on an unbounded region (`Cannot compute length of open 'UnitRange'`).
- `EmbeddedFieldOperatorProvider`: allocates through the rule and, as before, computes on the whole extent of its outputs. Its private size map is gone; missing output metadata falls back to the default dtype as in the program provider.
- `NumpyDataProvider`: a `domain` given with ranges is labelled through the rule, so `wgtfacq_c` and `wgtfacq_e` declare their three bottom levels with zone markers instead of `num_levels - 3` computed at construction. A bare dimension tuple still labels the returned array by its shape, since dimensions such as `LsqUnkDim` have no grid size.