### PR TITLE
fix output time step

### DIFF
--- a/model/common/src/icon4py/model/common/io/io.py
+++ b/model/common/src/icon4py/model/common/io/io.py
@@ -404,14 +404,14 @@ class IOMonitor(monitor.Monitor):
         for m in self._group_monitors:
             m.close()
 
-    def captures_next_store(self) -> bool:
-        """Whether any field group captures at the next ``store`` call.
+    def at_capture_time(self) -> bool:
+        """Whether any field group captures at the current ``store`` call.
 
         A pure predicate (no counter changes), identical on all ranks: callers may
         skip assembling the output state for steps nobody captures -- ``store`` must
         still be called every step (it advances the schedule counters).
         """
-        return any(m.captures_next_store() for m in self._group_monitors)
+        return any(m.at_capture_time() for m in self._group_monitors)
 
     def report_timings(self) -> None:
         """Log the accumulated output overhead of this rank, per field group and phase.
@@ -588,7 +588,7 @@ class FieldGroupMonitor(monitor.Monitor):
             model_time: the current time step of the simulation
         """
         self._step_counter += 1
-        if not self._at_capture_time():
+        if not self.at_capture_time():
             return
         # TODO(halungge): this should do a deep copy of the data once IO becomes
         #   asynchronous (the gather/halo-strip paths already copy, the single-node
@@ -636,13 +636,9 @@ class FieldGroupMonitor(monitor.Monitor):
         assert self._dataset is not None
         self._dataset.append(state_to_store, model_time)
 
-    def _at_capture_time(self) -> bool:
+    def at_capture_time(self) -> bool:
         # fire every N model steps
         return self._step_counter % self._output_interval_steps == 0
-
-    def captures_next_store(self) -> bool:
-        """Whether the next ``store`` call falls on a capture step (pure predicate)."""
-        return (self._step_counter + 1) % self._output_interval_steps == 0
 
     @property
     def phase_seconds(self) -> dict[str, list[float]]:

--- a/model/driver/src/icon4py/model/driver/driver.py
+++ b/model/driver/src/icon4py/model/driver/driver.py
@@ -171,20 +171,20 @@ class Icon4pyDriver:
         for steps that discard them, and the output timers hold only real capture work.
         """
         assert self.io_monitor is not None
-        if not self.io_monitor.captures_next_store():
-            self.io_monitor.store({}, simulation_current_datetime)
-            return
-        with self.timer_collection.timers[driver_states.DriverTimers.OUTPUT_ASSEMBLE.value]:
-            metrics = self.static_field_factories.metrics
-            interpolation = self.static_field_factories.interpolation
-            state_to_store = driver_io.prognostic_state_to_dataarrays(prognostic_state)
-            diagnostic_fields = self._diagnostics_computer.compute(
-                prognostic_state,
-                ddqz_z_full=metrics.get(metrics_attr.DDQZ_Z_FULL),
-                rbf_vec_coeff_c1=interpolation.get(intp_attr.RBF_VEC_COEFF_C1),
-                rbf_vec_coeff_c2=interpolation.get(intp_attr.RBF_VEC_COEFF_C2),
-            )
-            state_to_store.update(driver_io.diagnostic_fields_to_dataarrays(diagnostic_fields))
+        if self.io_monitor.at_capture_time():
+            with self.timer_collection.timers[driver_states.DriverTimers.OUTPUT_ASSEMBLE.value]:
+                metrics = self.static_field_factories.metrics
+                interpolation = self.static_field_factories.interpolation
+                state_to_store = driver_io.prognostic_state_to_dataarrays(prognostic_state)
+                diagnostic_fields = self._diagnostics_computer.compute(
+                    prognostic_state,
+                    ddqz_z_full=metrics.get(metrics_attr.DDQZ_Z_FULL),
+                    rbf_vec_coeff_c1=interpolation.get(intp_attr.RBF_VEC_COEFF_C1),
+                    rbf_vec_coeff_c2=interpolation.get(intp_attr.RBF_VEC_COEFF_C2),
+                )
+                state_to_store.update(driver_io.diagnostic_fields_to_dataarrays(diagnostic_fields))
+        else:
+            state_to_store = {}
         with self.timer_collection.timers[driver_states.DriverTimers.OUTPUT_STORE.value]:
             self.io_monitor.store(state_to_store, simulation_current_datetime)
 


### PR DESCRIPTION
The original full description is here https://openproj-392761827400.europe-west1.run.app/detail/issue-28b2f7.

In the _store_output function in driver.py, the following check determines whether output should be generated at the current time step:

```python
if not self.io_monitor.captures_next_store():
```

When the next time step is not scheduled for output, the driver skips assembling the output variables and calls `self.io_monitor.store` with an empty dictionary to avoid unnecessary computation.

However, this logic causes two issues when the output interval is longer than the model time step.

1. **The initial condition is not output**

   If a user does not request output at every time step, the initial condition is skipped because the next time step is not an output time step.

2. **Output occurs one time step earlier than requested**

   The `store` function of `FieldGroupMonitor` always checks whether the **next** time step is scheduled for output rather than whether the **current** time step is an output time.
   For example, with:

   * `dtime = 1 s`
   * `output_interval = 10`
   * integration time = `60 s`

   the expected output times are:
   t = 0, 10, 20, 30, 40, 50, 60 s
   However, the current implementation produces output at:
   t = 9, 19, 29, 39, 49, 59 s

Therefore, the output schedule is shifted by one time step and the initial condition is missing.

In this PR:
The output logic should distinguish between the current time step and the next output time step. The initial condition should also be handled explicitly so that it is stored at t = 0 when requested.

The monitor should determine whether the current model time is an output time when store is called, rather than always checking the next scheduled output time.