### PR TITLE
Avoid OOM in CSCS CI

### DIFF
--- a/.cscs-ci/base.yml
+++ b/.cscs-ci/base.yml
@@ -150,7 +150,7 @@ variables:
     # that don't run many tests.
     NUM_PROCESSES: 32
     OMP_NUM_THREADS: 8
-    GT4PY_BUILD_JOBS: 12
+    GT4PY_BUILD_JOBS: 8
     GT4PY_BUILD_CACHE_LIFETIME: "persistent"
     PY2F_GPU_TESTS: 1
     CUDACXX: "${HPC_SDK_PATH}/compilers/bin/nvcc"

--- a/.cscs-ci/scripts/gt4py-cache.sh
+++ b/.cscs-ci/scripts/gt4py-cache.sh
@@ -23,7 +23,9 @@ flags_hash=$(echo -n "CXXFLAGS=${CXXFLAGS:-} NVCC_APPEND_FLAGS=${NVCC_APPEND_FLA
 
 # Then set the cache directory for this run based on the backend and current date.
 DATE=$(date +%Y-%W)
-export GT4PY_BUILD_CACHE_DIR="${ICON4PY_CI_GT4PY_BUILD_CACHE_BASE_DIR}/icon4py/gt4py-cache/base-${base_image_hash}-uv-lock-${uv_lock_hash}-flags-${flags_hash}-job-${job_name_hash}-${DATE}"
+# TODO: remove before merging
+CACHE_BUST=$(date +%s)
+export GT4PY_BUILD_CACHE_DIR="${ICON4PY_CI_GT4PY_BUILD_CACHE_BASE_DIR}/icon4py/gt4py-cache/base-${base_image_hash}-uv-lock-${uv_lock_hash}-flags-${flags_hash}-job-${job_name_hash}-${DATE}-${CACHE_BUST}"
 mkdir -p "${GT4PY_BUILD_CACHE_DIR}"
 
 echo "Using GT4PY_BUILD_CACHE_DIR=${GT4PY_BUILD_CACHE_DIR}"

--- a/.cscs-ci/scripts/gt4py-cache.sh
+++ b/.cscs-ci/scripts/gt4py-cache.sh
@@ -23,9 +23,7 @@ flags_hash=$(echo -n "CXXFLAGS=${CXXFLAGS:-} NVCC_APPEND_FLAGS=${NVCC_APPEND_FLA
 
 # Then set the cache directory for this run based on the backend and current date.
 DATE=$(date +%Y-%W)
-# TODO: remove before merging
-CACHE_BUST=$(date +%s)
-export GT4PY_BUILD_CACHE_DIR="${ICON4PY_CI_GT4PY_BUILD_CACHE_BASE_DIR}/icon4py/gt4py-cache/base-${base_image_hash}-uv-lock-${uv_lock_hash}-flags-${flags_hash}-job-${job_name_hash}-${DATE}-${CACHE_BUST}"
+export GT4PY_BUILD_CACHE_DIR="${ICON4PY_CI_GT4PY_BUILD_CACHE_BASE_DIR}/icon4py/gt4py-cache/base-${base_image_hash}-uv-lock-${uv_lock_hash}-flags-${flags_hash}-job-${job_name_hash}-${DATE}"
 mkdir -p "${GT4PY_BUILD_CACHE_DIR}"
 
 echo "Using GT4PY_BUILD_CACHE_DIR=${GT4PY_BUILD_CACHE_DIR}"


### PR DESCRIPTION
Reduce GT4PY_BUILD_JOBS back down to 8 in MPI test jobs to avoid OOMs for e.g. diffusion and tracer_advection.